### PR TITLE
fix: Add missing AWS_SES_* env vars to preview-coach-sentinel

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -185,6 +185,14 @@ services:
         sync: false
       - key: AWS_REGION
         value: us-east-1
+      # SES vars are required by common.py — even though the worker doesn't
+      # send emails directly, importing settings fails without them.
+      - key: AWS_SES_REGION_NAME
+        sync: false
+      - key: AWS_SES_REGION_ENDPOINT
+        sync: false
+      - key: AWS_SES_SOURCE_EMAIL
+        sync: false
       - key: STAGING_AWS_STORAGE_BUCKET_NAME
         value: discovita-dev-coach-staging
 


### PR DESCRIPTION
## Summary

The worker crashed on startup:
```
django.core.exceptions.ImproperlyConfigured: Set the AWS_SES_REGION_NAME environment variable
```

`server/settings/common.py` reads `AWS_SES_REGION_NAME`, `AWS_SES_REGION_ENDPOINT`, and `AWS_SES_SOURCE_EMAIL` with no defaults — so settings imports fail on any service missing them, even if that service never sends email.

The api had all three. The worker had none. Adding them as `sync: false` (same pattern as the api).

## Diff: +8 (one file)

## Commits

- `93c9df3` fix: Add missing AWS_SES_* env vars to preview-coach-sentinel

## After merging

Render will resync. It'll prompt for the 3 new `sync: false` vars on the worker — paste the same values you used for the api.

🤖 Generated with [Claude Code](https://claude.com/claude-code)