### PR TITLE
fix: Bump preview DB to basic-1gb (basic-256mb OOMs during restore)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -80,7 +80,12 @@ previews:
 databases:
   - name: preview-coach-database
     region: oregon
+    # Base service stays on basic-256mb — it's just the template, never
+    # serves real traffic. Previews use basic-1gb because basic-256mb
+    # consistently OOMs / drops its connection partway through restoring
+    # the staging dump (after ~11 tables, before the users table).
     plan: basic-256mb
+    previewPlan: basic-1gb
     postgresMajorVersion: "17"
 
 services:


### PR DESCRIPTION
Preview DB consistently drops its connection ~11 tables into the staging restore — classic OOM signature. basic-256mb is too small. Set previewPlan: basic-1gb so previews get 1 GB of RAM while the base stays cheap (it's just a template).