### PR TITLE
fix: Correct render.yaml against prod-deployment export

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -32,6 +32,7 @@ databases:
   - name: preview-coach-database
     region: oregon
     plan: basic-256mb
+    postgresMajorVersion: "17"
     previews:
       generation: manual
 
@@ -52,7 +53,7 @@ services:
       python manage.py collectstatic --noinput
       pg_dump "$STAGING_DATABASE_URL" --no-owner --no-acl --clean --if-exists | psql "$PREVIEW_DATABASE_URL"
       python manage.py migrate --noinput
-    startCommand: gunicorn wsgi:application --bind 0.0.0.0:$PORT --workers 2
+    startCommand: gunicorn asgi:application --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT --timeout 600 --workers 2
     envVars:
       - key: DJANGO_SETTINGS_MODULE
         value: settings.previews
@@ -96,7 +97,7 @@ services:
       - key: PREVIEW_REDIS_URL
         fromService:
           name: preview-coach-redis
-          type: redis
+          type: keyvalue
           property: connectionString
       # AWS — same creds as staging, same bucket as staging (scoped by prefix).
       - key: AWS_ACCESS_KEY_ID
@@ -165,7 +166,7 @@ services:
       - key: PREVIEW_REDIS_URL
         fromService:
           name: preview-coach-redis
-          type: redis
+          type: keyvalue
           property: connectionString
       - key: AWS_ACCESS_KEY_ID
         sync: false
@@ -194,6 +195,12 @@ services:
       npm install
       npm run build
     staticPublishPath: dist
+    # SPA route rewrite — without this, refreshing a non-root URL
+    # (e.g. /dashboard) would 404 instead of being handled by client routing.
+    routes:
+      - type: rewrite
+        source: /*
+        destination: /index.html
     envVars:
       - key: PREVIEW_API_HOST
         fromService:
@@ -219,10 +226,11 @@ services:
   # ---------------------------------------------------------------------------
   # Redis (Valkey) — Celery broker
   # ---------------------------------------------------------------------------
-  - type: redis
+  - type: keyvalue
     name: preview-coach-redis
     region: oregon
-    plan: free
+    plan: starter
+    maxmemoryPolicy: allkeys-lru
     ipAllowList: []
     previews:
       generation: manual


### PR DESCRIPTION
## Summary

Fix-up to #63 based on the actual prod deployment YAML exported from Render. Catches five things the previous PR couldn't verify because we didn't have a working reference. **Merge this before attempting the dashboard sync** — without these the first sync will either fail or produce a broken preview.

## Fixes

| # | Change | Why |
|---|---|---|
| 1 | Redis service `type: redis` → `type: keyvalue` (and the two `fromService` refs from api/worker) | Render renamed the resource type. The export confirms `type: keyvalue` is current. |
| 2 | Redis `plan: free` → `plan: starter`, add `maxmemoryPolicy: allkeys-lru` | Free tier no longer offered for key-value. Mirrors prod's `prod-coach-redis` config. |
| 3 | Add `postgresMajorVersion: "17"` on the preview database | Prod uses Postgres 17. Without this, `pg_dump` from staging-coach-database (also v17) could hit version-mismatch warnings restoring into a different default version. |
| 4 | Frontend: add `routes: [{type: rewrite, source: /*, destination: /index.html}]` | SPA client-side routing breaks without this — refreshing `/dashboard` would 404. Both prod static frontends in the export have this rule. |
| 5 | API `startCommand`: `gunicorn wsgi:application --workers 2` → `gunicorn asgi:application --worker-class uvicorn.workers.UvicornWorker --timeout 600 --workers 2` | Matches `prod-dev-coach-api`. App already has `server/asgi.py` and ships `uvicorn-worker` in requirements. `--timeout 600` accommodates AI calls that exceed gunicorn's default 30s. |

## What I deliberately did NOT copy from the prod export

- `--bind 0.0.0.0:81` — prod hardcodes port 81 for some reason. `$PORT` (Render's env-injected default) is the correct pattern, keeping that.
- `npm install; npm run build` (semicolon) — using `&&` instead so the build aborts if install fails.
- `autoDeployTrigger: commit` — this is the default behavior, no need to set it explicitly.
- `--bind 0.0.0.0:81 --timeout 600` literal port — same reason as above.

## Diff: +13 / −5

Single file changed (`render.yaml`).

## Commits

- `cb97bc7` fix: Correct render.yaml against prod-deployment export