### PR TITLE
test: Fresh preview env [render preview]

### DIFF
--- a/server/settings/common.py
+++ b/server/settings/common.py
@@ -286,3 +286,4 @@ VERSATILEIMAGEFIELD_SETTINGS = {
 CELERY_WORKER_CONCURRENCY = 1               # one fork, one Django copy
 CELERY_WORKER_MAX_TASKS_PER_CHILD = 50      # recycle worker after N tasks
 CELERY_WORKER_MAX_MEMORY_PER_CHILD = 400000  # recycle if RSS exceeds ~400 MB (KB)
+# (no-op edit: trigger fresh preview env to test STAGING_DATABASE_URL propagation)


### PR DESCRIPTION
Spawning a brand-new preview env from scratch to test whether STAGING_DATABASE_URL propagates from the env group when the preview is created AFTER the env group was populated.