### PR TITLE
feat: Add previews settings module for ephemeral PR environments

### DIFF
--- a/server/settings/previews.py
+++ b/server/settings/previews.py
@@ -1,0 +1,67 @@
+"""Settings for ephemeral PR preview environments on Render."""
+from settings.common import *
+
+DEBUG = False
+
+# Database — the preview's own ephemeral Postgres, wired by Render's
+# fromDatabase ref in render.yaml. The data inside is seeded from a
+# pg_dump of the staging DB during the preview's build step.
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.environ["PREVIEW_DB_NAME"],
+        "USER": os.environ["PREVIEW_DB_USER"],
+        "PASSWORD": os.environ["PREVIEW_DB_PASSWORD"],
+        "HOST": os.environ["PREVIEW_DB_HOST"],
+        "PORT": os.environ["PREVIEW_DB_PORT"],
+    }
+}
+
+# Static files configuration
+STATIC_URL = "/static/"
+STATIC_ROOT = ".staticfiles"
+
+
+# S3 Configuration
+# Note: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are set in common.py
+# Reuse the staging bucket — previews share it with staging but are
+# scoped into their own per-PR subfolder via S3_LOCATION_PREFIX.
+bucket_name = env(
+    "STAGING_AWS_STORAGE_BUCKET_NAME", default="discovita-dev-coach-staging"
+)
+custom_domain = f"{bucket_name}.s3.amazonaws.com"
+# Required — the blueprint sets this per preview to something like
+# "previews/pr-101/media". No default: silent collisions with staging
+# data would be far worse than a hard failure on misconfiguration.
+s3_location = os.environ["S3_LOCATION_PREFIX"]
+
+# Media files configuration
+# Django 4.2+ STORAGES format per django-storages documentation
+STORAGES = {
+    "default": {
+        "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+        "OPTIONS": {
+            "bucket_name": bucket_name,
+            "region_name": env("AWS_REGION", default="us-east-1"),
+            "location": s3_location,
+            "custom_domain": custom_domain,
+            # Note: ACLs are disabled on this bucket. Public access is handled via bucket policy.
+            "object_parameters": {
+                "CacheControl": "max-age=86400",
+            },
+            "querystring_auth": False,
+        },
+    },
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}
+
+MEDIA_URL = f"https://{custom_domain}/{s3_location}/"
+
+
+# Celery — preview's own Redis, wired by Render's fromService ref in render.yaml.
+CELERY_BROKER_URL = os.environ["PREVIEW_REDIS_URL"]
+CELERY_RESULT_BACKEND = None
+CELERY_TASK_TRACK_STARTED = True
+CELERY_TIMEZONE = "UTC"


### PR DESCRIPTION
## Summary

Adds `server/settings/previews.py` — the Django settings module that PR-preview services on Render will use. Mirrors the structure of `staging.py` so reviewers can compare line-by-line; the differences are intentional and minimal.

This is **PR 3 of 4** in the Render PR-previews track. **Purely additive** — nothing in the codebase or any existing environment uses these settings yet. The blueprint coming in PR 4 will set `DJANGO_SETTINGS_MODULE=settings.previews` on preview services and populate the env vars this module reads.

## Differences from staging.py

| Concern | staging.py | previews.py | Why |
|---|---|---|---|
| **DB env vars** | `STAGING_DB_*` | `PREVIEW_DB_*` | Each preview gets its own ephemeral Postgres (seeded from staging via pg_dump). The staging DB stays alive as the dump source but isn't the preview's runtime DB. |
| **S3 bucket** | `discovita-dev-coach-staging` | same | Previews share the staging bucket. |
| **S3 location prefix** | `S3_LOCATION_PREFIX` with default `"media"` | `S3_LOCATION_PREFIX` **required, no default** | A preview with no prefix would silently scribble into staging's `media/` folder. Hard failure on misconfig is much safer. |
| **Celery broker** | `STAGING_REDIS_URL` | `PREVIEW_REDIS_URL` | Each preview gets its own Redis. |

Everything else (CORS, CSRF, REST framework, image config, email, Celery hygiene from PR #60, etc.) is inherited from `common.py` unchanged.

## What this does NOT include

Deliberately leaving these for follow-up PRs after the first preview spins up — easier to fix surgically once we see what actually breaks:

- **CORS / CSRF for preview frontend domains.** The preview frontend will live at something like `preview-coach-frontend-pr-101.onrender.com`. `common.py` currently lists `dev-coach-frontend.onrender.com` in `CORS_ALLOWED_ORIGINS` and `CSRF_TRUSTED_ORIGINS`. If preview auth fails, we'll add a regex pattern (`CORS_ALLOWED_ORIGIN_REGEXES`, wildcard `CSRF_TRUSTED_ORIGINS`) in a small PR. Bite-sized fixes are easier than over-engineering up front.
- **Email backend override.** Previews should probably use a console/dummy backend (don't send real password-reset emails from a preview env). I'll add this if/when it surfaces during smoke testing.

## Env vars the blueprint will need to set

For reference (these come in PR 4 via `render.yaml`):

- `PREVIEW_DB_NAME`, `PREVIEW_DB_USER`, `PREVIEW_DB_PASSWORD`, `PREVIEW_DB_HOST`, `PREVIEW_DB_PORT` — `fromDatabase` ref to `preview-coach-database`
- `PREVIEW_REDIS_URL` — `fromService` ref to `preview-coach-redis`
- `S3_LOCATION_PREFIX` — literal value computed per preview, e.g. `previews/pr-${RENDER_GIT_PR_NUMBER}/media`
- `STAGING_AWS_STORAGE_BUCKET_NAME`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` — same as staging

## Commits

- `29fc188` feat: Add previews settings module for ephemeral PR environments