### PR TITLE
fix: Correct render.yaml schema errors + supersede #64

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -32,8 +32,7 @@ databases:
   - name: preview-coach-database
     region: oregon
     plan: basic-256mb
-    previews:
-      generation: manual
+    postgresMajorVersion: "17"
 
 services:
   # ---------------------------------------------------------------------------
@@ -52,7 +51,7 @@ services:
       python manage.py collectstatic --noinput
       pg_dump "$STAGING_DATABASE_URL" --no-owner --no-acl --clean --if-exists | psql "$PREVIEW_DATABASE_URL"
       python manage.py migrate --noinput
-    startCommand: gunicorn wsgi:application --bind 0.0.0.0:$PORT --workers 2
+    startCommand: gunicorn asgi:application --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT --timeout 600 --workers 2
     envVars:
       - key: DJANGO_SETTINGS_MODULE
         value: settings.previews
@@ -96,7 +95,7 @@ services:
       - key: PREVIEW_REDIS_URL
         fromService:
           name: preview-coach-redis
-          type: redis
+          type: keyvalue
           property: connectionString
       # AWS — same creds as staging, same bucket as staging (scoped by prefix).
       - key: AWS_ACCESS_KEY_ID
@@ -165,7 +164,7 @@ services:
       - key: PREVIEW_REDIS_URL
         fromService:
           name: preview-coach-redis
-          type: redis
+          type: keyvalue
           property: connectionString
       - key: AWS_ACCESS_KEY_ID
         sync: false
@@ -194,6 +193,12 @@ services:
       npm install
       npm run build
     staticPublishPath: dist
+    # SPA route rewrite — without this, refreshing a non-root URL
+    # (e.g. /dashboard) would 404 instead of being handled by client routing.
+    routes:
+      - type: rewrite
+        source: /*
+        destination: /index.html
     envVars:
       - key: PREVIEW_API_HOST
         fromService:
@@ -219,10 +224,9 @@ services:
   # ---------------------------------------------------------------------------
   # Redis (Valkey) — Celery broker
   # ---------------------------------------------------------------------------
-  - type: redis
+  - type: keyvalue
     name: preview-coach-redis
     region: oregon
-    plan: free
+    plan: starter
+    maxmemoryPolicy: allkeys-lru
     ipAllowList: []
-    previews:
-      generation: manual


### PR DESCRIPTION
## Summary

Render's blueprint validator rejected the first sync attempt with `field previews not found in type file.Database` (and the same error on the keyvalue/Redis service). Fix that, plus roll up the prod-export-based corrections from #64 (which never merged) into one PR.

**Supersedes [#64](https://github.com/Discovita/dev-coach/pull/64)** — close that one without merging; this is a strict superset.

## Fixes

| # | Change | Why |
|---|---|---|
| 1 | **Remove `previews:` from the database** | Render's schema doesn't allow this field on databases. They get ephemeral preview copies automatically via `fromDatabase` refs from web/worker services that DO have `previews:`. |
| 2 | **Remove `previews:` from the keyvalue (Redis) service** | Same — keyvalue resources inherit preview behavior from `fromService` refs, no opt-in field on the resource itself. |
| 3 | Redis service `type: redis` → `type: keyvalue` (and the two `fromService` refs from api/worker) | Render renamed the resource type. The prod export confirms `keyvalue`. |
| 4 | Redis `plan: free` → `plan: starter`, add `maxmemoryPolicy: allkeys-lru` | Free tier no longer offered for key-value. Mirrors prod's `prod-coach-redis`. |
| 5 | Add `postgresMajorVersion: "17"` to the database | Prod uses Postgres 17. Without explicit version, `pg_dump` from staging (also v17) could hit version-mismatch warnings restoring into a different default. |
| 6 | Frontend: add `routes: [{type: rewrite, source: /*, destination: /index.html}]` | SPA client-side routing breaks without this — refreshing `/dashboard` 404s. Both prod static frontends in the export have this rule. |
| 7 | API `startCommand`: `gunicorn wsgi:application --workers 2` → `gunicorn asgi:application --worker-class uvicorn.workers.UvicornWorker --timeout 600 --workers 2` | Matches `prod-dev-coach-api`. App already has `server/asgi.py` and ships `uvicorn-worker` in requirements. `--timeout 600` accommodates AI calls that exceed gunicorn's default 30s. |

## Diff: +13 / −9 (one file)

## Commits

- `0cc619f` fix: Correct render.yaml schema errors + apply prod-export learnings

## After merging

1. Close PR #64 as superseded (no merge needed)
2. Retry the blueprint sync — Render should accept the file this time
3. Continue with the secrets / S3 lifecycle / smoke test steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)