### PR TITLE
fix: Dump staging to a file first, then restore

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -122,7 +122,15 @@ services:
         return 1
       }
       wait_for_db
-      pg_dump "$STAGING_DATABASE_URL" --no-owner --no-acl --clean --if-exists | psql "$PREVIEW_DATABASE_URL"
+      # Dump staging to a local file first, then restore from the file. The
+      # previous streaming `pg_dump | psql` approach kept two SSL connections
+      # open simultaneously and consistently dropped one of them mid-transfer
+      # (after ~11 tables of ~25), leaving the preview DB only partially
+      # populated. Buffering through a file means each connection only has to
+      # stay open for ONE side of the transfer.
+      pg_dump "$STAGING_DATABASE_URL" --no-owner --no-acl --clean --if-exists -f /tmp/staging-dump.sql
+      psql "$PREVIEW_DATABASE_URL" -f /tmp/staging-dump.sql
+      rm -f /tmp/staging-dump.sql
       wait_for_db
       python manage.py migrate --noinput
     startCommand: gunicorn asgi:application --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT --timeout 600 --workers 2


### PR DESCRIPTION
Streaming pg_dump | psql drops SSL mid-transfer after ~11 of ~25 tables. Buffer through /tmp/staging-dump.sql so each SSL connection only has to stay open for one side of the transfer. The users table sorts late alphabetically, which is probably why login was failing — its data never made it across before the connection died.