### PR TITLE
fix: Append .onrender.com to PREVIEW_API_HOST for valid frontend URL

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -226,7 +226,11 @@ services:
     runtime: static
     rootDir: client
     buildCommand: |
-      export VITE_COACH_BASE_URL="https://${PREVIEW_API_HOST}/api/v1"
+      # Render's fromService property: host returns just the service slug
+      # (e.g. "preview-coach-api-pr-78"), not the full hostname. Append
+      # .onrender.com so VITE_COACH_BASE_URL is a valid URL the browser
+      # can resolve.
+      export VITE_COACH_BASE_URL="https://${PREVIEW_API_HOST}.onrender.com/api/v1"
       export VITE_ENV=preview
       npm install
       npm run build


### PR DESCRIPTION
## Summary

PR #78's preview frontend was sending login requests to `https://preview-coach-api-pr-78/api/v1/auth/login` — missing the `.onrender.com` suffix. Browsers can't resolve that hostname, so no requests reached the API at all.

Render's `fromService` `property: host` returns just the service slug on previews (e.g. `preview-coach-api-pr-78`), not the full hostname. Appending `.onrender.com` in the build script.

## Diff: +5 / −1 (one file)

## After merging

PR #78 will rebuild → fresh URL → try login again. If CORS rejects the request (likely next gotcha — the API only allows `dev-coach-frontend.onrender.com` in `CORS_ALLOWED_ORIGINS`), I'll write the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)