### PR TITLE
refactor: Make S3 media location prefix env-driven

### DIFF
--- a/server/settings/local.py
+++ b/server/settings/local.py
@@ -34,6 +34,10 @@ bucket_name = env(
     "STAGING_AWS_STORAGE_BUCKET_NAME", default="discovita-dev-coach-staging"
 )
 custom_domain = f"{bucket_name}.s3.amazonaws.com"
+# S3 prefix under which all media is stored. Env-driven for symmetry with
+# the deployed environments (defaults to "media" so local behavior is
+# unchanged).
+s3_location = env("S3_LOCATION_PREFIX", default="media")
 
 # Media files configuration - Use S3 for local development (staging bucket)
 # Django 4.2+ STORAGES format per django-storages documentation
@@ -43,7 +47,7 @@ STORAGES = {
         "OPTIONS": {
             "bucket_name": bucket_name,
             "region_name": env("AWS_REGION", default="us-east-1"),
-            "location": "media",  # Prefix for all files stored in S3
+            "location": s3_location,
             "custom_domain": custom_domain,
             # Note: ACLs are disabled on this bucket. Public access is handled via bucket policy.
             "object_parameters": {
@@ -57,7 +61,7 @@ STORAGES = {
     },
 }
 
-MEDIA_URL = f"https://{custom_domain}/media/"
+MEDIA_URL = f"https://{custom_domain}/{s3_location}/"
 
 # Optional: Add debug logging for static files
 if DEBUG:

--- a/server/settings/production.py
+++ b/server/settings/production.py
@@ -28,6 +28,10 @@ bucket_name = env(
     "PROD_AWS_STORAGE_BUCKET_NAME", default="discovita-dev-coach-production"
 )
 custom_domain = f"{bucket_name}.s3.amazonaws.com"
+# S3 prefix under which all media is stored. Env-driven for symmetry with
+# staging and preview environments (defaults to the historical "media" so
+# production behavior is unchanged).
+s3_location = env("S3_LOCATION_PREFIX", default="media")
 
 # Media files configuration
 # Django 4.2+ STORAGES format per django-storages documentation
@@ -37,7 +41,7 @@ STORAGES = {
         "OPTIONS": {
             "bucket_name": bucket_name,
             "region_name": env("AWS_REGION", default="us-east-1"),
-            "location": "media",  # Prefix for all files stored in S3
+            "location": s3_location,
             "custom_domain": custom_domain,
             # Note: ACLs are disabled on this bucket. Public access is handled via bucket policy.
             "object_parameters": {
@@ -51,7 +55,7 @@ STORAGES = {
     },
 }
 
-MEDIA_URL = f"https://{custom_domain}/media/"
+MEDIA_URL = f"https://{custom_domain}/{s3_location}/"
 
 
 CELERY_BROKER_URL = os.environ["PROD_REDIS_URL"]

--- a/server/settings/staging.py
+++ b/server/settings/staging.py
@@ -28,6 +28,10 @@ bucket_name = env(
     "STAGING_AWS_STORAGE_BUCKET_NAME", default="discovita-dev-coach-staging"
 )
 custom_domain = f"{bucket_name}.s3.amazonaws.com"
+# S3 prefix under which all media is stored. Env-driven so preview
+# environments can scope themselves to a per-PR subfolder of the same bucket
+# (e.g. "previews/pr-101/media") without colliding with each other.
+s3_location = env("S3_LOCATION_PREFIX", default="media")
 
 # Media files configuration
 # Django 4.2+ STORAGES format per django-storages documentation
@@ -37,7 +41,7 @@ STORAGES = {
         "OPTIONS": {
             "bucket_name": bucket_name,
             "region_name": env("AWS_REGION", default="us-east-1"),
-            "location": "media",  # Prefix for all files stored in S3
+            "location": s3_location,
             "custom_domain": custom_domain,
             # Note: ACLs are disabled on this bucket. Public access is handled via bucket policy.
             "object_parameters": {
@@ -51,7 +55,7 @@ STORAGES = {
     },
 }
 
-MEDIA_URL = f"https://{custom_domain}/media/"
+MEDIA_URL = f"https://{custom_domain}/{s3_location}/"
 
 
 CELERY_BROKER_URL = os.environ["STAGING_REDIS_URL"]


### PR DESCRIPTION
## Summary

Replace the hardcoded `"media"` S3 prefix in `local`, `staging`, and `production` settings with an env-driven value (`S3_LOCATION_PREFIX`). Both the django-storages `location` and `MEDIA_URL` now derive from the same variable, defaulting to `"media"` so every existing environment behaves identically.

This is **PR 2 of 4** in the Render PR-previews implementation track. It's purely a refactor — no behavior change today, but it's the foundation that lets PR 3 (a new `previews.py` settings module) scope each preview's uploads into its own subfolder of the staging bucket (e.g. `previews/pr-101/media`).

## Changes

Same edit applied symmetrically to all three settings files:

```python
# new
s3_location = env("S3_LOCATION_PREFIX", default="media")

# changed
"location": s3_location,                         # was: "media"
MEDIA_URL = f"https://{custom_domain}/{s3_location}/"   # was: ".../media/"
```

| File | Lines |
|---|---|
| `server/settings/local.py` | +6 / −2 |
| `server/settings/staging.py` | +6 / −2 |
| `server/settings/production.py` | +6 / −2 |

## Why touch local.py

For symmetry. The local settings already use the staging bucket, so the same env-var pattern works there too — and any developer who wants to test a PR's preview-prefix behavior locally can just `export S3_LOCATION_PREFIX=...` and have it Just Work. Default is unchanged.

## Commits

- `4dd8528` refactor: Make S3 media location prefix env-driven