### PR TITLE
fix: Add Celery worker memory hygiene to prevent OOM crashes

### DIFF
--- a/server/settings/common.py
+++ b/server/settings/common.py
@@ -275,3 +275,14 @@ VERSATILEIMAGEFIELD_SETTINGS = {
     "image_key_post_processor": None,
     "progressive_jpeg": False,
 }
+
+# ----------------------------------------------
+# CELERY WORKER MEMORY HYGIENE
+# ----------------------------------------------
+# Prefork workers accumulate memory over time (Django app, ORM caches, AI
+# client state). Without these guards, a single worker can grow past the
+# host's RAM limit and get OOM-killed, eventually causing Render to suspend
+# the service.
+CELERY_WORKER_CONCURRENCY = 1               # one fork, one Django copy
+CELERY_WORKER_MAX_TASKS_PER_CHILD = 50      # recycle worker after N tasks
+CELERY_WORKER_MAX_MEMORY_PER_CHILD = 400000  # recycle if RSS exceeds ~400 MB (KB)


### PR DESCRIPTION
## Summary

Adds three Celery worker settings to `server/settings/common.py` so they apply across local, staging, and production. Fixes the OOM crashes that have been killing `prod-dev-coach-sentinel` (currently suspended by Render after repeated failures), which has broken user-note extraction in production.

This is **PR 1 of 4** in the Render PR-previews implementation track. It's also a real bug fix on its own — even before previews ship, this gets the prod sentinel healthy again.

## Changes

`server/settings/common.py` (+11 lines):

| Setting | Value | What it does |
|---|---|---|
| `CELERY_WORKER_CONCURRENCY` | `1` | One prefork process. Avoids multiplying the per-process Django footprint. |
| `CELERY_WORKER_MAX_TASKS_PER_CHILD` | `50` | Worker is recycled after handling 50 tasks. Releases any leaked memory. |
| `CELERY_WORKER_MAX_MEMORY_PER_CHILD` | `400000` | Worker is recycled if RSS exceeds ~400 MB (KB). Hard ceiling well below the 2 GB plan limit. |

These are read by Celery via the existing `app.config_from_object("django.conf:settings", namespace="CELERY")` line in `server/celery_config.py:18` — no Celery app code changes needed.

## Why this happened

The prefork pool's per-process Django footprint plus slow accumulation (ORM caches, AI client state, retained `PromptManager` references in the sentinel pipeline) pushed workers past the 2 GB Standard-plan limit. Render's event log shows the pattern: recover → OOM → recover → OOM → suspended.

## Caveat

This is a **tourniquet, not a cure.** The underlying memory growth in the sentinel pipeline is worth a separate investigation later — a single Celery worker doing one OpenAI call should not naturally grow past 500 MB. With these guards in place the worker stays healthy either way (recycled before it can blow up), but if you ever see workers being recycled aggressively (e.g., every few tasks instead of every 50), that's the signal that the underlying leak is bad.

## Commits

- `af62704` fix: Add Celery worker memory hygiene to prevent OOM crashes