### PR TITLE
fix: Use top-level previews block (Preview Environments, not per-service)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,21 +2,25 @@
 # Render Blueprint — PR Preview Environments
 # =============================================================================
 # This file defines the six "base" services that Render uses as the template
-# for ephemeral PR-preview environments. Each open PR can spin up its own
-# isolated copy of all six services via the "Create Preview" button on the PR.
+# for ephemeral PR-preview environments. PRs that include `[render preview]`
+# in their title spawn a complete clone of every resource (services, db, redis)
+# into a new Render Environment.
 #
 # Lifecycle:
 #   1. Sync this blueprint into the discovita > Previews environment in the
-#      Render dashboard (one-time, after merge).
+#      Render dashboard (one-time).
 #   2. Render creates the six base services (always-on; lowest tier).
-#   3. When a teammate clicks "Create Preview" on a PR, Render forks ephemeral
-#      copies of every service with `previews: { generation: manual }` set.
+#   3. When a teammate edits a PR title to include `[render preview]`, Render
+#      clones the entire blueprint into a new Preview Environment for that PR.
 #   4. The preview API service runs `pg_dump` of staging into the preview's
-#      ephemeral Postgres during build, then runs migrations from the PR
+#      ephemeral Postgres during preDeploy, then runs migrations from the PR
 #      branch.
 #   5. The preview frontend builds with VITE_COACH_BASE_URL pointing at the
 #      preview's own API URL (wired by Render's fromService ref).
-#   6. The PR comment shows the preview URL. Click → smoke test.
+#   6. The PR's GitHub Deployments section shows the preview URL — click
+#      "View deployment" next to the web service.
+#   7. When the PR is merged or closed, Render auto-destroys the entire
+#      preview environment.
 #
 # Secrets to set in the Render dashboard once after first sync:
 #   - STAGING_DATABASE_URL    (full postgres:// URL of staging-coach-database)
@@ -27,6 +31,16 @@
 #   - AWS_SES_REGION_NAME, AWS_SES_REGION_ENDPOINT, AWS_SES_SOURCE_EMAIL
 #     (same as staging)
 # =============================================================================
+
+# Top-level previews block enables the Preview Environments feature: every PR
+# with `[render preview]` in its title spawns a complete clone of every
+# resource in this blueprint (services, database, key-value) into a new
+# environment. Manual generation means previews only spin up when explicitly
+# requested via the title tag, not on every PR.
+#
+# Preview Environments require a Render Pro plan or higher.
+previews:
+  generation: manual
 
 databases:
   - name: preview-coach-database
@@ -44,8 +58,6 @@ services:
     region: oregon
     plan: starter
     rootDir: server
-    previews:
-      generation: manual
     buildCommand: |
       pip install -r requirements.txt
       python manage.py collectstatic --noinput
@@ -161,8 +173,6 @@ services:
     region: oregon
     plan: starter
     rootDir: server
-    previews:
-      generation: manual
     buildCommand: pip install -r requirements.txt
     startCommand: celery -A celery_config worker --loglevel=INFO
     envVars:
@@ -226,8 +236,6 @@ services:
     name: preview-coach-frontend
     runtime: static
     rootDir: client
-    previews:
-      generation: manual
     buildCommand: |
       export VITE_COACH_BASE_URL="https://${PREVIEW_API_HOST}/api/v1"
       export VITE_ENV=preview
@@ -254,8 +262,6 @@ services:
     name: preview-coach-docs
     runtime: static
     rootDir: docs
-    previews:
-      generation: manual
     buildCommand: |
       npm install
       npm run build


### PR DESCRIPTION
## Summary

The previous YAML configured the **wrong Render feature**.

`previews: { generation: manual }` on individual services configures **Pull Request Previews** — Render's per-service feature that only spins up that one service per PR. From the Render dashboard text I found:

> "Pull Request Previews create a new instance for **just this service**. Use **Preview Environments** to clone a **group of services** for every PR."

We need **Preview Environments** — the group-clone behavior that copies every resource in the blueprint (services + database + key-value) into a fresh Render Environment per PR. The YAML syntax is a **top-level** `previews:` block, not per-service.

## Fix

```yaml
# At the top of render.yaml, above databases:
previews:
  generation: manual
```

And remove `previews: { generation: manual }` from all four services (api, sentinel, frontend, docs).

Preview Environments require a Render Pro plan — workspace already has it.

## How it actually works (corrected)

1. PR opened against main with `[render preview]` in the title
2. Render clones the entire blueprint into a new Preview Environment
3. The PR's GitHub Deployments section gets links to each service URL (no status checks, no comments — Deployments)
4. Click "View deployment" next to the web service to access
5. Push more commits → preview redeploys
6. Merge or close PR → entire preview environment auto-destroys

## Diff: +21 / −15 (one file)

## Commits

- `193a970` fix: Switch from per-service Pull Request Previews to top-level Preview Environments

## After merging

1. Render will resync the blueprint with the new top-level config
2. Edit PR #72's title to add `[render preview]` at the end (or open a fresh test PR with that in the title)
3. Watch GitHub Deployments section on the PR — within a couple minutes you should see preview environment deployments appear
4. Click "View deployment" → access the preview frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)