### PR TITLE
freezing test sessions now actually freeze the test session

### DIFF
--- a/client/src/pages/test/components/TestScenarioChatControls.tsx
+++ b/client/src/pages/test/components/TestScenarioChatControls.tsx
@@ -4,24 +4,22 @@ import { Textarea } from "@/components/ui/textarea";
 import { ConversationExporter } from "@/pages/chat/components/ConversationExporter";
 import { TestScenarioConversationResetter } from "@/pages/test/components/TestScenarioConversationResetter";
 import { TestScenarioSessionFreezer } from "@/pages/test/components/TestScenarioSessionFreezer";
-import { useReactiveQueryData } from "@/hooks/useReactiveQueryData";
-import { User } from "@/types/user";
 
 interface TestScenarioChatControlsProps {
   isProcessingMessage: boolean;
   onSendMessage: (msg: string) => void;
   scenarioId: string;
+  testUserId: string; // Add testUserId prop
   onResetSuccess?: () => void;
 }
 
 export const TestScenarioChatControls: React.FC<
   TestScenarioChatControlsProps
-> = ({ isProcessingMessage, onSendMessage, scenarioId, onResetSuccess }) => {
+> = ({ isProcessingMessage, onSendMessage, scenarioId, testUserId, onResetSuccess }) => {
   const [inputMessage, setInputMessage] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  // Get current user profile from TanStack Query cache
-  const profile = useReactiveQueryData<User>(["user", "profile"]);
+
 
   /**
    * Resizes the textarea to fit content, up to a max height.
@@ -104,7 +102,7 @@ export const TestScenarioChatControls: React.FC<
           onResetSuccess={onResetSuccess}
         />
         <TestScenarioSessionFreezer
-          userId={profile?.id || ""}
+          userId={testUserId}
           onSuccess={() => {}}
         />
         <ConversationExporter />

--- a/client/src/pages/test/components/TestScenarioChatInterface.tsx
+++ b/client/src/pages/test/components/TestScenarioChatInterface.tsx
@@ -123,6 +123,7 @@ export const TestScenarioChatInterface: React.FC<{ userId: string; scenarioId: s
         isProcessingMessage={isPending}
         onSendMessage={handleSendMessage}
         scenarioId={scenarioId}
+        testUserId={userId}
         onResetSuccess={handleResetSuccess}
       />
     </div>


### PR DESCRIPTION
## Fix Test Scenario Session Freezing Bug

### Summary
This PR fixes a bug where clicking "Create Test Scenario from Current Session" within a test scenario would freeze the actual logged-in user's session instead of the intended test scenario user's session.

### Changes Made

#### `TestScenarioChatControls.tsx`
- Removed `useReactiveQueryData` import and `User` type import
- Added `testUserId: string` prop to the component interface
- Updated `TestScenarioSessionFreezer` to use `testUserId` prop instead of `profile?.id || ""`

#### `TestScenarioChatInterface.tsx`
- Added `testUserId={userId}` prop when rendering `TestScenarioChatControls`

### Problem Fixed
The `TestScenarioSessionFreezer` component was incorrectly using the logged-in user's ID from the query cache (`profile?.id`) instead of the test scenario user's ID, causing the wrong session to be frozen.

### Solution
By explicitly passing the test scenario user's ID as a prop, the session freezer now correctly operates on the intended test scenario user's session rather than the logged-in user's session.