### PR TITLE
added the affirmation_identities context key

### DIFF
--- a/server/enums/context_keys.py
+++ b/server/enums/context_keys.py
@@ -21,6 +21,7 @@ class ContextKey(models.TextChoices):
     CURRENT_IDENTITY = "current_identity", "Current Identity"
     ASKED_QUESTIONS = "asked_questions", "Asked Questions"
     REFINEMENT_IDENTITIES = "refinement_identities", "Refinement Identities"
+    AFFIRMATION_IDENTITIES = "affirmation_identities", "Affirmation Identities"
 
     @classmethod
     def from_string(cls, value: str) -> "ContextKey":

--- a/server/services/prompt_manager/models/prompt_context.py
+++ b/server/services/prompt_manager/models/prompt_context.py
@@ -24,3 +24,4 @@ class PromptContext(BaseModel):
     current_identity: Optional[str]
     asked_questions: Optional[str]
     refinement_identities: Optional[str]
+    affirmation_identities: Optional[str]

--- a/server/services/prompt_manager/utils/context/func/__init__.py
+++ b/server/services/prompt_manager/utils/context/func/__init__.py
@@ -14,3 +14,4 @@ from .get_brainstorming_category_context import get_brainstorming_category_conte
 from .get_current_identity_context import get_current_identity_context
 from .get_asked_questions import get_asked_questions
 from .get_refinement_identities_context import get_refinement_identities_context
+from .get_affirmation_identities_context import get_affirmation_identities_context

--- a/server/services/prompt_manager/utils/context/func/get_affirmation_identities_context.py
+++ b/server/services/prompt_manager/utils/context/func/get_affirmation_identities_context.py
@@ -1,0 +1,23 @@
+from typing import List
+from apps.coach_states.models import CoachState
+from apps.identities.models import Identity
+from enums.identity_state import IdentityState
+from services.prompt_manager.utils.format_identities import format_identities
+
+
+def get_affirmation_identities_context(coach_state: CoachState) -> str:
+    """
+    Get the User's Identities that are NOT affirmation_complete and format them for insertion into a prompt.
+    This provides a "to do" list of identities that still need affirmation.
+    Each Identity is formatted into a markdown-compatible string.
+    If no identities remain to be affirmed, returns instructions to move to the next phase.
+    """
+    user = coach_state.user
+    # Filter to only show identities that are NOT affirmation_complete
+    identities: List[Identity] = user.identities.exclude(state=IdentityState.AFFIRMATION_COMPLETE)
+
+    # Check if there are any identities left to affirm
+    if identities.count() == 0:
+        return "No more identities left to affirm - time to move to the Identity Visualization phase"
+    
+    return format_identities(identities)

--- a/server/services/prompt_manager/utils/context/get_context_value.py
+++ b/server/services/prompt_manager/utils/context/get_context_value.py
@@ -16,6 +16,7 @@ from services.prompt_manager.utils.context.func import (
     get_current_identity_context,
     get_asked_questions,
     get_refinement_identities_context,
+    get_affirmation_identities_context,
 )
 
 def get_context_value(key: ContextKey, coach_state: CoachState):
@@ -53,4 +54,6 @@ def get_context_value(key: ContextKey, coach_state: CoachState):
         return get_asked_questions(coach_state)
     elif key == ContextKey.REFINEMENT_IDENTITIES:
         return get_refinement_identities_context(coach_state)
+    elif key == ContextKey.AFFIRMATION_IDENTITIES:
+        return get_affirmation_identities_context(coach_state)
     # Add more context key handlers as needed

--- a/server/services/prompt_manager/utils/context_logging.py
+++ b/server/services/prompt_manager/utils/context_logging.py
@@ -33,3 +33,4 @@ def log_context_stats(prompt_context: PromptContext):
     log.debug(f"CURRENT_IDENTITY: {getattr(prompt_context, 'current_identity', None)}")
     log.debug(f"ASKED_QUESTIONS: {getattr(prompt_context, 'asked_questions', None)}")
     log.debug(f"REFINEMENT_IDENTITIES: {getattr(prompt_context, 'refinement_identities', None)}")
+    log.debug(f"AFFIRMATION_IDENTITIES: {getattr(prompt_context, 'affirmation_identities', None)}")


### PR DESCRIPTION
# Add affirmation_identities Context Key

## Summary
Added `affirmation_identities` context key that filters identities to show only those not marked as `affirmation_complete`. Provides "to do" list for Identity Affirmation phase and clear instructions when all identities are complete.

## Changes
- Added `AFFIRMATION_IDENTITIES` to ContextKey enum
- Added `affirmation_identities` field to PromptContext model  
- Created `get_affirmation_identities_context()` function with filtering logic
- Updated `get_context_value()` and `log_context_stats()` functions
- Updated `__init__.py` with new import

## Technical Details
- Filters using `exclude(state=IdentityState.AFFIRMATION_COMPLETE)`
- Returns formatted list or "No more identities left to affirm" message
- Integrates with existing `format_identities()` utility
