### PR TITLE
fix: Move pg_dump and migrate to preDeployCommand

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -49,6 +49,12 @@ services:
     buildCommand: |
       pip install -r requirements.txt
       python manage.py collectstatic --noinput
+    # preDeployCommand runs after build, in the runtime environment where the
+    # preview DB is fully provisioned and reachable. Running pg_dump | psql in
+    # buildCommand was unreliable because the build container's connectivity
+    # to the freshly-created preview DB is racy — the dump would start, COPY
+    # a few tables, then drop the SSL connection mid-stream.
+    preDeployCommand: |
       pg_dump "$STAGING_DATABASE_URL" --no-owner --no-acl --clean --if-exists | psql "$PREVIEW_DATABASE_URL"
       python manage.py migrate --noinput
     startCommand: gunicorn asgi:application --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT --timeout 600 --workers 2


### PR DESCRIPTION
## Summary

Last deploy got past pip install (Python pinning worked) but failed at the `pg_dump | psql` step:

```
COPY 23
COPY 298
SSL error: unexpected eof while reading
invalid socket
connection to server was lost
```

Then `migrate` hit `psycopg2.OperationalError: connection to server ... port 5432 failed: Connection refused`.

The build container's connectivity to the freshly-created preview DB is racy — the connection drops mid-stream and the DB is briefly unreachable. The fix is to move DB-touching steps out of `buildCommand` (which runs in an ephemeral build container) and into **`preDeployCommand`** (which runs after build in the runtime environment with the DB stable and reachable).

## Diff: +6 (one file)

- `buildCommand` keeps only DB-independent steps: `pip install`, `collectstatic`
- `preDeployCommand` runs `pg_dump | psql` then `migrate` once per deploy with stable connectivity

## Commits

- `17f362a` fix: Move pg_dump and migrate from buildCommand to preDeployCommand