### PR TITLE
test: Verify Preview Environment with manual env group [render preview]

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -19,6 +19,7 @@
       rel="stylesheet"
     />
     <title>neovita</title>
+    <!-- (no-op edit to satisfy Render's rootDir filter on the frontend service) -->
   </head>
   <body>
     <div id="app"></div>

--- a/server/settings/common.py
+++ b/server/settings/common.py
@@ -287,3 +287,4 @@ CELERY_WORKER_CONCURRENCY = 1               # one fork, one Django copy
 CELERY_WORKER_MAX_TASKS_PER_CHILD = 50      # recycle worker after N tasks
 CELERY_WORKER_MAX_MEMORY_PER_CHILD = 400000  # recycle if RSS exceeds ~400 MB (KB)
 # (no-op edit to satisfy Render's rootDir filter for Preview Environment trigger)
+# (and another to surface the STAGING_DATABASE_URL diagnostic)

--- a/server/settings/common.py
+++ b/server/settings/common.py
@@ -286,3 +286,4 @@ VERSATILEIMAGEFIELD_SETTINGS = {
 CELERY_WORKER_CONCURRENCY = 1               # one fork, one Django copy
 CELERY_WORKER_MAX_TASKS_PER_CHILD = 50      # recycle worker after N tasks
 CELERY_WORKER_MAX_MEMORY_PER_CHILD = 400000  # recycle if RSS exceeds ~400 MB (KB)
+# (no-op edit to satisfy Render's rootDir filter for Preview Environment trigger)


### PR DESCRIPTION
## Summary

Fresh test PR after restructuring the env group to be dashboard-managed (per #77). Verifying that all 11 vars — including the 7 sync:false secrets — now propagate to the spawned preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)