### PR TITLE
feat: Add render.yaml blueprint for PR preview environments

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,228 @@
+# =============================================================================
+# Render Blueprint — PR Preview Environments
+# =============================================================================
+# This file defines the six "base" services that Render uses as the template
+# for ephemeral PR-preview environments. Each open PR can spin up its own
+# isolated copy of all six services via the "Create Preview" button on the PR.
+#
+# Lifecycle:
+#   1. Sync this blueprint into the discovita > Previews environment in the
+#      Render dashboard (one-time, after merge).
+#   2. Render creates the six base services (always-on; lowest tier).
+#   3. When a teammate clicks "Create Preview" on a PR, Render forks ephemeral
+#      copies of every service with `previews: { generation: manual }` set.
+#   4. The preview API service runs `pg_dump` of staging into the preview's
+#      ephemeral Postgres during build, then runs migrations from the PR
+#      branch.
+#   5. The preview frontend builds with VITE_COACH_BASE_URL pointing at the
+#      preview's own API URL (wired by Render's fromService ref).
+#   6. The PR comment shows the preview URL. Click → smoke test.
+#
+# Secrets to set in the Render dashboard once after first sync:
+#   - STAGING_DATABASE_URL    (full postgres:// URL of staging-coach-database)
+#   - DJANGO_SECRET_KEY       (any random string; previews don't need to share
+#                              with prod)
+#   - AWS_ACCESS_KEY_ID       (same as staging — see staging dashboard)
+#   - AWS_SECRET_ACCESS_KEY   (same as staging)
+#   - AWS_SES_REGION_NAME, AWS_SES_REGION_ENDPOINT, AWS_SES_SOURCE_EMAIL
+#     (same as staging)
+# =============================================================================
+
+databases:
+  - name: preview-coach-database
+    region: oregon
+    plan: basic-256mb
+    previews:
+      generation: manual
+
+services:
+  # ---------------------------------------------------------------------------
+  # Django API (web)
+  # ---------------------------------------------------------------------------
+  - type: web
+    name: preview-coach-api
+    runtime: python
+    region: oregon
+    plan: starter
+    rootDir: server
+    previews:
+      generation: manual
+    buildCommand: |
+      pip install -r requirements.txt
+      python manage.py collectstatic --noinput
+      pg_dump "$STAGING_DATABASE_URL" --no-owner --no-acl --clean --if-exists | psql "$PREVIEW_DATABASE_URL"
+      python manage.py migrate --noinput
+    startCommand: gunicorn wsgi:application --bind 0.0.0.0:$PORT --workers 2
+    envVars:
+      - key: DJANGO_SETTINGS_MODULE
+        value: settings.previews
+      - key: DJANGO_SECRET_KEY
+        sync: false
+      # Per-PR S3 prefix so previews never collide with each other or with
+      # real staging data. RENDER_GIT_PR_NUMBER is auto-set by Render on
+      # preview environments.
+      - key: S3_LOCATION_PREFIX
+        value: previews/pr-${RENDER_GIT_PR_NUMBER}/media
+      # Staging DB — used as the source for pg_dump during build only.
+      - key: STAGING_DATABASE_URL
+        sync: false
+      # Preview DB — wired in five forms because previews.py reads them
+      # individually and the build script needs the URL for pg_dump dest.
+      - key: PREVIEW_DATABASE_URL
+        fromDatabase:
+          name: preview-coach-database
+          property: connectionString
+      - key: PREVIEW_DB_NAME
+        fromDatabase:
+          name: preview-coach-database
+          property: database
+      - key: PREVIEW_DB_USER
+        fromDatabase:
+          name: preview-coach-database
+          property: user
+      - key: PREVIEW_DB_PASSWORD
+        fromDatabase:
+          name: preview-coach-database
+          property: password
+      - key: PREVIEW_DB_HOST
+        fromDatabase:
+          name: preview-coach-database
+          property: host
+      - key: PREVIEW_DB_PORT
+        fromDatabase:
+          name: preview-coach-database
+          property: port
+      # Redis (Valkey) — Celery broker for the sentinel worker.
+      - key: PREVIEW_REDIS_URL
+        fromService:
+          name: preview-coach-redis
+          type: redis
+          property: connectionString
+      # AWS — same creds as staging, same bucket as staging (scoped by prefix).
+      - key: AWS_ACCESS_KEY_ID
+        sync: false
+      - key: AWS_SECRET_ACCESS_KEY
+        sync: false
+      - key: AWS_REGION
+        value: us-east-1
+      - key: AWS_SES_REGION_NAME
+        sync: false
+      - key: AWS_SES_REGION_ENDPOINT
+        sync: false
+      - key: AWS_SES_SOURCE_EMAIL
+        sync: false
+      - key: STAGING_AWS_STORAGE_BUCKET_NAME
+        value: discovita-dev-coach-staging
+      # Frontend URL (used in password-reset emails etc).
+      - key: FRONTEND_URL
+        fromService:
+          name: preview-coach-frontend
+          type: web
+          property: host
+
+  # ---------------------------------------------------------------------------
+  # Sentinel — Celery worker for user-note extraction
+  # ---------------------------------------------------------------------------
+  # Same image as the api, different start command. Memory hygiene flags
+  # come from CELERY_WORKER_* settings in server/settings/common.py.
+  - type: worker
+    name: preview-coach-sentinel
+    runtime: python
+    region: oregon
+    plan: starter
+    rootDir: server
+    previews:
+      generation: manual
+    buildCommand: pip install -r requirements.txt
+    startCommand: celery -A celery_config worker --loglevel=INFO
+    envVars:
+      - key: DJANGO_SETTINGS_MODULE
+        value: settings.previews
+      - key: DJANGO_SECRET_KEY
+        sync: false
+      - key: S3_LOCATION_PREFIX
+        value: previews/pr-${RENDER_GIT_PR_NUMBER}/media
+      - key: PREVIEW_DB_NAME
+        fromDatabase:
+          name: preview-coach-database
+          property: database
+      - key: PREVIEW_DB_USER
+        fromDatabase:
+          name: preview-coach-database
+          property: user
+      - key: PREVIEW_DB_PASSWORD
+        fromDatabase:
+          name: preview-coach-database
+          property: password
+      - key: PREVIEW_DB_HOST
+        fromDatabase:
+          name: preview-coach-database
+          property: host
+      - key: PREVIEW_DB_PORT
+        fromDatabase:
+          name: preview-coach-database
+          property: port
+      - key: PREVIEW_REDIS_URL
+        fromService:
+          name: preview-coach-redis
+          type: redis
+          property: connectionString
+      - key: AWS_ACCESS_KEY_ID
+        sync: false
+      - key: AWS_SECRET_ACCESS_KEY
+        sync: false
+      - key: AWS_REGION
+        value: us-east-1
+      - key: STAGING_AWS_STORAGE_BUCKET_NAME
+        value: discovita-dev-coach-staging
+
+  # ---------------------------------------------------------------------------
+  # Frontend — Vite/React static site
+  # ---------------------------------------------------------------------------
+  # VITE_* env vars are baked into the bundle at build time; we export them
+  # before `npm run build` so each preview's bundle points at its own API.
+  - type: web
+    name: preview-coach-frontend
+    runtime: static
+    region: oregon
+    rootDir: client
+    previews:
+      generation: manual
+    buildCommand: |
+      export VITE_COACH_BASE_URL="https://${PREVIEW_API_HOST}/api/v1"
+      export VITE_ENV=preview
+      npm install
+      npm run build
+    staticPublishPath: dist
+    envVars:
+      - key: PREVIEW_API_HOST
+        fromService:
+          name: preview-coach-api
+          type: web
+          property: host
+
+  # ---------------------------------------------------------------------------
+  # Docs — Docusaurus static site
+  # ---------------------------------------------------------------------------
+  - type: web
+    name: preview-coach-docs
+    runtime: static
+    region: oregon
+    rootDir: docs
+    previews:
+      generation: manual
+    buildCommand: |
+      npm install
+      npm run build
+    staticPublishPath: build
+
+  # ---------------------------------------------------------------------------
+  # Redis (Valkey) — Celery broker
+  # ---------------------------------------------------------------------------
+  - type: redis
+    name: preview-coach-redis
+    region: oregon
+    plan: free
+    ipAllowList: []
+    previews:
+      generation: manual


### PR DESCRIPTION
## Summary

Adds `render.yaml` at the repo root — the Render Blueprint that defines six base services used as the template for ephemeral PR-preview environments. This is **PR 4 of 4** in the previews track and the meatiest one. Builds on:

- #60 (Celery memory hygiene)
- #61 (env-driven S3 prefix)
- #62 (`server/settings/previews.py`)

After merging, a one-time Render dashboard sync turns the YAML into real services, and the "Create Preview" button starts appearing on every PR.

## What's in the blueprint

| Service | Type | Plan | Purpose |
|---|---|---|---|
| `preview-coach-api` | Django (web) | starter | API. Build runs `pg_dump` from staging into the preview DB, then migrates. |
| `preview-coach-sentinel` | Celery worker | starter | User-note extraction. Uses `CELERY_WORKER_*` hygiene from #60. |
| `preview-coach-frontend` | Vite/React static | free | UI. `VITE_COACH_BASE_URL` wired per-preview via `fromService`. |
| `preview-coach-docs` | Docusaurus static | free | Reference docs. |
| `preview-coach-database` | Postgres | basic-256mb | Per-preview ephemeral DB. |
| `preview-coach-redis` | Valkey (Redis) | free | Per-preview ephemeral broker. |

All six have `previews: { generation: manual }` → PR previews are opt-in (button click), not auto-spawned on every push.

## Per-PR isolation

- **DB:** each preview gets its own ephemeral Postgres, seeded fresh from `staging-coach-database` via `pg_dump --clean --if-exists | psql` in the api's `buildCommand`. Migrations from the PR branch then run against the cloned data.
- **S3:** `S3_LOCATION_PREFIX=previews/pr-${RENDER_GIT_PR_NUMBER}/media` — shared staging bucket but scoped per PR. `previews.py` requires this env var (PR #62), so a misconfigured preview fails fast.
- **Redis:** each preview gets its own.
- **Frontend bundle:** `VITE_COACH_BASE_URL` is constructed at build time as `https://${PREVIEW_API_HOST}/api/v1` where `PREVIEW_API_HOST` resolves to *that preview's* API URL via `fromService`.

## What you need to do AFTER merging

### 1. Tear down old staging services (Render dashboard)
Delete everything in the `Staging` environment **except `staging-coach-database`** — that one stays alive as the dump source for previews. While you're there, rename the environment from `Staging` to `Previews` (or create a new one and use that as the sync target).

### 2. Sync the blueprint (Render dashboard)
- New → Blueprint → connect repo `Discovita/dev-coach` → branch `main`
- Pick the `Previews` environment in the discovita project as the sync target
- Render will create the six base services from this file

### 3. Set the secret env vars (one-time)
Render will prompt for these `sync: false` vars on first sync (they're needed by the api/worker but I can't put them in the YAML):

| Var | Value |
|---|---|
| `STAGING_DATABASE_URL` | Full `postgres://` URL of `staging-coach-database`. Get from staging DB's "Connect" → "External Database URL" |
| `DJANGO_SECRET_KEY` | Any random string. `openssl rand -hex 32` is fine — previews don't need to share with prod |
| `AWS_ACCESS_KEY_ID` | Same as staging — copy from staging-dev-coach-api's env vars |
| `AWS_SECRET_ACCESS_KEY` | Same as staging |
| `AWS_SES_REGION_NAME`, `AWS_SES_REGION_ENDPOINT`, `AWS_SES_SOURCE_EMAIL` | Same as staging |

### 4. S3 bucket lifecycle rule (AWS console, one-time)
On `discovita-dev-coach-staging`, add a lifecycle rule that deletes objects under prefix `previews/` after 7 days. This auto-cleans abandoned preview uploads.

### 5. Smoke test
- Open a throwaway PR with a no-op change
- Click "Create Preview" on the PR (Render's GitHub integration posts this)
- Watch the build — most likely failure modes:
  - `pg_dump` not on PATH → may need to add `apt-get install -y postgresql-client &&` to the buildCommand
  - YAML schema rejection (a field name I got wrong) → Render's error message tells you which line
  - `fromService` ref to `redis` type may need to be `keyvalue` instead — Render renamed but yaml may accept either
- Iterate via small follow-up PRs

## Known uncertainties

I'm flagging these up front since YAML schema errors are the most likely failure on first sync. **None of these break anything by being wrong — Render rejects the sync with a clear error message and we fix in a follow-up.**

| Field | What I used | Possible alternative |
|---|---|---|
| Redis service `type` | `redis` | `keyvalue` (Render's newer name) |
| Static site `runtime` | `static` | `env: static` (older syntax) |
| `previews:` block on databases/redis | included | may be ignored or rejected — preview scope might inherit from referencing services |
| `${RENDER_GIT_PR_NUMBER}` interpolation in `value:` | assumed supported | may need to compute in build script instead |

If any of these blow up on sync, the fix is a tiny PR.

## What this does NOT do (deliberate, save for follow-ups)

- **CORS / CSRF for `*.onrender.com`** — `previews.py` inherits from `common.py` which only lists `dev-coach-frontend.onrender.com`. Preview frontends will fail to auth until we add a regex pattern. Will fix in a follow-up PR after smoke testing reveals the exact issue.
- **Email backend override for previews** — previews can technically still send real emails. Probably worth swapping to console backend later.
- **Adopting prod into the blueprint (Phase 2)** — prod stays handcrafted for now. Once previews are trusted (a few weeks of use), we adopt.

## Commits

- `cbae274` feat: Add render.yaml blueprint for PR preview environments