### PR TITLE
fix: Wait for preview DB to accept connections in preDeployCommand

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -54,7 +54,20 @@ services:
     # buildCommand was unreliable because the build container's connectivity
     # to the freshly-created preview DB is racy — the dump would start, COPY
     # a few tables, then drop the SSL connection mid-stream.
+    #
+    # The retry loop at the start handles a different race: each new preview
+    # creates a fresh Postgres that takes ~1-2 min to fully accept connections.
+    # preDeployCommand fires as soon as build finishes, so the first attempt
+    # often hits Connection refused. We poll up to 2 minutes before giving up.
     preDeployCommand: |
+      for i in 1 2 3 4 5 6 7 8; do
+        if psql "$PREVIEW_DATABASE_URL" -c 'SELECT 1' >/dev/null 2>&1; then
+          echo "Preview DB is ready (attempt $i)"
+          break
+        fi
+        echo "Preview DB not ready (attempt $i/8), waiting 15s..."
+        sleep 15
+      done
       pg_dump "$STAGING_DATABASE_URL" --no-owner --no-acl --clean --if-exists | psql "$PREVIEW_DATABASE_URL"
       python manage.py migrate --noinput
     startCommand: gunicorn asgi:application --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT --timeout 600 --workers 2


### PR DESCRIPTION
## Summary

preDeployCommand failed with `Connection refused` to the preview DB:
```
psycopg2.OperationalError: connection to server at "dpg-..." port 5432 failed: Connection refused
==> Pre-deploy has failed
```

Render's freshly-provisioned Postgres takes ~1-2 minutes to fully accept connections, but `preDeployCommand` fires immediately after build finishes. So the first attempt races — DB is still spinning up.

## Fix

Add a poll loop at the top of `preDeployCommand`: `psql SELECT 1` every 15 seconds, up to 8 attempts (2 min total). Once the DB responds, proceed with the dump and migrate.

This is **not just a one-time fix for the first sync** — every new preview creates a fresh DB and would race the same way. So the loop has to live in the YAML for every preview going forward.

## Diff: +13 (one file)

## Commits

- `ce4020d` fix: Wait for preview DB to accept connections in preDeployCommand

## After merging

Auto-resync should retry preDeploy with the new loop. Watch the logs — you should see "Preview DB not ready (attempt N/8)..." messages, then "Preview DB is ready", then the dump runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)