### PR TITLE
feat: Add API key auth for MCP server machine-to-machine access

### DIFF
--- a/server/apps/prompts/views/prompt_view_set.py
+++ b/server/apps/prompts/views/prompt_view_set.py
@@ -8,6 +8,7 @@ from django.shortcuts import get_object_or_404
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
+from rest_framework_api_key.permissions import HasAPIKey
 
 from apps.prompts.models import Prompt
 from apps.prompts.serializers import PromptSerializer
@@ -39,7 +40,7 @@ class PromptViewSet(
     - latest:         GET    /api/prompts/latest?coaching_phase=...
     """
 
-    permission_classes = [IsAdminUser]
+    permission_classes = [HasAPIKey | IsAdminUser]
     serializer_class = PromptSerializer
 
     def get_queryset(self):

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -28,6 +28,7 @@ django-storages==1.14.4
 django-uuid-upload-path==1.0.0
 django-versatileimagefield==3.1
 djangorestframework==3.15.2
+djangorestframework-api-key==3.1.0
 djangorestframework_simplejwt==5.5.0
 drf-spectacular==0.28.0
 google-api-core==2.24.2

--- a/server/settings/common.py
+++ b/server/settings/common.py
@@ -71,6 +71,7 @@ INSTALLED_APPS = [
     "apps.reference_images",
     # Third-party apps...
     "rest_framework",
+    "rest_framework_api_key",
     "corsheaders",
     "drf_spectacular",
     "storages",  # Required for S3 file storage (django-storages)
@@ -99,6 +100,9 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }
+
+# API key auth ships keys via X-Api-Key. Authorization is reserved for JWT.
+API_KEY_CUSTOM_HEADER = "HTTP_X_API_KEY"
 
 SPECTACULAR_SETTINGS = {
     "TITLE": "Discovita Dev Coach API",
@@ -131,6 +135,7 @@ CORS_ALLOW_HEADERS = [
     "dnt",
     "origin",
     "user-agent",
+    "x-api-key",
     "x-csrftoken",
     "x-requested-with",
 ]


### PR DESCRIPTION
## Summary
- Install `djangorestframework-api-key==3.1.0` and register `rest_framework_api_key` in `INSTALLED_APPS`.
- Set `API_KEY_CUSTOM_HEADER = \"HTTP_X_API_KEY\"` so the key ships as `X-Api-Key` (the `Authorization` header is already used by JWT). Whitelist `x-api-key` in CORS.
- Apply `HasAPIKey | IsAdminUser` on `PromptViewSet` so the MCP server (`/Users/caseyschmid/Programming/MCP/dev-coach/server.py`) can authenticate to `/api/v1/prompts/latest` and `POST /api/v1/prompts` machine-to-machine. Logged-in admins still work via JWT.

## Why
The MCP server's `get_latest_prompt` and `create_new_coach_prompt` tools need to call prompt endpoints that are currently `IsAdminUser`-gated. JWT isn't a good fit for a non-interactive client. API keys handle this cleanly per the [Add API Key Authentication](https://procedures.discovita.com/) NOP.

## After merge
1. Run `python manage.py migrate` on each env (creates `rest_framework_api_key_apikey`).
2. Issue a key in Django admin → \"API Key Permissions → API keys → Add\". Copy the displayed key **once**.
3. Store the key on the MCP server side as an env var. Update MCP tool calls to send `X-Api-Key: <key>`.