### PR TITLE
test: Verify Preview Environment with envVarGroup [render preview]

### DIFF
--- a/server/settings/common.py
+++ b/server/settings/common.py
@@ -286,3 +286,4 @@ VERSATILEIMAGEFIELD_SETTINGS = {
 CELERY_WORKER_CONCURRENCY = 1               # one fork, one Django copy
 CELERY_WORKER_MAX_TASKS_PER_CHILD = 50      # recycle worker after N tasks
 CELERY_WORKER_MAX_MEMORY_PER_CHILD = 400000  # recycle if RSS exceeds ~400 MB (KB)
+# (no-op edit to satisfy Render's rootDir filter for Preview Environment trigger)


### PR DESCRIPTION
## Summary

Fresh test PR to verify Render Preview Environments work end-to-end now that:
- Top-level `previews: { generation: manual }` is in the YAML ✅
- Shared secrets live in the `preview-shared-secrets` envVarGroup ✅
- Group secrets are populated in Render dashboard ✅
- This PR's diff touches a file inside a service rootDir (`server/`) ✅
- Title contains `[render preview]` ✅

If this works → all 4 deployable services should build green and the GitHub Deployments section will show URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)