### PR TITLE
fix: Remove region from static sites in render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -183,7 +183,6 @@ services:
   - type: web
     name: preview-coach-frontend
     runtime: static
-    region: oregon
     rootDir: client
     previews:
       generation: manual
@@ -212,7 +211,6 @@ services:
   - type: web
     name: preview-coach-docs
     runtime: static
-    region: oregon
     rootDir: docs
     previews:
       generation: manual


### PR DESCRIPTION
## Summary

Render's blueprint validator rejected the sync with:
```
services[2]: static sites cannot have a region
services[3]: static sites cannot have a region
```

Static sites are served from a global CDN, not region-pinned. Removing `region: oregon` from `preview-coach-frontend` and `preview-coach-docs`.

## Diff: -2 lines

## Commits

- `0d9af84` fix: Remove region from static sites in render.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)