### PR TITLE
docs: Add coaching phase videos spec and 25-PR implementation plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ backend/public/*
 storybook-static
 server/services/ai/openai_service/scripts/images/
 server/services/image_generation/research/gemini/images
+
+# Coaching session video source files (uploaded to S3, not committed)
+videos/

--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000",
+    "local": "vite --port 5173 --host",
     "start": "vite --port 3000",
     "build": "vite build && tsc",
     "serve": "vite preview",

--- a/notes/coaching-phase-videos-prs.md
+++ b/notes/coaching-phase-videos-prs.md
@@ -1,0 +1,743 @@
+# Coaching Phase Videos — PR Coordination
+
+**Spec:** [`notes/coaching-phase-videos.md`](./coaching-phase-videos.md)
+**Feature flag:** `COACHING_PHASE_VIDEOS_ENABLED` (created in PR 1, flipped in PR 22, removed in PR 23).
+**Owner / coordinator:** Casey
+
+## Approach (locked in)
+
+**Handler-driven injection.** Session boundaries are detected by enriching two existing/new action handlers:
+
+- **`transition_phase` handler** — when the LLM transitions, the handler consults the `SESSIONS` map:
+  - If leaving session has an outro → attach the outro video component to the LLM's response message.
+  - Else if entering session has an intro → attach the intro video component to the LLM's response message.
+  - Else → just transition.
+- **`END_BREAK` handler** — after closing the break, if `current_phase` is the first phase of a session whose intro is not in `shown_videos` → return the intro video component.
+
+Welcome video is seeded in `ensure_initial_message_exists`. The video Continue button dispatches `{message: null, actions: [ACK, ...]}`; the break "I'm Ready" button dispatches `{message: "I'm ready", actions: [END_BREAK]}` (canned-response pattern).
+
+**What this approach intentionally avoids vs. the prior plan:**
+- No multi-message coach response shape — components ride along on the existing single-message-with-component pattern.
+- No pre-LLM intro gate or post-LLM outro hook in `process_message` — handlers carry the logic.
+- No `process_message` surgery beyond the null-message contract and skip-LLM-on-component rule (both lightweight).
+
+## Workflow rules (strict)
+
+1. **Strictly serial.** Each PR lands on `main` before the next one is started. No parallel work, no stacking.
+2. **One branch per PR.** Use the branch name listed in the status table. Branch off of `main` (which always has the previous PR merged).
+3. **Tests gate the push.** Every test listed under `Tests required to pass before push` must pass locally before the PR is opened.
+4. **Full suites green every time.** `pytest server/` and `cd client && npm test` must both pass — no regressions.
+5. **Update this doc as part of the PR.** When you claim a PR, edit the status table in the same branch. When the PR merges, the merge SHA + date go in the table.
+6. **Discoveries log is mandatory.** Surprises, design clarifications, gotchas — append to the bottom so the next PR's author starts informed.
+
+## How to claim a PR
+
+1. Pick the next `[ ]` in the table (everything is serial; you only ever pick the next one).
+2. Edit the row: status `[~]`, fill in your handle + ISO date.
+3. Read the per-PR section in full + the linked spec section before coding.
+4. Create the branch using the exact name in the `Branch` column.
+5. Write the tests listed under `Tests required to pass before push`. Add more if you find gaps; record additions in `Discoveries`.
+6. Open the PR against `main`. Update the table: status `[👀]` + PR link.
+7. After merge: status `[✓]` + merge SHA + date.
+
+## Status legend
+
+- `[ ]` Not started
+- `[~]` In progress — claim with handle + ISO date
+- `[👀]` In review — PR open
+- `[✓]` Merged
+- `[⛔]` Blocked — explain in Notes
+
+## Status table
+
+| #   | Title                                                                       | Branch                                       | Status | Claim | PR  | Logical deps |
+|-----|-----------------------------------------------------------------------------|----------------------------------------------|--------|-------|-----|--------------|
+| 1   | Feature flag scaffold                                                       | `casey/cpv-01-feature-flag`                  | `[ ]`  | —     | —   | — |
+| 2   | SESSIONS map + helpers                                                      | `casey/cpv-02-sessions-map`                  | `[ ]`  | —     | —   | — |
+| 3   | `CoachState.shown_videos` migration                                         | `casey/cpv-03-shown-videos-migration`        | `[ ]`  | —     | —   | — |
+| 4   | `Break` model + migration                                                   | `casey/cpv-04-break-model`                   | `[ ]`  | —     | —   | — |
+| 5   | Video registry + new enum values                                            | `casey/cpv-05-video-registry-enums`          | `[ ]`  | —     | —   | 2 |
+| 6   | `ACKNOWLEDGE_SESSION_VIDEO` handler                                         | `casey/cpv-06-ack-session-video-action`      | `[ ]`  | —     | —   | 3, 5 |
+| 7   | `START_BREAK` handler                                                       | `casey/cpv-07-start-break-action`            | `[ ]`  | —     | —   | 4, 5 |
+| 8   | `END_BREAK` handler (basic close)                                           | `casey/cpv-08-end-break-action`              | `[ ]`  | —     | —   | 4 |
+| 9   | `on_break` API field                                                        | `casey/cpv-09-on-break-api-field`            | `[ ]`  | —     | —   | 4 |
+| 10  | `process_message` null-message contract + skip-LLM-on-component rule        | `casey/cpv-10-null-message-contract`         | `[ ]`  | —     | —   | — |
+| 11  | History serialization + count bump (LLM read shim)                          | `casey/cpv-11-history-serialization`         | `[ ]`  | —     | —   | 3, 4 |
+| 12  | Welcome injection (flag-gated)                                              | `casey/cpv-12-welcome-injection`             | `[ ]`  | —     | —   | 1, 5 |
+| 13  | `transition_phase` handler enrichment — outro/intro auto-emit (flag-gated)  | `casey/cpv-13-transition-phase-enrichment`   | `[ ]`  | —     | —   | 1, 2, 5 |
+| 14  | `END_BREAK` handler enrichment — intro auto-emit (flag-gated)               | `casey/cpv-14-end-break-enrichment`          | `[ ]`  | —     | —   | 1, 2, 5, 8 |
+| 15  | FE: `on_break` composer disable + read shape                                | `casey/cpv-15-fe-on-break-composer`          | `[ ]`  | —     | —   | 9 |
+| 16  | FE: `SessionVideoCard` + modal shell                                        | `casey/cpv-16-fe-session-video-card`         | `[ ]`  | —     | —   | 5 |
+| 17  | FE: video modal threshold gate + action dispatch                            | `casey/cpv-17-fe-session-video-modal-action` | `[ ]`  | —     | —   | 6, 7, 16 |
+| 18  | FE: `SessionBreakComponent` + unacked-video composer rule                   | `casey/cpv-18-fe-session-break-composer`     | `[ ]`  | —     | —   | 8, 15, 17 |
+| 19  | Rename `dev-coach/videos/` files to match session keys                      | `casey/cpv-19-rename-video-files`            | `[ ]`  | —     | —   | — |
+| 20  | S3 upload + populate registry URLs                                          | `casey/cpv-20-s3-upload-registry-urls`       | `[ ]`  | —     | —   | 5, 19 |
+| 21  | Docs update — phases, transition-phase, persistent-components, new actions  | `casey/cpv-21-docs-update`                   | `[ ]`  | —     | —   | 2, 5, 6, 7, 8, 13, 14 |
+| 22  | Flip flag in staging + prod (no code — ops change)                          | n/a — Render dashboard env var               | `[ ]`  | —     | —   | 12–14, 18, 20, 21 |
+| 23  | Remove flag plumbing                                                        | `casey/cpv-23-remove-flag-plumbing`          | `[ ]`  | —     | —   | 22 |
+| 24  | Delete `INITIAL_MESSAGE` constant                                           | `casey/cpv-24-delete-initial-message`        | `[ ]`  | —     | —   | 23 |
+| 25  | Procedure MCP doc — Add a Session Video                                     | n/a — Procedures MCP `create_document`       | `[ ]`  | —     | —   | 24 |
+
+> The `Logical deps` column shows real code dependencies. Because the workflow is strictly serial, you'll always have all of them merged anyway — they're listed for sanity-checking the order, not for branching.
+
+## Cross-cutting verification
+
+Every code PR must satisfy these before push:
+
+- ✅ All tests listed in the PR's `Tests required to pass before push` section pass locally
+- ✅ Full backend test suite green (`pytest server/`)
+- ✅ Full frontend test suite green (`cd client && npm test`)
+- ✅ `python manage.py makemigrations --check --dry-run` clean (backend PRs)
+- ✅ Type-check passes (`mypy` if configured; `tsc --noEmit` for frontend)
+- ✅ Lint passes (`ruff` / `eslint`)
+- ✅ No `console.log`, `print`, or debugger statements left behind
+- ✅ Manual verification step (where listed) is performed and noted in the PR description
+- ✅ This doc updated in the same branch (status row, plus any `Discoveries` entries)
+
+---
+
+## PR 1 — Feature flag scaffold
+
+**Branch:** `casey/cpv-01-feature-flag`
+**Scope:** Add `COACHING_PHASE_VIDEOS_ENABLED` Django setting (env-driven, default `False`), a `videos_enabled()` helper, and expose the flag as `videos_enabled: bool` on the user-state endpoint so frontend can branch on it.
+**Files likely touched:**
+- `server/settings.py` (or equivalent settings module)
+- `server/apps/<core>/utils/feature_flags.py` (new — or extend wherever existing flags live)
+- `server/apps/users/views/user_state.py` (or wherever `/user/me/` is served) — include in serializer
+- Admin test-user state endpoint (same field for parity)
+
+**Tests required to pass before push:**
+- [ ] `test_videos_enabled_default_false` — env var unset → helper returns `False`
+- [ ] `test_videos_enabled_env_true` — env var `"true"` / `"1"` → `True`
+- [ ] `test_videos_enabled_env_false_explicit` — env var `"false"` / `"0"` → `False`
+- [ ] `test_user_state_response_includes_videos_enabled_field` — `/user/me/` JSON has `videos_enabled: bool`
+- [ ] `test_admin_test_user_state_includes_videos_enabled_field` — admin endpoint also includes it
+- [ ] Full backend test suite green (no regressions)
+
+**Manual verification:** none.
+
+---
+
+## PR 2 — SESSIONS map + helpers
+
+**Branch:** `casey/cpv-02-sessions-map`
+**Spec section:** Core design decision 1.
+**Scope:** Add the `SESSIONS` dict and three helpers (`session_of`, `is_first_phase_of_session`, `is_last_phase_of_session`) to `server/enums/coaching_phase.py`. Pure data + functions, no behavior change anywhere else.
+**Files likely touched:**
+- `server/enums/coaching_phase.py`
+- `server/enums/__tests__/test_coaching_phase.py` (new)
+
+**Tests required to pass before push:**
+- [ ] `test_sessions_map_covers_every_coaching_phase_exactly_once` — every `CoachingPhase` value appears in exactly one session's `phases` list
+- [ ] `test_session_of_returns_correct_session` — parametrized over every phase
+- [ ] `test_session_of_raises_for_unknown_phase`
+- [ ] `test_is_first_phase_of_session_true_for_first_phase` — parametrized over every session
+- [ ] `test_is_first_phase_of_session_false_for_non_first_phases` — parametrized
+- [ ] `test_is_last_phase_of_session_true_for_last_phase` — parametrized
+- [ ] `test_is_last_phase_of_session_false_for_non_last_phases` — parametrized
+- [ ] `test_welcome_session_outro_is_none` — asymmetric session sanity
+- [ ] `test_visualization_session_outro_is_none` — asymmetric session sanity
+- [ ] `test_session_keys_all_end_with_underscore_session_suffix` — naming convention guard
+- [ ] Full backend test suite green
+
+**Manual verification:** none.
+
+---
+
+## PR 3 — `CoachState.shown_videos` migration
+
+**Branch:** `casey/cpv-03-shown-videos-migration`
+**Spec section:** Core design decision 3.
+**Scope:** Add `shown_videos = ArrayField(CharField(max_length=255), default=list, blank=True)` to `CoachState`. Migration only — nothing reads or writes it yet.
+**Files likely touched:**
+- `server/apps/<coach>/models/coach_state.py` (or wherever `CoachState` lives)
+- `server/apps/<coach>/migrations/00XX_coach_state_shown_videos.py` (new)
+
+**Tests required to pass before push:**
+- [ ] `python manage.py makemigrations --check --dry-run` returns no pending migrations after the new one is added
+- [ ] `python manage.py migrate` succeeds on a fresh DB
+- [ ] `python manage.py migrate <app> <prev_migration>` rolls back cleanly
+- [ ] `test_coach_state_shown_videos_defaults_to_empty_list` — new instance has `shown_videos == []`
+- [ ] `test_coach_state_shown_videos_accepts_appended_strings` — can append and re-fetch
+- [ ] `test_coach_state_serializer_includes_shown_videos` — exposed via API if the serializer auto-includes fields (verify or pin it explicitly)
+- [ ] Full backend test suite green
+
+**Manual verification:** none.
+
+---
+
+## PR 4 — `Break` model + migration
+
+**Branch:** `casey/cpv-04-break-model`
+**Spec section:** Core design decision 9.
+**Scope:** New `Break` model with `user`, `started_at` (auto_now_add), `ended_at` (nullable), `triggered_by_session` (CharField), `coach_message` (nullable FK). Basic admin registration. Nothing creates rows yet.
+**Files likely touched:**
+- `server/apps/<coach>/models/break.py` (new)
+- `server/apps/<coach>/models/__init__.py` — export
+- `server/apps/<coach>/admin.py` — register
+- `server/apps/<coach>/migrations/00XX_break.py` (new)
+
+**Tests required to pass before push:**
+- [ ] `python manage.py makemigrations --check --dry-run` clean after migration added
+- [ ] `python manage.py migrate` succeeds
+- [ ] Rollback succeeds
+- [ ] `test_break_model_create_with_required_fields` — happy path
+- [ ] `test_break_started_at_auto_set` — `auto_now_add` populates it
+- [ ] `test_break_ended_at_nullable` — can save with `ended_at=None`
+- [ ] `test_break_user_relationship` — FK works in both directions
+- [ ] `test_break_admin_list_view_loads` — basic smoke through Django test client as superuser
+- [ ] Full backend test suite green
+
+**Manual verification:** none.
+
+---
+
+## PR 5 — Video registry + new enum values
+
+**Branch:** `casey/cpv-05-video-registry-enums`
+**Spec section:** Core design decision 4 + "Net surface area" enum rows.
+**Scope:** Add static `SESSION_VIDEOS = {video_key: {"name": ..., "url": ""}}` dict with all 12 keys derivable from the SESSIONS map. URLs blank — populated in PR 20. Add `ACKNOWLEDGE_SESSION_VIDEO`, `START_BREAK`, `END_BREAK` to `ActionType`. Add `SESSION_VIDEO`, `SESSION_BREAK` to `ComponentType`. Add a `get_video(key)` helper.
+**Files likely touched:**
+- `server/apps/<coach>/constants/session_videos.py` (new)
+- `server/enums/action_type.py`
+- `server/enums/component_type.py`
+- `server/apps/core/views/enums.py` (or wherever the enums endpoint is) — verify new values appear
+
+**Tests required to pass before push:**
+- [ ] `test_session_videos_has_intro_entry_for_every_session` — derived from SESSIONS map
+- [ ] `test_session_videos_has_outro_entry_only_for_sessions_with_outro`
+- [ ] `test_get_video_returns_dict_with_name_and_url`
+- [ ] `test_get_video_raises_keyerror_on_unknown_key`
+- [ ] `test_actiontype_has_acknowledge_session_video`
+- [ ] `test_actiontype_has_start_break`
+- [ ] `test_actiontype_has_end_break`
+- [ ] `test_componenttype_has_session_video`
+- [ ] `test_componenttype_has_session_break`
+- [ ] `test_enums_endpoint_response_includes_new_action_types` — `/api/core/enums/` JSON contains them
+- [ ] `test_enums_endpoint_response_includes_new_component_types`
+- [ ] Full backend test suite green
+
+**Manual verification:** none.
+
+---
+
+## PR 6 — `ACKNOWLEDGE_SESSION_VIDEO` handler
+
+**Branch:** `casey/cpv-06-ack-session-video-action`
+**Spec section:** Core design decision 7.
+**Scope:** Action handler that appends a `video_key` to `coach_state.shown_videos`. Idempotent. Param model with `video_key: str`. **Validates `video_key` against the `SESSION_VIDEOS` registry — raises `ValidationError` on unknown key.** Registered in the action handler dispatch table.
+**Files likely touched:**
+- `server/apps/<coach>/handlers/acknowledge_session_video.py` (new)
+- Param model file
+- Handler registry / dispatch table
+- `server/apps/<coach>/handlers/__tests__/test_acknowledge_session_video.py` (new)
+
+**Tests required to pass before push:**
+- [ ] `test_ack_appends_video_key_to_shown_videos`
+- [ ] `test_ack_is_idempotent` — calling twice doesn't duplicate the key
+- [ ] `test_ack_persists_to_db` — re-fetched CoachState reflects the change
+- [ ] `test_ack_raises_validation_error_for_unknown_video_key` — locked in: validate against registry
+- [ ] `test_ack_returns_no_component_config` — does not trigger skip-LLM rule by itself
+- [ ] `test_ack_dispatchable_through_action_handler` — end-to-end via the action handler entrypoint
+- [ ] Full backend test suite green
+
+**Manual verification:** none.
+
+---
+
+## PR 7 — `START_BREAK` handler
+
+**Branch:** `casey/cpv-07-start-break-action`
+**Spec section:** Core design decision 7.
+**Scope:** Creates a `Break` row with `triggered_by_session=session_key, coach_message=<id>` and returns a `SESSION_BREAK` `ComponentConfig` (with the "I'm Ready" button + `END_BREAK()` action baked in). Param model with `session_key: str`. **Hard rule: it must be impossible to start a new break while one is already open. If `Break.objects.filter(user=u, ended_at__isnull=True).exists()`, raise `ValidationError`. No silent reuse, no replace, no overlap.**
+**Files likely touched:**
+- `server/apps/<coach>/handlers/start_break.py` (new)
+- Param model
+- Handler registry
+- `server/apps/<coach>/handlers/__tests__/test_start_break.py` (new)
+
+**Tests required to pass before push:**
+- [ ] `test_start_break_creates_break_row_with_correct_triggered_by_session`
+- [ ] `test_start_break_returns_session_break_component_config` — has the right `component_type`, contains an "I'm Ready" button bound to `END_BREAK()`
+- [ ] `test_start_break_links_break_to_coach_message_when_provided`
+- [ ] `test_start_break_raises_validation_error_when_open_break_exists_for_user` — locked in: no overlap, ever
+- [ ] `test_start_break_allowed_after_previous_break_closed` — once `ended_at` is stamped, a new break can be started
+- [ ] `test_start_break_isolates_per_user` — user A's open break does not block user B from starting one
+- [ ] `test_start_break_raises_for_unknown_session_key` — validate against SESSIONS map
+- [ ] `test_start_break_returned_component_triggers_skip_llm_rule_via_apply_user_component_actions` — integration: confirms PR 10's rule fires when this is the user action
+- [ ] Full backend test suite green
+
+**Manual verification:** none.
+
+**Notes:**
+- The `session_key` is the session **being left**, not the user's current_phase session. Spec is explicit on this.
+
+---
+
+## PR 8 — `END_BREAK` handler (basic close)
+
+**Branch:** `casey/cpv-08-end-break-action`
+**Spec section:** Core design decision 7.
+**Scope:** Zero-param handler that closes the user's single open `Break` (`ended_at__isnull=True`) by stamping `ended_at=now()`. Because PR 7 guarantees at most one open break per user, this can safely use `.get()` (or `.filter().first()` + null-check). **Intro-emission logic is added in PR 14** — this PR keeps the handler scope minimal.
+**Files likely touched:**
+- `server/apps/<coach>/handlers/end_break.py` (new)
+- Handler registry
+- `server/apps/<coach>/handlers/__tests__/test_end_break.py` (new)
+
+**Tests required to pass before push:**
+- [ ] `test_end_break_stamps_ended_at_on_open_break`
+- [ ] `test_end_break_no_op_when_no_open_break` — handle gracefully (no exception)
+- [ ] `test_end_break_only_closes_current_users_break` — isolation between users
+- [ ] `test_end_break_does_not_touch_already_closed_breaks`
+- [ ] `test_end_break_returns_no_component_config_in_this_pr` — locks the split with PR 14
+- [ ] Full backend test suite green
+
+**Manual verification:** none.
+
+---
+
+## PR 9 — `on_break` API field
+
+**Branch:** `casey/cpv-09-on-break-api-field`
+**Spec section:** Core design decision 9.
+**Scope:** Add `on_break: bool` to coach response serializer AND user-state endpoint (regular + admin test-user variants). Derived from `Break.objects.filter(user=u, ended_at__isnull=True).exists()`.
+**Files likely touched:**
+- `server/apps/<coach>/serializers/coach_response.py`
+- `server/apps/<users>/views/user_state.py`
+- Admin test-user state endpoint
+
+**Tests required to pass before push:**
+- [ ] `test_user_state_on_break_false_when_no_break_rows`
+- [ ] `test_user_state_on_break_true_when_open_break_exists`
+- [ ] `test_user_state_on_break_false_when_break_ended_at_set`
+- [ ] `test_coach_response_includes_on_break_field`
+- [ ] `test_admin_test_user_state_includes_on_break_field`
+- [ ] `test_on_break_isolated_per_user` — user A's open break doesn't make user B `on_break`
+- [ ] Full backend test suite green
+
+**Manual verification:** none.
+
+---
+
+## PR 10 — `process_message` null-message contract + skip-LLM-on-component rule
+
+**Branch:** `casey/cpv-10-null-message-contract`
+**Spec section:** "process_message null-message contract" + Skip-LLM rule.
+**Scope:** Two changes:
+1. **Null-message contract.** Accept `message=None` programmatically — no user ChatMessage saved, user actions still apply. `message=""` continues to be treated as a real (empty) user message. Required for the video Continue button which dispatches `{message: null, actions: [...]}`.
+2. **Skip-LLM-on-component rule.** If any user action returned a `component_config`, skip the LLM call this turn. Required for the `START_BREAK` → `SESSION_BREAK` flow and the `END_BREAK` → intro-video flow (added in PR 14).
+
+**No intro-gate clause, no pre/post-LLM injection hooks** — those don't exist in this approach. The handlers in PRs 13 + 14 attach components directly to messages they produce.
+
+**Files likely touched:**
+- `server/apps/<coach>/functions/public/process_message.py`
+- `server/apps/<coach>/serializers/process_message_request.py` — allow `message: Optional[str]`
+- `server/apps/<coach>/__tests__/test_process_message.py`
+
+**Tests required to pass before push:**
+- [ ] `test_message_none_does_not_save_user_chatmessage`
+- [ ] `test_message_none_still_applies_user_actions`
+- [ ] `test_message_empty_string_saves_user_chatmessage_with_empty_content`
+- [ ] `test_message_string_saves_user_chatmessage_with_content`
+- [ ] `test_skip_llm_when_user_action_returns_component_config` — use a mock action that returns a config
+- [ ] `test_llm_called_when_no_component_config_returned`
+- [ ] `test_existing_process_message_flows_unchanged` — regression
+- [ ] Full backend test suite green
+
+**Manual verification:** none.
+
+---
+
+## PR 11 — History serialization + count bump (LLM read shim)
+
+**Branch:** `casey/cpv-11-history-serialization`
+**Spec section:** Core design decision 10.
+**Scope:** Update `get_recent_chat_messages_for_prompt` to render `component_config` as bracketed narrative text using `shown_videos` and the `Break` table as sources of truth. Bump default `count` from 5 to 10. DB rows unchanged — only LLM-facing strings differ.
+**Files likely touched:**
+- `server/apps/<coach>/utils/get_recent_chat_messages_for_prompt.py` (or wherever it lives)
+- Its tests
+
+**Tests required to pass before push:**
+- [ ] `test_acked_session_video_serialized_as_bracketed_watched_text`
+- [ ] `test_unacked_session_video_serialized_as_bracketed_not_watched_text`
+- [ ] `test_closed_break_serialized_as_bracketed_returned_text`
+- [ ] `test_open_break_serialized_as_bracketed_not_returned_text`
+- [ ] `test_normal_text_messages_passed_through_unchanged`
+- [ ] `test_coach_message_with_text_and_component_serialized_with_both` — verifies the new common case (LLM text + outro/intro card in same row)
+- [ ] `test_default_count_is_10` (was 5)
+- [ ] `test_explicit_count_override_still_works`
+- [ ] `test_serialization_uses_video_name_from_registry`
+- [ ] Full backend test suite green
+
+**Manual verification:** none.
+
+---
+
+## PR 12 — Welcome injection (flag-gated)
+
+**Branch:** `casey/cpv-12-welcome-injection`
+**Spec section:** Core design decision 6.A.
+**Scope:** Rewrite `ensure_initial_message_exists` so that when `videos_enabled()` is `True`, it seeds a coach message with `text=""` and a `SESSION_VIDEO(welcome_session_intro)` `component_config`. When flag is `False`, preserve today's behavior (seed `INITIAL_MESSAGE` text). The `INITIAL_MESSAGE` constant stays — it's deleted in PR 24.
+**Files likely touched:**
+- `server/apps/chat_messages/utils/ensure_initial_message_exists.py`
+- Its tests
+
+**Tests required to pass before push:**
+- [ ] `test_flag_off_seeds_initial_message_text_only` (regression)
+- [ ] `test_flag_on_seeds_session_video_welcome_card_with_empty_text`
+- [ ] `test_flag_on_component_config_uses_welcome_session_intro_key`
+- [ ] `test_idempotent_when_initial_message_already_exists` (either branch)
+- [ ] Full backend test suite green
+
+**Manual verification:** with flag off, create a new user — first message is "Hi I'm Leigh-Ann..." as today. With flag on, first message is the welcome video card with empty text.
+
+---
+
+## PR 13 — `transition_phase` handler enrichment — outro/intro auto-emit (flag-gated)
+
+**Branch:** `casey/cpv-13-transition-phase-enrichment`
+**Spec section:** Core design decisions 1 + 6.B/C (revised — handler-driven).
+**Scope:** Modify the existing `transition_phase` action handler. After the phase transition runs, consult the `SESSIONS` map (using `session_of(old_phase)` and `session_of(new_phase)`):
+
+1. **If `is_last_phase_of_session(old_phase)` AND the leaving session has an outro** → attach a `SESSION_VIDEO(outro_key)` component config to the coach message this turn. The Continue button on the outro card carries `[ACK(outro_key), START_BREAK(leaving_session_key)]`.
+2. **Else if `is_first_phase_of_session(new_phase)` AND the entering session has an intro AND that intro is not in `shown_videos`** → attach a `SESSION_VIDEO(intro_key)` component config to the coach message this turn. The Continue button carries `[ACK(intro_key)]`.
+3. **Else** → no component attached. Normal transition.
+
+When the flag is `False`, this enrichment short-circuits — the handler behaves identically to today. The transition itself is unchanged in both branches.
+
+**Implementation note:** the handler ATTACHES the component to the coach message the LLM is producing this turn — it does not create a new message row. This is the existing message-with-component pattern. No multi-message response shape required.
+
+**Files likely touched:**
+- `server/apps/<coach>/handlers/transition_phase.py`
+- `server/apps/<coach>/utils/session_video_injection.py` (new — helpers shared with PR 14)
+- `server/apps/<coach>/handlers/__tests__/test_transition_phase.py`
+
+**Tests required to pass before push:**
+- [ ] `test_transition_phase_attaches_outro_when_leaving_session_has_outro` — parametrized over every session with an outro
+- [ ] `test_transition_phase_outro_button_carries_ack_and_start_break_with_leaving_session_key`
+- [ ] `test_transition_phase_attaches_intro_when_leaving_session_has_no_outro_and_entering_has_intro` — INTRODUCTION → GET_TO_KNOW_YOU case
+- [ ] `test_transition_phase_intro_button_carries_only_ack_with_intro_key`
+- [ ] `test_transition_phase_no_video_for_intra_session_transition` — e.g., GET_TO_KNOW_YOU → IDENTITY_WARMUP
+- [ ] `test_transition_phase_no_intro_when_entering_session_intro_already_in_shown_videos` — idempotency
+- [ ] `test_transition_phase_prefers_outro_over_intro_when_both_would_apply` — locks rule precedence
+- [ ] `test_transition_phase_no_video_when_flag_off` — regression
+- [ ] `test_transition_phase_phase_change_unchanged_in_both_flag_branches` — pure transition behavior preserved
+- [ ] Integration: end-to-end LLM turn with `transition_phase` action → response coach message has both text and component_config
+- [ ] Full backend test suite green
+
+**Manual verification:** with a test user, force the LLM to emit `transition_phase` at a session boundary — expect the LLM's text + the outro card in the same response. Force a transition out of `welcome_session` → expect the LLM's text + the intro card for `get_to_know_session`.
+
+---
+
+## PR 14 — `END_BREAK` handler enrichment — intro auto-emit (flag-gated)
+
+**Branch:** `casey/cpv-14-end-break-enrichment`
+**Spec section:** Core design decisions 1 + 6.B (revised — handler-driven).
+**Scope:** Extend the `END_BREAK` handler (built in PR 8) to also emit the next session's intro video when the user returns from a break.
+
+After stamping `ended_at`:
+1. Look up `session_of(coach_state.current_phase)`.
+2. If `is_first_phase_of_session(current_phase)` AND that session has an intro AND the intro is not in `shown_videos` → return a `SESSION_VIDEO(intro_key)` `ComponentConfig`. The Continue button carries `[ACK(intro_key)]`.
+3. Else → return nothing (basic close, same as PR 8).
+
+This is what makes the post-break intro fire deterministically. The component return triggers PR 10's skip-LLM rule, so the LLM doesn't run this turn — the user must ack the intro first, then the LLM speaks in the new session on the next turn.
+
+When the flag is `False`, this enrichment short-circuits — the handler behaves like PR 8.
+
+**Files likely touched:**
+- `server/apps/<coach>/handlers/end_break.py` — extend
+- `server/apps/<coach>/utils/session_video_injection.py` — shared helpers from PR 13
+- `server/apps/<coach>/handlers/__tests__/test_end_break.py`
+
+**Tests required to pass before push:**
+- [ ] `test_end_break_returns_intro_component_when_current_phase_is_session_first_phase_with_unacked_intro` — parametrized
+- [ ] `test_end_break_intro_button_carries_only_ack_with_intro_key`
+- [ ] `test_end_break_no_intro_when_intro_already_acked` — idempotency
+- [ ] `test_end_break_no_intro_when_current_phase_is_not_first_phase_of_session` — edge case if break ever closes mid-session
+- [ ] `test_end_break_no_intro_when_flag_off` — regression
+- [ ] `test_end_break_still_closes_break_in_both_flag_branches` — core behavior preserved
+- [ ] `test_end_break_returned_component_triggers_skip_llm_rule_via_apply_user_component_actions` — integration with PR 10
+- [ ] Integration: full break-close cycle — user clicks "I'm Ready" → break closes → intro card returned → LLM does not run this turn
+- [ ] Full backend test suite green
+
+**Manual verification:** with a test user mid-break, click "I'm Ready" — expect the intro card for the new session as the next coach message, with no LLM text. ACK it on the following turn → expect the LLM's first message in the new session.
+
+---
+
+## PR 15 — FE: `on_break` composer disable + read shape
+
+**Branch:** `casey/cpv-15-fe-on-break-composer`
+**Spec section:** Core design decision 9 + composer disable rule.
+**Scope:** Frontend reads `on_break: bool` from coach response + user-state endpoint. Composer is disabled when `on_break === true`. **No multi-message response handling needed** — the response shape is unchanged. The unacked-SESSION_VIDEO clause is added in PR 18.
+**Files likely touched:**
+- `client/src/hooks/useUserState.ts` — expose `on_break`
+- `client/src/hooks/useSendMessage.ts` — read `on_break` from response (composer state updates after each turn)
+- `client/src/components/chat/Composer.tsx` — disable on `on_break`
+- Tests for each
+
+**Tests required to pass before push:**
+- [ ] `useUserState exposes on_break`
+- [ ] `Composer is disabled when on_break is true`
+- [ ] `Composer is enabled when on_break is false`
+- [ ] `Composer remains enabled when on_break field is missing` (graceful)
+- [ ] `on_break from coach response updates composer state after a message turn`
+- [ ] Full frontend test suite green
+
+**Manual verification:** toggle `on_break` in test-user state → composer disables / re-enables. Run a full break flow (when the FE work in PRs 17/18 is in place) and confirm composer disables on `START_BREAK` and re-enables on `END_BREAK`.
+
+---
+
+## PR 16 — FE: `SessionVideoCard` + modal shell
+
+**Branch:** `casey/cpv-16-fe-session-video-card`
+**Spec section:** Core design decision 8 (card + modal shell only — no threshold gate, no action dispatch).
+**Scope:** Build the visual shell. New React component for `SESSION_VIDEO`: thin card with video name + `[Watch]` / `[Watch Again]` button (label derives from `shownVideos.includes(video_key)`). Clicking opens a modal containing the `<video>` element. Modal closes on Esc or backdrop click — no actions fire on close. **No Continue button yet, no threshold logic, no action dispatch.** This PR is testable in browser by clicking through Watch → modal opens → modal closes.
+**Files likely touched:**
+- `client/src/components/chat/components/SessionVideoCard.tsx` (new)
+- `client/src/components/chat/components/SessionVideoModal.tsx` (new) — shell only
+- `client/src/components/chat/components/registry.ts` (or wherever components are wired) — register SESSION_VIDEO
+- Tests
+
+**Tests required to pass before push:**
+- [ ] `SessionVideoCard renders video name from registry`
+- [ ] `SessionVideoCard renders Watch button when video_key not in shown_videos`
+- [ ] `SessionVideoCard renders Watch Again button when video_key in shown_videos`
+- [ ] `Card click opens the modal`
+- [ ] `SessionVideoModal renders <video> element with src from registry`
+- [ ] `Esc key closes the modal`
+- [ ] `Backdrop click closes the modal`
+- [ ] `Modal does NOT render a Continue button in this PR` (negative test — locks the split)
+- [ ] `Modal close fires no API action` (negative test)
+- [ ] `SESSION_VIDEO is registered in the component renderer registry`
+- [ ] Full frontend test suite green
+
+**Manual verification:** in `npm run dev:local`, force a SESSION_VIDEO card into chat (dev shortcut or hardcoded mock with a placeholder MP4 URL like Big Buck Bunny). Click Watch → modal opens with video playing → Esc → modal closes, card still showing Watch. Click Watch Again toggle by mocking `shownVideos`.
+
+---
+
+## PR 17 — FE: video modal threshold gate + action dispatch
+
+**Branch:** `casey/cpv-17-fe-session-video-modal-action`
+**Spec section:** Core design decision 8 (threshold-gated Continue) + 7 (action dispatch).
+**Scope:** Add the Continue button to `SessionVideoModal` with threshold-disabled state (20s before end for videos > 30s; 50% for videos ≤ 30s). Wire bundled action dispatch on Continue click (ACK for intros; ACK + START_BREAK for outros, with the `session_key` carried by the card's `component_config`). Esc / backdrop close still fires no action. Watch Again modal still has no Continue button.
+**Files likely touched:**
+- `client/src/components/chat/components/SessionVideoModal.tsx` — add Continue + threshold + dispatch
+- `client/src/hooks/useVideoThreshold.ts` (new) — encapsulate threshold logic
+- `client/src/api/chat.ts` — ensure send-message accepts `{ message: null, actions: [...] }`
+- Tests
+
+**Tests required to pass before push:**
+- [ ] `Continue button rendered for active (unacked) modal`
+- [ ] `Continue button NOT rendered for Watch Again (acked) modal`
+- [ ] `Continue button is disabled at start of video`
+- [ ] `Continue button enables at 20s before end for videos > 30s` — simulate `timeupdate` events
+- [ ] `Continue button enables at 50% for videos ≤ 30s` — simulate
+- [ ] `Continue click for intro video dispatches {message: null, actions: [ACK(video_key)]}`
+- [ ] `Continue click for outro video dispatches {message: null, actions: [ACK(video_key), START_BREAK(session_key)]}` with correct session_key from component_config
+- [ ] `Continue click closes the modal`
+- [ ] `Esc still closes modal without dispatching actions`
+- [ ] `Backdrop click still closes modal without dispatching actions`
+- [ ] `useVideoThreshold returns enabled when threshold reached` — unit test the hook in isolation
+- [ ] `useVideoThreshold returns disabled before threshold` — unit test
+- [ ] Full frontend test suite green
+
+**Manual verification:** in browser with `videos_enabled=true` for a test user and a placeholder MP4 in the registry, walk through: Watch → modal opens → Continue disabled → scrub close to end (or wait) → Continue enables → click → modal closes → confirm API call fired with the correct actions.
+
+---
+
+## PR 18 — FE: `SessionBreakComponent` + unacked-video composer rule
+
+**Branch:** `casey/cpv-18-fe-session-break-composer`
+**Spec section:** Core design decisions 7 + 9 + composer disable rule.
+**Scope:** New React component for `SESSION_BREAK` — renders "I'm Ready" button that dispatches `{message: "I'm ready", actions: [END_BREAK()]}` (canned-response pattern, same as `IntroCannedResponseComponent`). Extend composer-disable hook with the unacked-SESSION_VIDEO clause.
+**Files likely touched:**
+- `client/src/components/chat/components/SessionBreakComponent.tsx` (new)
+- Component registry
+- `client/src/components/chat/Composer.tsx` (extend disable rule)
+- `client/src/hooks/useComposerDisabled.ts` (new or extend) — pin the rule in one place
+- Tests
+
+**Tests required to pass before push:**
+- [ ] `SessionBreakComponent renders I'm Ready button`
+- [ ] `I'm Ready click dispatches {message: "I'm ready", actions: [END_BREAK()]}`
+- [ ] `I'm Ready label becomes a real user ChatMessage` (integration via mock)
+- [ ] `Composer disabled when latest coach message is SESSION_VIDEO and key not in shown_videos`
+- [ ] `Composer enabled when latest SESSION_VIDEO is in shown_videos`
+- [ ] `Composer disabled when on_break is true regardless of latest message type`
+- [ ] `Composer enabled when on_break false and no unacked video card is latest`
+- [ ] `Both rules combine correctly` — truth table coverage
+- [ ] Full frontend test suite green
+
+**Manual verification:** trigger the full break flow in browser — see break card, composer disabled, click I'm Ready, see "I'm ready" appear as user message, composer re-enable after intro card lands.
+
+---
+
+## PR 19 — Rename `dev-coach/videos/` files to match session keys
+
+**Branch:** `casey/cpv-19-rename-video-files`
+**Spec section:** "Sessions & videos" table.
+**Scope:** Pure rename — bring filenames in `dev-coach/videos/` into line with the spec's table (e.g. `01-welcome-session-intro.mov`). No code changes unless something references a filename.
+**Files likely touched:**
+- `dev-coach/videos/*.mov` — rename via `git mv`
+- Any upload script that hard-codes old names
+
+**Tests required to pass before push:**
+- [ ] All 12 files exist at the new paths listed in the spec's "Sessions & videos" table
+- [ ] `grep -r "<old-filename>" --include='*.py' --include='*.ts' --include='*.tsx' --include='*.md' .` returns no hits for any renamed file (excluding this doc + the spec)
+- [ ] Upload script (if any) updated to reference new names
+- [ ] Full backend + frontend test suites green (sanity — should be unaffected)
+
+**Manual verification:** none.
+
+---
+
+## PR 20 — S3 upload + populate registry URLs
+
+**Branch:** `casey/cpv-20-s3-upload-registry-urls`
+**Spec section:** Core design decision 5.
+**Scope:** Upload all 12 video files to the project's S3 bucket (same pattern as user images — match key prefix convention). Populate `SESSION_VIDEOS[video_key]["url"]` with the resulting S3 URL for each entry.
+**Files likely touched:**
+- `server/apps/<coach>/constants/session_videos.py` — fill in URLs
+- Upload script (one-off or committed) under `scripts/` or `aws/`
+
+**Tests required to pass before push:**
+- [ ] All 12 S3 URLs respond `200 OK` to `curl -I` (smoke)
+- [ ] HTTP Range requests work — `curl -r 0-1024 <url>` returns `206 Partial Content`
+- [ ] `test_session_videos_all_urls_non_empty` — backend test enforcing no blanks
+- [ ] `test_session_videos_all_urls_are_https` — guard against accidental http
+- [ ] `test_session_videos_all_urls_unique` — no copy-paste collisions
+- [ ] Full backend test suite green
+
+**Manual verification:** in browser, hit each S3 URL once to confirm playback (or scripted: `ffprobe` each URL).
+
+---
+
+## PR 21 — Docs update — phases, transition-phase, persistent-components, new actions
+
+**Branch:** `casey/cpv-21-docs-update`
+**Spec section:** all of them — this is the doc consolidation.
+**Scope:** Update the dev-coach repo docs (`docs/docs/...`) to describe the new sessions / video / break framework. These docs sync into the Procedures MCP server, so the source of truth is the markdown in this repo. Single consolidated PR — easier to review the framework holistically than scatter doc edits across the implementation PRs.
+
+**Files to edit:**
+- `docs/docs/coach/phases.md` — add a "Sessions" section explaining that phases roll up into sessions via the `SESSIONS` map, and that session boundaries trigger intro/outro videos + breaks. Link to the per-action docs below.
+- `docs/docs/core-systems/action-handler/actions/transition-phase.md` — add a "Session-boundary side effects" section documenting the outro/intro auto-emit rules (PR 13). Include the precedence rule (outro wins over intro when both would apply).
+- `docs/docs/core-systems/component-renderer/persistent-components.md` — add entries for `SESSION_VIDEO` and `SESSION_BREAK`. Document the `SessionVideoCard` deviation from the no-buttons-on-history convention (Watch Again is allowed because it's frontend-only). Document `on_break` composer disable + unacked-video composer disable rules.
+- `docs/docs/core-systems/component-renderer/overview.md` — mention the two new component types in the registry list.
+- `docs/docs/core-systems/action-handler/overview.md` — mention the three new actions.
+
+**Files to create:**
+- `docs/docs/core-systems/action-handler/actions/acknowledge-session-video.md` — param model (`video_key: str`), idempotency, registry validation.
+- `docs/docs/core-systems/action-handler/actions/start-break.md` — param model (`session_key: str`), `Break` row creation, returned component config, one-open-break-per-user invariant.
+- `docs/docs/core-systems/action-handler/actions/end-break.md` — zero-param close + the intro auto-emit side effect (PR 14). Document that this is the post-break intro trigger.
+
+**Tests required to pass before push:**
+- [ ] All edited files pass any project-level markdown lint or link check (if configured)
+- [ ] `grep -rn "SESSION_VIDEO\|SESSION_BREAK\|ACKNOWLEDGE_SESSION_VIDEO\|START_BREAK\|END_BREAK" docs/docs/` returns matches in the expected files (sanity)
+- [ ] Cross-links resolve: every `[link](other-doc.md)` introduced in this PR points to an existing file
+- [ ] If the doc sync to Procedures MCP runs in CI: confirm it succeeds and the new/edited docs appear in `mcp__procedures__browse(doc_type="system", category="dev-coach")` output post-merge
+
+**Manual verification:** read each edited / new doc top-to-bottom. The framework should be derivable from the docs alone — i.e., a new engineer should be able to understand session boundaries, video triggers, and break flow without reading the spec.
+
+**Notes:**
+- This PR carries no code changes. It exists because the feature ships in PR 22 and the docs should describe the shipped behavior, not the prior architecture.
+- The "Add a Session Video" procedure (PR 25) is separate — it lives in the Procedures MCP server, not in the repo.
+
+---
+
+## PR 22 — Flip flag in staging + prod (ops only — no code PR)
+
+**Branch:** none — Render dashboard env-var change only.
+**Spec section:** prerequisite for cleanup PRs.
+**Scope:** Set `COACHING_PHASE_VIDEOS_ENABLED=true` in the staging service environment, smoke test, then set the same in the production service environment, smoke test again. No code changes. No PR — this is a deploy ticket / dashboard change tracked here for sequencing.
+
+**Verification required before marking complete:**
+- [ ] `COACHING_PHASE_VIDEOS_ENABLED=true` set in staging service env vars (verified via Render dashboard or API)
+- [ ] `COACHING_PHASE_VIDEOS_ENABLED=true` set in production service env vars (verified)
+- [ ] Staging smoke (manual):
+  - [ ] Create a new test user → see welcome video card as first message
+  - [ ] Walk through INTRODUCTION → first session boundary → see LLM transition message with intro card attached → ACK → LLM continues in new session
+  - [ ] Walk to first outro boundary → see LLM transition message with outro card attached → ACK → break opens → composer disabled
+  - [ ] Click "I'm Ready" → next session intro appears (no LLM text on that turn) → ACK → LLM continues in new session
+  - [ ] Refresh mid-break → composer correctly remains disabled (via `on_break` on initial user-state load)
+- [ ] Production smoke (manual, with a test account):
+  - [ ] Same walkthrough as staging on a real user account
+  - [ ] Existing pre-flip user chats still render correctly — historical messages don't crash
+- [ ] Monitor error rates / logs for 24h after flip; no anomalies
+
+**Notes:**
+- This is the moment the feature goes live. Coordinate timing with Casey before flipping prod.
+
+---
+
+## PR 23 — Remove flag plumbing
+
+**Branch:** `casey/cpv-23-remove-flag-plumbing`
+**Spec section:** cleanup (not in spec).
+**Scope:** Now that the flag is permanently `true` in all environments, remove the conditional plumbing. Delete the `COACHING_PHASE_VIDEOS_ENABLED` Django setting. Delete the `videos_enabled()` helper. Collapse every `if videos_enabled():` branch to its on-branch (delete the dead off-branch). Remove `videos_enabled: bool` from the user-state endpoint response (frontend no longer needs it). Tests that asserted "flag off → old behavior" are deleted.
+**Files likely touched:**
+- `server/settings.py`
+- `server/apps/<core>/utils/feature_flags.py` — delete the helper
+- `server/apps/users/views/user_state.py` — remove field
+- `server/apps/<coach>/handlers/transition_phase.py` — collapse flag check
+- `server/apps/<coach>/handlers/end_break.py` — collapse flag check
+- `server/apps/chat_messages/utils/ensure_initial_message_exists.py` — collapse to on-branch
+- `server/apps/<coach>/utils/session_video_injection.py` — collapse flag check
+
+**Tests required to pass before push:**
+- [ ] `grep -rn "COACHING_PHASE_VIDEOS_ENABLED" .` returns no hits
+- [ ] `grep -rn "videos_enabled" server/ client/src/` returns no hits
+- [ ] Backend test suite green — all previously-flag-on tests now pass without conditional setup
+- [ ] Frontend test suite green
+- [ ] `test_user_state_response_no_longer_includes_videos_enabled_field` (positive removal test)
+- [ ] Manual smoke in staging — full flow still works identically to PR 22's smoke
+
+**Manual verification:** repeat PR 22's staging smoke walkthrough — behavior must be identical. Confirm no regressions visible in browser dev-tools network tab.
+
+---
+
+## PR 24 — Delete `INITIAL_MESSAGE` constant
+
+**Branch:** `casey/cpv-24-delete-initial-message`
+**Spec section:** "Net surface area" — `ensure_initial_message_exists` rewrite says delete `INITIAL_MESSAGE`.
+**Scope:** Pure dead-code cleanup. The constant has been unreachable since PR 12's on-branch became the only branch in PR 23. Delete the constant, any dead imports referencing it, and any tests that asserted on its content. Keep this PR minimal — one constant, its imports, any tests using it.
+**Files likely touched:**
+- `server/apps/chat_messages/constants.py` — delete `INITIAL_MESSAGE` (and the file entirely if it becomes empty)
+- Any file with `from chat_messages.constants import INITIAL_MESSAGE` — drop the import
+- Any test using `INITIAL_MESSAGE` — delete the test (these only existed to assert the old welcome-text behavior)
+
+**Tests required to pass before push:**
+- [ ] `grep -rn "INITIAL_MESSAGE" server/` returns no hits
+- [ ] Backend test suite green
+- [ ] Frontend test suite green (should be unaffected)
+
+**Manual verification:** none.
+
+---
+
+## PR 25 — Procedure MCP doc: Add a Session Video
+
+**Branch:** none — Procedures MCP `create_document` call.
+**Spec section:** "Reframe" + "Net surface area" — Procedure doc is a first-class deliverable.
+**Scope:** Create a `procedure / dev-coach / coach / add-session-video` document in the Procedures MCP server. NOP-style walkthrough: how Leigh Ann or a developer adds, swaps, or removes a video given the architecture this branch shipped. Must demonstrate that zero code changes are needed for video swaps.
+
+**Verification required before marking complete:**
+- [ ] Doc created via `mcp__procedures__create_document` and retrievable via `mcp__procedures__get_documents` with the returned ID
+- [ ] Doc appears under `mcp__procedures__browse(doc_type="procedure", category="dev-coach", subject="coach")`
+- [ ] **Dry-run the procedure**: pick one existing video (e.g. `brainstorming_session_intro`), follow the doc step-by-step to swap its S3 URL to a test bucket URL, confirm:
+  - [ ] No code changes were required (only registry edit + S3 upload)
+  - [ ] The new video plays end-to-end for a test user
+  - [ ] Roll back by re-running the procedure with the original URL
+- [ ] Doc references the `SESSIONS` map and `SESSION_VIDEOS` registry by absolute path so future readers can find them
+- [ ] Doc explicitly calls out the three-step procedure from the spec: upload to S3, edit `SESSIONS` map intro/outro key (if mapping changes), edit registry entry (`video_key → { name, url }`)
+- [ ] Doc explicitly states "no prompt edits, no migrations, no enum updates, no frontend work" for the common case of swapping a video file
+- [ ] Doc links to the in-repo system docs updated in PR 21 (transition-phase side effects, persistent-components entries, etc.) for the architecture context
+
+**Manual verification:** dry-run as above.
+
+---
+
+## Discoveries
+
+> Append-only log. Add entries with date + your handle + what you found. The next agent should read this top-to-bottom before starting work.
+
+_(empty)_

--- a/notes/coaching-phase-videos-prs.md
+++ b/notes/coaching-phase-videos-prs.md
@@ -1,7 +1,7 @@
 # Coaching Phase Videos — PR Coordination
 
 **Spec:** [`notes/coaching-phase-videos.md`](./coaching-phase-videos.md)
-**Feature flag:** `COACHING_PHASE_VIDEOS_ENABLED` (created in PR 1, flipped in PR 22, removed in PR 23).
+**Feature flag:** `COACHING_PHASE_VIDEOS_ENABLED` (hardcoded boolean in `server/settings/common.py`, **Summer Program pattern**). Created in PR 1, flipped via code change in PR 22, optionally removed in PR 23 (default: keep as kill switch).
 **Owner / coordinator:** Casey
 
 ## Approach (locked in)
@@ -20,6 +20,92 @@ Welcome video is seeded in `ensure_initial_message_exists`. The video Continue b
 - No multi-message coach response shape — components ride along on the existing single-message-with-component pattern.
 - No pre-LLM intro gate or post-LLM outro hook in `process_message` — handlers carry the logic.
 - No `process_message` surgery beyond the null-message contract and skip-LLM-on-component rule (both lightweight).
+
+## Codebase paths reference (verified 2026-05-24)
+
+Treat this as the source of truth. Every `<coach>` / `<core>` / `<users>` placeholder in the PR sections below resolves to one of these. Patterns called out here are what new code mirrors.
+
+**Backend layout**
+- Django settings: `server/settings/common.py` (plus `local.py`, `staging.py`, `production.py`, `test.py`, `previews.py`)
+- API router: `server/apps/api_urls.py` — `DefaultRouter` instances registered here, mounted by `server/urls.py` at `/api/v1/`
+- Test runner: `pytest` via `server/pytest.ini`. Run as `pytest server/` from repo root, or `cd server && pytest`. **Note:** the homeschool-backend Summer Program tests use Django's test runner (`manage.py test ...`) — for dev-coach we follow the local convention and use pytest.
+
+**Apps (`server/apps/<name>/`)**
+- `coach/` — coach orchestration:
+  - `functions/public/process_message.py` (orchestrator)
+  - `utils/` — `apply_coach_response_actions.py`, `apply_user_component_actions.py`, `build_coach_prompt.py`, `build_coach_response_data.py`, `generate_coach_ai_response.py`, `get_recent_chat_messages_for_prompt.py`
+  - `views/coach_view_set.py`, `views/admin_coach_view_set.py`
+  - `serializers/coach_request_serializer.py`, `serializers/coach_response_serializer.py`, `serializers/admin_coach_request_serializer.py`
+- `coach_states/` — `CoachState` model (`models/coach_state.py`), `admin/coach_state_admin.py`, `serializers/coach_state_serializer.py`, `migrations/`. **New `Break` model and `SESSION_VIDEOS` registry live in this app** (next to CoachState).
+- `chat_messages/` — `ChatMessage` model (`models/chat_message.py`, includes `component_config` JSONField), `INITIAL_MESSAGE` constant at `constants/initial_messages.py`, `utils/ensure_initial_message_exists.py`, `utils/add_chat_message.py`
+- `users/` — `UserViewSet` at `views/user_viewset.py` serves `/api/v1/user/me/*` (actions: `me`, `complete`, `coach-state`, …). `AdminTestUserViewSet` at `views/test_user_viewset.py` serves `/api/v1/admin/test-user/{pk}/*`. Serializers: `serializers/user_serializer.py` (full nested), `serializers/user_profile_serializer.py` (profile only)
+- `core/` — `CoreViewSet` registered as `r"core"` in `api_urls.py`. **No `functions/` directory exists yet — PR 1 creates `apps/core/functions/__init__.py` and `apps/core/functions/public/__init__.py`.**
+- `actions/` — `Action` model (audit log of action invocations). Action handlers themselves live in `services/action_handler/` (see below).
+- `prompts/`, `identities/`, `reference_images/`, `test_scenario/`, `user_notes/`, `authentication/` — out of scope for this feature
+
+**Services (`server/services/<name>/`)**
+- `action_handler/` — all action handlers + dispatch:
+  - State-mutation actions: `actions/<name>.py` (e.g., `transition_phase.py`, `accept_identity.py`, `create_identity.py`)
+  - Component-returning actions: `actions/components/show_*.py`
+  - Persistent-component-returning actions: `actions/persistent_components/persist_*.py`
+  - Sentinel actions (not Action-logged): `actions/sentinel/*.py`
+  - Param models (single file — append to it): `models/params.py`
+  - Action handler dispatch + `ACTION_REGISTRY`: `handler.py`
+  - Export aggregator: `actions/__init__.py`
+  - Tests: `tests/test_*_action.py` (`test_transition_phase_action.py` exists — mirror its structure)
+- `logger/`, `image_generation/` — out of scope
+
+**Enums (`server/enums/`)**
+- `action_type.py`, `component_type.py`, `coaching_phase.py`, `message_role.py`, `ai.py`, `identity_state.py`, `prompt_type.py`, `context_keys.py`, `identity_category.py`, `get_to_know_you_questions.py`
+
+**Top-level models (`server/models/`)**
+- `CoachChatResponse.py` — pydantic schema for the LLM's structured response. **New actions get added as optional fields here** so the LLM can emit them.
+- `SentinelChatResponse.py` — similar for sentinel responses
+- `components/ComponentConfig.py` — `ComponentConfig`, `ComponentButton`, `ComponentAction`, `ComponentIdentity` (mirror these when building new components)
+
+**Action handler contract (mirror this exactly for new actions):**
+```python
+# services/action_handler/actions/<name>.py
+def my_action(
+    coach_state: CoachState,
+    params: MyActionParams,
+    coach_message: ChatMessage,
+) -> Optional[ComponentConfig]:
+    # 1. Mutate state on coach_state (call .save() if needed)
+    # 2. Optionally build a ComponentConfig and return it (skip-LLM rule fires if so)
+    # 3. Log to Action.objects.create(user=..., action_type=ActionType.<NAME>.value, parameters=params.model_dump(), result_summary=..., coach_message=coach_message)
+    return component_config_or_None
+```
+
+**To register a new action, edit all 5 of these:**
+1. `enums/action_type.py` — add the enum value
+2. `services/action_handler/models/params.py` — append a `<Name>Params` pydantic class
+3. `services/action_handler/actions/<name>.py` — implement the handler
+4. `services/action_handler/actions/__init__.py` — add the import/export
+5. `services/action_handler/handler.py` — add to `ACTION_REGISTRY` dict
+6. `models/CoachChatResponse.py` — add an optional field so the LLM can emit it (only for LLM-callable actions; the three new video/break actions are user-button-only, so this step is **skipped** for them — they never appear in `CoachChatResponse`)
+
+**To register a new component type:**
+1. `enums/component_type.py` — add the enum value
+2. `client/src/enums/componentType.ts` — mirror on the frontend
+3. `client/src/pages/chat/components/coach-message-with-component/<Name>Component.tsx` — implement (mirror `IntroCannedResponseComponent.tsx`)
+4. `client/src/pages/chat/components/coach-message-with-component/CoachMessageWithComponent.tsx` — add a `case` arm in the switch
+
+**Coach response shape note:** the `on_break: bool` field is built into the response by `apps/coach/utils/build_coach_response_data.py` (call site that constructs the dict), **and** declared in `apps/coach/serializers/coach_response_serializer.py` (the DRF serializer). Both touchpoints are required.
+
+**Skip-LLM rule wiring:** `apply_user_component_actions` lives in `apps/coach/utils/apply_user_component_actions.py` but the skip-LLM check happens in the orchestrator `apps/coach/functions/public/process_message.py` — modify the orchestrator to check whether the user-action call returned a `ComponentConfig`, and skip the `generate_coach_ai_response` call if so.
+
+**Frontend layout (`client/src/`)**
+- API clients: `api/*.ts` (camelCase — `coach.ts`, `user.ts`, `auth.ts`, …)
+- Hooks: `hooks/use-*.ts` (kebab-case — `use-coach-state.ts`, `use-chat-messages.ts`, `use-profile.ts`)
+- Chat page entry: `pages/chat/Chat.tsx`
+- Chat children: `pages/chat/components/*.tsx` (`ChatInterface.tsx`, `ChatControls.tsx`, `ChatMessages.tsx`, `CoachMessage.tsx`, `UserMessage.tsx`)
+- Component renderer (the registry): `pages/chat/components/coach-message-with-component/CoachMessageWithComponent.tsx` — a switch statement on `component_type`. Adding a new component type means adding a `case` arm here AND a sibling component file.
+- Existing component implementations to mirror: `IntroCannedResponseComponent.tsx`, `CombineIdentitiesConfirmation.tsx`, `IAmStatementsSummaryComponent.tsx` (all in the same dir)
+- Enum types: `enums/componentType.ts`, `enums/actionType.ts`, `enums/coachingPhase.ts`, …
+- TS type definitions: `types/componentConfig.ts`, `types/coachRequest.ts`, …
+- Test runner: `vitest` — `cd client && npm test` (which is `vitest run`). Test files are `*.test.tsx` colocated under `__tests__/` directories.
+- **Composer / message input location:** not 100% confirmed at audit time. The composer-disable wiring goes wherever the chat input lives — likely `pages/chat/components/ChatControls.tsx` or `ChatInterface.tsx`. PR 15's first step is to identify the exact file and add the disable rule there.
 
 ## Workflow rules (strict)
 
@@ -73,8 +159,8 @@ Welcome video is seeded in `ensure_initial_message_exists`. The video Continue b
 | 19  | Rename `dev-coach/videos/` files to match session keys                      | `casey/cpv-19-rename-video-files`            | `[ ]`  | —     | —   | — |
 | 20  | S3 upload + populate registry URLs                                          | `casey/cpv-20-s3-upload-registry-urls`       | `[ ]`  | —     | —   | 5, 19 |
 | 21  | Docs update — phases, transition-phase, persistent-components, new actions  | `casey/cpv-21-docs-update`                   | `[ ]`  | —     | —   | 2, 5, 6, 7, 8, 13, 14 |
-| 22  | Flip flag in staging + prod (no code — ops change)                          | n/a — Render dashboard env var               | `[ ]`  | —     | —   | 12–14, 18, 20, 21 |
-| 23  | Remove flag plumbing                                                        | `casey/cpv-23-remove-flag-plumbing`          | `[ ]`  | —     | —   | 22 |
+| 22  | Flip flag to `True` (one-line code change)                                  | `casey/cpv-22-flip-flag`                     | `[ ]`  | —     | —   | 12–14, 18, 20, 21 |
+| 23  | Remove flag plumbing (OPTIONAL — default skip)                              | `casey/cpv-23-remove-flag-plumbing`          | `[ ]`  | —     | —   | 22 |
 | 24  | Delete `INITIAL_MESSAGE` constant                                           | `casey/cpv-24-delete-initial-message`        | `[ ]`  | —     | —   | 23 |
 | 25  | Procedure MCP doc — Add a Session Video                                     | n/a — Procedures MCP `create_document`       | `[ ]`  | —     | —   | 24 |
 
@@ -99,22 +185,110 @@ Every code PR must satisfy these before push:
 ## PR 1 — Feature flag scaffold
 
 **Branch:** `casey/cpv-01-feature-flag`
-**Scope:** Add `COACHING_PHASE_VIDEOS_ENABLED` Django setting (env-driven, default `False`), a `videos_enabled()` helper, and expose the flag as `videos_enabled: bool` on the user-state endpoint so frontend can branch on it.
-**Files likely touched:**
-- `server/settings.py` (or equivalent settings module)
-- `server/apps/<core>/utils/feature_flags.py` (new — or extend wherever existing flags live)
-- `server/apps/users/views/user_state.py` (or wherever `/user/me/` is served) — include in serializer
-- Admin test-user state endpoint (same field for parity)
+**Pattern reference:** Copy the **Summer Program flag pattern** from `AlphaAnywhere/homeschool-backend` verbatim. Specifically:
+- `homeschool-backend/server/settings/common.py:707` (hardcoded boolean + comment)
+- `homeschool-backend/server/apps/core/functions/public/get_summer_program.py` (TypedDict + helper)
+- `homeschool-backend/server/apps/core/views/summer_program_view_set.py` (public ViewSet)
+- `homeschool-backend/server/apps/core/tests/test_get_summer_program.py` (helper tests)
+- `homeschool-backend/server/apps/core/tests/test_summer_program_endpoint.py` (endpoint tests)
 
-**Tests required to pass before push:**
-- [ ] `test_videos_enabled_default_false` — env var unset → helper returns `False`
-- [ ] `test_videos_enabled_env_true` — env var `"true"` / `"1"` → `True`
-- [ ] `test_videos_enabled_env_false_explicit` — env var `"false"` / `"0"` → `False`
-- [ ] `test_user_state_response_includes_videos_enabled_field` — `/user/me/` JSON has `videos_enabled: bool`
-- [ ] `test_admin_test_user_state_includes_videos_enabled_field` — admin endpoint also includes it
+**Scope:** Add a `COACHING_PHASE_VIDEOS_ENABLED` flag as a **hardcoded boolean** in `server/settings/common.py` (not env-driven — flip via code change + deploy). Add a `get_coaching_phase_videos()` helper returning a TypedDict config. Expose it on a public ViewSet at `GET /api/v1/core/public/coaching-phase-videos/`. The endpoint always returns the full shape; `enabled` is the only field for now (shape can grow later if we expose tunables like the video Continue threshold).
+
+**Files to create / touch:**
+- `server/settings/common.py` — add the constant with a comment explaining the deploy-to-flip convention (mirror the wording from `common.py:703-706` in homeschool-backend)
+- `server/apps/core/functions/__init__.py` — create directory + re-export `get_coaching_phase_videos`
+- `server/apps/core/functions/public/__init__.py` — re-export
+- `server/apps/core/functions/public/get_coaching_phase_videos.py` — new (mirror `get_summer_program.py`)
+- `server/apps/core/views/__init__.py` — add export of the new ViewSet
+- `server/apps/core/views/coaching_phase_videos_view_set.py` — new (mirror `summer_program_view_set.py`)
+- `server/apps/api_urls.py` — register the new ViewSet on one of the existing routers (probably a new `public_router` since this is `AllowAny`, OR register directly on `default_router` with the path `r"core/public/coaching-phase-videos"`). Match the homeschool-backend convention: `router.register(r"core/public/coaching-phase-videos", CoachingPhaseVideosViewSet, basename="coaching-phase-videos")`. Mount the router in `urlpatterns` in the same file.
+- `server/apps/core/tests/test_get_coaching_phase_videos.py` — new (mirror `test_get_summer_program.py`)
+- `server/apps/core/tests/test_coaching_phase_videos_endpoint.py` — new (mirror `test_summer_program_endpoint.py`). **Use pytest** (dev-coach convention), not Django's test runner.
+
+**Code skeleton** (copy-this-shape, change names):
+
+```python
+# server/settings/common.py
+# -------------------------------------------------------------------------
+# Coaching Phase Videos feature flag
+# -------------------------------------------------------------------------
+# Exposed to the frontend via GET /api/v1/core/public/coaching-phase-videos/
+# so the UI can decide whether to expect / render video and break components.
+#
+# COACHING_PHASE_VIDEOS_ENABLED is the feature flag — flip it to control
+# visibility without an env-var change. Flipping is a code change + deploy.
+COACHING_PHASE_VIDEOS_ENABLED = False
+```
+
+```python
+# server/apps/core/functions/public/get_coaching_phase_videos.py
+from typing import TypedDict
+from django.conf import settings
+
+
+class CoachingPhaseVideosConfig(TypedDict):
+    enabled: bool
+
+
+def get_coaching_phase_videos() -> CoachingPhaseVideosConfig:
+    """
+    Return the Coaching Phase Videos config as a JSON-serializable dict.
+
+    Always returns the full shape regardless of whether the feature is
+    enabled — the frontend / backend decide what to render based on `enabled`.
+    """
+    return {
+        "enabled": settings.COACHING_PHASE_VIDEOS_ENABLED,
+    }
+```
+
+```python
+# server/apps/core/views/coaching_phase_videos_view_set.py
+import logging
+from rest_framework import status, viewsets
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+from apps.core.functions import get_coaching_phase_videos
+
+log = logging.getLogger(__name__)
+
+
+class CoachingPhaseVideosViewSet(viewsets.GenericViewSet):
+    """
+    Public Coaching Phase Videos config.
+
+    Endpoints:
+        GET /api/v1/core/public/coaching-phase-videos/ → list()
+    """
+
+    permission_classes = [AllowAny]
+
+    def list(self, request: Request) -> Response:
+        return Response(get_coaching_phase_videos(), status=status.HTTP_200_OK)
+```
+
+**Backend gating convention going forward (other PRs):** check the flag with `from django.conf import settings` and read `settings.COACHING_PHASE_VIDEOS_ENABLED` directly in app code (handlers, `ensure_initial_message_exists`, etc.). The helper function is for the endpoint contract; in-code gates use the setting directly. No `videos_enabled()` wrapper helper.
+
+**Tests required to pass before push** (mirror Summer Program tests one-for-one):
+- [ ] `test_get_coaching_phase_videos_returns_full_shape` — result keys == `{"enabled"}`
+- [ ] `test_get_coaching_phase_videos_reflects_enabled_true` — `@override_settings(COACHING_PHASE_VIDEOS_ENABLED=True)` → `enabled` is `True`
+- [ ] `test_get_coaching_phase_videos_reflects_enabled_false` — `@override_settings(COACHING_PHASE_VIDEOS_ENABLED=False)` → `enabled` is `False`
+- [ ] `test_get_coaching_phase_videos_returns_full_shape_even_when_disabled` — shape doesn't shrink based on flag
+- [ ] `test_endpoint_returns_200` — `GET /api/v1/core/public/coaching-phase-videos/` returns 200
+- [ ] `test_endpoint_accessible_without_authentication` — `self.client.logout()` then GET still returns 200 (matches `AllowAny`)
+- [ ] `test_endpoint_response_has_expected_keys` — `set(response.data.keys()) == {"enabled"}`
+- [ ] `test_endpoint_reflects_enabled_flag_when_on` — `@override_settings(COACHING_PHASE_VIDEOS_ENABLED=True)` → response `enabled` True
+- [ ] `test_endpoint_reflects_enabled_flag_when_off` — `@override_settings(COACHING_PHASE_VIDEOS_ENABLED=False)` → response `enabled` False, full shape still returned
+- [ ] `test_endpoint_post_not_allowed` — POST returns 405 (read-only)
 - [ ] Full backend test suite green (no regressions)
 
-**Manual verification:** none.
+**Manual verification:** `curl http://localhost:8000/api/v1/core/public/coaching-phase-videos/` returns `{"enabled": false}` without auth.
+
+**Notes:**
+- **Not env-driven.** The Summer Program flag is hardcoded; we follow that. No `os.environ.get(...)`, no `.env` line, no Render dashboard env var. Flipping the flag in PR 22 is a one-line code change + merge.
+- **No frontend hook in this PR.** Backend handlers gate their own behavior on `settings.COACHING_PHASE_VIDEOS_ENABLED`, so when the flag is off the frontend never sees video/break components and renders normally. A frontend hook can be added later if there's a use case (e.g., showing a "video feature available" banner outside chat) — none today.
+- **No removal planned in PR 23 by default.** Summer Program does not remove its flag plumbing; it's kept as a kill switch. We follow the same pattern (see PR 23 notes for the trade-off).
 
 ---
 
@@ -150,8 +324,9 @@ Every code PR must satisfy these before push:
 **Spec section:** Core design decision 3.
 **Scope:** Add `shown_videos = ArrayField(CharField(max_length=255), default=list, blank=True)` to `CoachState`. Migration only — nothing reads or writes it yet.
 **Files likely touched:**
-- `server/apps/<coach>/models/coach_state.py` (or wherever `CoachState` lives)
-- `server/apps/<coach>/migrations/00XX_coach_state_shown_videos.py` (new)
+- `server/apps/coach_states/models/coach_state.py` — add the field
+- `server/apps/coach_states/serializers/coach_state_serializer.py` — verify the field appears in the serializer (pin explicitly if `fields = "__all__"` isn't in use)
+- `server/apps/coach_states/migrations/00XX_coach_state_shown_videos.py` — generated via `python manage.py makemigrations coach_states`
 
 **Tests required to pass before push:**
 - [ ] `python manage.py makemigrations --check --dry-run` returns no pending migrations after the new one is added
@@ -170,12 +345,13 @@ Every code PR must satisfy these before push:
 
 **Branch:** `casey/cpv-04-break-model`
 **Spec section:** Core design decision 9.
-**Scope:** New `Break` model with `user`, `started_at` (auto_now_add), `ended_at` (nullable), `triggered_by_session` (CharField), `coach_message` (nullable FK). Basic admin registration. Nothing creates rows yet.
+**Scope:** New `Break` model with `user`, `started_at` (auto_now_add), `ended_at` (nullable), `triggered_by_session` (CharField), `coach_message` (nullable FK). Basic admin registration. Nothing creates rows yet. **App ownership decided: `Break` lives in the `coach_states` app** — it's a piece of coaching session state, lives next to `CoachState`, and shares migrations/admin conventions.
 **Files likely touched:**
-- `server/apps/<coach>/models/break.py` (new)
-- `server/apps/<coach>/models/__init__.py` — export
-- `server/apps/<coach>/admin.py` — register
-- `server/apps/<coach>/migrations/00XX_break.py` (new)
+- `server/apps/coach_states/models/break.py` — new model file
+- `server/apps/coach_states/models/__init__.py` — export `Break`
+- `server/apps/coach_states/admin/break_admin.py` — new admin file (mirror `coach_state_admin.py`)
+- `server/apps/coach_states/admin/__init__.py` — register the new admin
+- `server/apps/coach_states/migrations/00XX_break.py` — generated via `python manage.py makemigrations coach_states`
 
 **Tests required to pass before push:**
 - [ ] `python manage.py makemigrations --check --dry-run` clean after migration added
@@ -198,10 +374,13 @@ Every code PR must satisfy these before push:
 **Spec section:** Core design decision 4 + "Net surface area" enum rows.
 **Scope:** Add static `SESSION_VIDEOS = {video_key: {"name": ..., "url": ""}}` dict with all 12 keys derivable from the SESSIONS map. URLs blank — populated in PR 20. Add `ACKNOWLEDGE_SESSION_VIDEO`, `START_BREAK`, `END_BREAK` to `ActionType`. Add `SESSION_VIDEO`, `SESSION_BREAK` to `ComponentType`. Add a `get_video(key)` helper.
 **Files likely touched:**
-- `server/apps/<coach>/constants/session_videos.py` (new)
-- `server/enums/action_type.py`
-- `server/enums/component_type.py`
-- `server/apps/core/views/enums.py` (or wherever the enums endpoint is) — verify new values appear
+- `server/apps/coach_states/constants/__init__.py` (new directory + file)
+- `server/apps/coach_states/constants/session_videos.py` (new) — registry + `get_video(key)` helper. **Locating the registry in `coach_states` keeps it next to the `shown_videos` field and the `Break` model.**
+- `server/enums/action_type.py` — add `ACKNOWLEDGE_SESSION_VIDEO`, `START_BREAK`, `END_BREAK`
+- `server/enums/component_type.py` — add `SESSION_VIDEO`, `SESSION_BREAK`
+- `client/src/enums/actionType.ts` — mirror the three new action types (the frontend uses these when constructing `ComponentAction` objects on button clicks)
+- `client/src/enums/componentType.ts` — mirror the two new component types
+- `server/apps/core/views/core_view_set.py` (or wherever `CoreViewSet` lives — confirm via `apps/core/views/__init__.py`) — if there's an `/enums` endpoint exposing enum values, verify the new ones appear. If no such endpoint exists, skip this bullet.
 
 **Tests required to pass before push:**
 - [ ] `test_session_videos_has_intro_entry_for_every_session` — derived from SESSIONS map
@@ -225,12 +404,13 @@ Every code PR must satisfy these before push:
 
 **Branch:** `casey/cpv-06-ack-session-video-action`
 **Spec section:** Core design decision 7.
-**Scope:** Action handler that appends a `video_key` to `coach_state.shown_videos`. Idempotent. Param model with `video_key: str`. **Validates `video_key` against the `SESSION_VIDEOS` registry — raises `ValidationError` on unknown key.** Registered in the action handler dispatch table.
+**Scope:** Action handler that appends a `video_key` to `coach_state.shown_videos`. Idempotent. Param model with `video_key: str`. **Validates `video_key` against the `SESSION_VIDEOS` registry — raises `ValidationError` on unknown key.** Registered in the action handler dispatch table. Note: this is a **user-button-only action** — it does NOT appear in `models/CoachChatResponse.py` (the LLM cannot emit it).
 **Files likely touched:**
-- `server/apps/<coach>/handlers/acknowledge_session_video.py` (new)
-- Param model file
-- Handler registry / dispatch table
-- `server/apps/<coach>/handlers/__tests__/test_acknowledge_session_video.py` (new)
+- `server/services/action_handler/actions/acknowledge_session_video.py` — new handler (mirror `transition_phase.py` for the signature + Action logging)
+- `server/services/action_handler/models/params.py` — append `AcknowledgeSessionVideoParams(BaseModel)` with `video_key: str`
+- `server/services/action_handler/actions/__init__.py` — export
+- `server/services/action_handler/handler.py` — add to `ACTION_REGISTRY`
+- `server/services/action_handler/tests/test_acknowledge_session_video_action.py` — new (mirror `test_transition_phase_action.py`)
 
 **Tests required to pass before push:**
 - [ ] `test_ack_appends_video_key_to_shown_videos`
@@ -249,12 +429,13 @@ Every code PR must satisfy these before push:
 
 **Branch:** `casey/cpv-07-start-break-action`
 **Spec section:** Core design decision 7.
-**Scope:** Creates a `Break` row with `triggered_by_session=session_key, coach_message=<id>` and returns a `SESSION_BREAK` `ComponentConfig` (with the "I'm Ready" button + `END_BREAK()` action baked in). Param model with `session_key: str`. **Hard rule: it must be impossible to start a new break while one is already open. If `Break.objects.filter(user=u, ended_at__isnull=True).exists()`, raise `ValidationError`. No silent reuse, no replace, no overlap.**
+**Scope:** Creates a `Break` row with `triggered_by_session=session_key, coach_message=<id>` and returns a `SESSION_BREAK` `ComponentConfig` (with the "I'm Ready" button + `END_BREAK()` action baked in). Param model with `session_key: str`. **Hard rule: it must be impossible to start a new break while one is already open. If `Break.objects.filter(user=u, ended_at__isnull=True).exists()`, raise `ValidationError`. No silent reuse, no replace, no overlap.** User-button-only action — not added to `CoachChatResponse`.
 **Files likely touched:**
-- `server/apps/<coach>/handlers/start_break.py` (new)
-- Param model
-- Handler registry
-- `server/apps/<coach>/handlers/__tests__/test_start_break.py` (new)
+- `server/services/action_handler/actions/persistent_components/start_break.py` — new handler. **Place in the `persistent_components/` subdir** because it returns a `ComponentConfig` (mirror `persist_combine_identities.py` for structure).
+- `server/services/action_handler/models/params.py` — append `StartBreakParams(BaseModel)` with `session_key: str`
+- `server/services/action_handler/actions/__init__.py` — export
+- `server/services/action_handler/handler.py` — add to `ACTION_REGISTRY`
+- `server/services/action_handler/tests/test_start_break_action.py` — new
 
 **Tests required to pass before push:**
 - [ ] `test_start_break_creates_break_row_with_correct_triggered_by_session`
@@ -278,11 +459,13 @@ Every code PR must satisfy these before push:
 
 **Branch:** `casey/cpv-08-end-break-action`
 **Spec section:** Core design decision 7.
-**Scope:** Zero-param handler that closes the user's single open `Break` (`ended_at__isnull=True`) by stamping `ended_at=now()`. Because PR 7 guarantees at most one open break per user, this can safely use `.get()` (or `.filter().first()` + null-check). **Intro-emission logic is added in PR 14** — this PR keeps the handler scope minimal.
+**Scope:** Zero-param handler that closes the user's single open `Break` (`ended_at__isnull=True`) by stamping `ended_at=now()`. Because PR 7 guarantees at most one open break per user, this can safely use `.get()` (or `.filter().first()` + null-check). **Intro-emission logic is added in PR 14** — this PR keeps the handler scope minimal. User-button-only action — not added to `CoachChatResponse`.
 **Files likely touched:**
-- `server/apps/<coach>/handlers/end_break.py` (new)
-- Handler registry
-- `server/apps/<coach>/handlers/__tests__/test_end_break.py` (new)
+- `server/services/action_handler/actions/end_break.py` — new handler. **Place at the `actions/` top level (not under `persistent_components/`)** because in this PR it returns `None`. PR 14 will extend it to optionally return a `ComponentConfig` — at that point either leave it in place or move it to `persistent_components/` (your call when you do PR 14). Mirror `transition_phase.py` for shape.
+- `server/services/action_handler/models/params.py` — append `EndBreakParams(BaseModel)` (zero fields, but the param class must exist for the dispatcher pattern)
+- `server/services/action_handler/actions/__init__.py` — export
+- `server/services/action_handler/handler.py` — add to `ACTION_REGISTRY`
+- `server/services/action_handler/tests/test_end_break_action.py` — new
 
 **Tests required to pass before push:**
 - [ ] `test_end_break_stamps_ended_at_on_open_break`
@@ -302,9 +485,10 @@ Every code PR must satisfy these before push:
 **Spec section:** Core design decision 9.
 **Scope:** Add `on_break: bool` to coach response serializer AND user-state endpoint (regular + admin test-user variants). Derived from `Break.objects.filter(user=u, ended_at__isnull=True).exists()`.
 **Files likely touched:**
-- `server/apps/<coach>/serializers/coach_response.py`
-- `server/apps/<users>/views/user_state.py`
-- Admin test-user state endpoint
+- `server/apps/coach/serializers/coach_response_serializer.py` — add `on_break = serializers.BooleanField(...)`
+- `server/apps/coach/utils/build_coach_response_data.py` — include `on_break` in the returned dict (this is the actual call site; the serializer just validates the shape)
+- `server/apps/users/views/user_viewset.py` — `me`, `complete`, and `coach-state` actions all expose user state. Add `on_break` to at least the `coach-state` and `complete` responses (the frontend reads it on initial chat load). Update `CoachStateSerializer` (`apps/coach_states/serializers/coach_state_serializer.py`) and/or `UserSerializer` (`apps/users/serializers/user_serializer.py`) accordingly — pick whichever already aggregates derived fields.
+- `server/apps/users/views/test_user_viewset.py` — `AdminTestUserViewSet` mirror of the above for admin parity (`/api/v1/admin/test-user/{pk}/coach-state` and `/complete`)
 
 **Tests required to pass before push:**
 - [ ] `test_user_state_on_break_false_when_no_break_rows`
@@ -330,9 +514,10 @@ Every code PR must satisfy these before push:
 **No intro-gate clause, no pre/post-LLM injection hooks** — those don't exist in this approach. The handlers in PRs 13 + 14 attach components directly to messages they produce.
 
 **Files likely touched:**
-- `server/apps/<coach>/functions/public/process_message.py`
-- `server/apps/<coach>/serializers/process_message_request.py` — allow `message: Optional[str]`
-- `server/apps/<coach>/__tests__/test_process_message.py`
+- `server/apps/coach/functions/public/process_message.py` — orchestrator. Today it always calls `add_chat_message(user, message, MessageRole.USER)` and `generate_coach_ai_response`. Change: (a) skip the user-message save when `message is None`, (b) capture the return of `apply_user_component_actions` and skip `generate_coach_ai_response` if it returned a `ComponentConfig`. **Note:** `apply_user_component_actions` currently has no return path for ComponentConfig — modify `server/apps/coach/utils/apply_user_component_actions.py` to return `Optional[ComponentConfig]` (mirror the return contract of `apply_coach_response_actions`).
+- `server/apps/coach/utils/apply_user_component_actions.py` — add return value plumbing
+- `server/apps/coach/serializers/coach_request_serializer.py` — change `message` field to `Optional[str]` / `allow_null=True`
+- `server/apps/coach/tests/test_process_message.py` — new or extended (check existing test layout under `apps/coach/tests/`)
 
 **Tests required to pass before push:**
 - [ ] `test_message_none_does_not_save_user_chatmessage`
@@ -354,8 +539,8 @@ Every code PR must satisfy these before push:
 **Spec section:** Core design decision 10.
 **Scope:** Update `get_recent_chat_messages_for_prompt` to render `component_config` as bracketed narrative text using `shown_videos` and the `Break` table as sources of truth. Bump default `count` from 5 to 10. DB rows unchanged — only LLM-facing strings differ.
 **Files likely touched:**
-- `server/apps/<coach>/utils/get_recent_chat_messages_for_prompt.py` (or wherever it lives)
-- Its tests
+- `server/apps/coach/utils/get_recent_chat_messages_for_prompt.py` — modify the serialization
+- `server/apps/coach/tests/test_get_recent_chat_messages_for_prompt.py` — new or extended (verify existing test location first)
 
 **Tests required to pass before push:**
 - [ ] `test_acked_session_video_serialized_as_bracketed_watched_text`
@@ -377,10 +562,10 @@ Every code PR must satisfy these before push:
 
 **Branch:** `casey/cpv-12-welcome-injection`
 **Spec section:** Core design decision 6.A.
-**Scope:** Rewrite `ensure_initial_message_exists` so that when `videos_enabled()` is `True`, it seeds a coach message with `text=""` and a `SESSION_VIDEO(welcome_session_intro)` `component_config`. When flag is `False`, preserve today's behavior (seed `INITIAL_MESSAGE` text). The `INITIAL_MESSAGE` constant stays — it's deleted in PR 24.
+**Scope:** Rewrite `ensure_initial_message_exists` so that when `settings.COACHING_PHASE_VIDEOS_ENABLED` is `True`, it seeds a coach message with `text=""` and a `SESSION_VIDEO(welcome_session_intro)` `component_config`. When flag is `False`, preserve today's behavior (seed `INITIAL_MESSAGE` text from `apps/chat_messages/constants/initial_messages.py`). Check the flag with `from django.conf import settings` — direct setting access, no wrapper helper. The `INITIAL_MESSAGE` constant stays — it's deleted in PR 24.
 **Files likely touched:**
-- `server/apps/chat_messages/utils/ensure_initial_message_exists.py`
-- Its tests
+- `server/apps/chat_messages/utils/ensure_initial_message_exists.py` — the file to modify
+- `server/apps/chat_messages/tests/test_ensure_initial_message_exists.py` — new or extended (verify existing test location first; `apps/chat_messages/tests/` should exist)
 
 **Tests required to pass before push:**
 - [ ] `test_flag_off_seeds_initial_message_text_only` (regression)
@@ -403,14 +588,14 @@ Every code PR must satisfy these before push:
 2. **Else if `is_first_phase_of_session(new_phase)` AND the entering session has an intro AND that intro is not in `shown_videos`** → attach a `SESSION_VIDEO(intro_key)` component config to the coach message this turn. The Continue button carries `[ACK(intro_key)]`.
 3. **Else** → no component attached. Normal transition.
 
-When the flag is `False`, this enrichment short-circuits — the handler behaves identically to today. The transition itself is unchanged in both branches.
+When `settings.COACHING_PHASE_VIDEOS_ENABLED` is `False`, this enrichment short-circuits — the handler behaves identically to today. Check the flag with `from django.conf import settings` — direct setting access, no wrapper helper. The transition itself is unchanged in both branches.
 
 **Implementation note:** the handler ATTACHES the component to the coach message the LLM is producing this turn — it does not create a new message row. This is the existing message-with-component pattern. No multi-message response shape required.
 
 **Files likely touched:**
-- `server/apps/<coach>/handlers/transition_phase.py`
-- `server/apps/<coach>/utils/session_video_injection.py` (new — helpers shared with PR 14)
-- `server/apps/<coach>/handlers/__tests__/test_transition_phase.py`
+- `server/services/action_handler/actions/transition_phase.py` — extend. Current signature: `transition_phase(coach_state, params: TransitionPhaseParams, coach_message: ChatMessage) -> None`. Change return type to `Optional[ComponentConfig]` and return the attached component when one applies. Note: the existing handler doesn't return anything — `apply_coach_actions` in `services/action_handler/handler.py` already handles `Optional[ComponentConfig]` returns from other handlers, so this fits the existing contract.
+- `server/apps/coach_states/utils/session_video_helpers.py` — new module with the predicate helpers `should_emit_outro(old_phase) -> bool`, `outro_component_for(leaving_session) -> ComponentConfig`, `should_emit_intro(new_phase, shown_videos) -> bool`, `intro_component_for(entering_session) -> ComponentConfig`. **Place in `coach_states/utils/` because the logic reads the SESSIONS map (from `enums/coaching_phase.py`) and the `shown_videos` field on `CoachState`.** Reuse across PR 14.
+- `server/services/action_handler/tests/test_transition_phase_action.py` — extend existing test file (already at this path — mirror its current structure)
 
 **Tests required to pass before push:**
 - [ ] `test_transition_phase_attaches_outro_when_leaving_session_has_outro` — parametrized over every session with an outro
@@ -442,12 +627,13 @@ After stamping `ended_at`:
 
 This is what makes the post-break intro fire deterministically. The component return triggers PR 10's skip-LLM rule, so the LLM doesn't run this turn — the user must ack the intro first, then the LLM speaks in the new session on the next turn.
 
-When the flag is `False`, this enrichment short-circuits — the handler behaves like PR 8.
+When `settings.COACHING_PHASE_VIDEOS_ENABLED` is `False`, this enrichment short-circuits — the handler behaves like PR 8. Check the flag with `from django.conf import settings` — direct setting access, no wrapper helper.
 
 **Files likely touched:**
-- `server/apps/<coach>/handlers/end_break.py` — extend
-- `server/apps/<coach>/utils/session_video_injection.py` — shared helpers from PR 13
-- `server/apps/<coach>/handlers/__tests__/test_end_break.py`
+- `server/services/action_handler/actions/end_break.py` — extend. Change return type from `None` to `Optional[ComponentConfig]`. Use the shared helpers from PR 13.
+- `server/apps/coach_states/utils/session_video_helpers.py` — already created in PR 13; reuse the intro helpers here
+- `server/services/action_handler/tests/test_end_break_action.py` — extend
+- **Optional consideration:** if `end_break.py` now returns a `ComponentConfig`, you may want to move the file to `services/action_handler/actions/persistent_components/end_break.py` for consistency with other component-returning actions. Not strictly required — the dispatcher doesn't care about file location.
 
 **Tests required to pass before push:**
 - [ ] `test_end_break_returns_intro_component_when_current_phase_is_session_first_phase_with_unacked_intro` — parametrized
@@ -470,10 +656,12 @@ When the flag is `False`, this enrichment short-circuits — the handler behaves
 **Spec section:** Core design decision 9 + composer disable rule.
 **Scope:** Frontend reads `on_break: bool` from coach response + user-state endpoint. Composer is disabled when `on_break === true`. **No multi-message response handling needed** — the response shape is unchanged. The unacked-SESSION_VIDEO clause is added in PR 18.
 **Files likely touched:**
-- `client/src/hooks/useUserState.ts` — expose `on_break`
-- `client/src/hooks/useSendMessage.ts` — read `on_break` from response (composer state updates after each turn)
-- `client/src/components/chat/Composer.tsx` — disable on `on_break`
-- Tests for each
+- `client/src/hooks/use-coach-state.ts` — extend to expose `on_break` from the `/api/v1/user/me/coach-state` response (handles initial-load case)
+- `client/src/hooks/use-chat-messages.ts` (or wherever the `process-message` POST is wrapped) — read `on_break` from the coach response after each turn
+- `client/src/api/coach.ts` — update the response TS type to include `on_break: boolean`
+- `client/src/types/` — verify a `CoachResponse` type lives here; update it if so
+- **Composer location:** identify by grepping `client/src/pages/chat/components/` for the `<input>` or `<textarea>` used for chat input. Best candidates: `ChatControls.tsx` or `ChatInterface.tsx`. Wire the disabled prop to the `on_break` flag. **Record the actual file path in `Discoveries` when you find it** so the next agent doesn't have to re-discover.
+- `client/src/pages/chat/components/__tests__/` — vitest tests colocated here
 
 **Tests required to pass before push:**
 - [ ] `useUserState exposes on_break`
@@ -493,10 +681,11 @@ When the flag is `False`, this enrichment short-circuits — the handler behaves
 **Spec section:** Core design decision 8 (card + modal shell only — no threshold gate, no action dispatch).
 **Scope:** Build the visual shell. New React component for `SESSION_VIDEO`: thin card with video name + `[Watch]` / `[Watch Again]` button (label derives from `shownVideos.includes(video_key)`). Clicking opens a modal containing the `<video>` element. Modal closes on Esc or backdrop click — no actions fire on close. **No Continue button yet, no threshold logic, no action dispatch.** This PR is testable in browser by clicking through Watch → modal opens → modal closes.
 **Files likely touched:**
-- `client/src/components/chat/components/SessionVideoCard.tsx` (new)
-- `client/src/components/chat/components/SessionVideoModal.tsx` (new) — shell only
-- `client/src/components/chat/components/registry.ts` (or wherever components are wired) — register SESSION_VIDEO
-- Tests
+- `client/src/pages/chat/components/coach-message-with-component/SessionVideoCard.tsx` — new (mirror `IntroCannedResponseComponent.tsx` for the wrapper shape; the card itself is custom)
+- `client/src/pages/chat/components/coach-message-with-component/SessionVideoModal.tsx` — new, shell only
+- `client/src/pages/chat/components/coach-message-with-component/CoachMessageWithComponent.tsx` — add a `case ComponentType.SESSION_VIDEO:` arm that renders `<SessionVideoCard ... />`. **This file IS the component registry** — there's no separate `registry.ts`.
+- `client/src/types/componentConfig.ts` — extend the `ComponentConfig` type to include the SESSION_VIDEO shape (`video_key: string`, etc.). Check the existing type definitions before adding.
+- `client/src/pages/chat/components/__tests__/SessionVideoCard.test.tsx` — new vitest tests (mirror `CoachMessageWithComponent.test.tsx` for setup)
 
 **Tests required to pass before push:**
 - [ ] `SessionVideoCard renders video name from registry`
@@ -521,10 +710,12 @@ When the flag is `False`, this enrichment short-circuits — the handler behaves
 **Spec section:** Core design decision 8 (threshold-gated Continue) + 7 (action dispatch).
 **Scope:** Add the Continue button to `SessionVideoModal` with threshold-disabled state (20s before end for videos > 30s; 50% for videos ≤ 30s). Wire bundled action dispatch on Continue click (ACK for intros; ACK + START_BREAK for outros, with the `session_key` carried by the card's `component_config`). Esc / backdrop close still fires no action. Watch Again modal still has no Continue button.
 **Files likely touched:**
-- `client/src/components/chat/components/SessionVideoModal.tsx` — add Continue + threshold + dispatch
-- `client/src/hooks/useVideoThreshold.ts` (new) — encapsulate threshold logic
-- `client/src/api/chat.ts` — ensure send-message accepts `{ message: null, actions: [...] }`
-- Tests
+- `client/src/pages/chat/components/coach-message-with-component/SessionVideoModal.tsx` — add Continue + threshold + dispatch
+- `client/src/hooks/use-video-threshold.ts` — new (kebab-case to match `use-*.ts` convention)
+- `client/src/api/coach.ts` — ensure the process-message POST accepts `{ message: null, actions: [...] }` (the TS type should allow `message: string | null`)
+- `client/src/types/coachRequest.ts` — update if needed for the null-message case
+- `client/src/hooks/__tests__/use-video-threshold.test.ts` — new vitest unit test for the hook
+- `client/src/pages/chat/components/__tests__/SessionVideoModal.test.tsx` — new vitest tests
 
 **Tests required to pass before push:**
 - [ ] `Continue button rendered for active (unacked) modal`
@@ -541,7 +732,7 @@ When the flag is `False`, this enrichment short-circuits — the handler behaves
 - [ ] `useVideoThreshold returns disabled before threshold` — unit test
 - [ ] Full frontend test suite green
 
-**Manual verification:** in browser with `videos_enabled=true` for a test user and a placeholder MP4 in the registry, walk through: Watch → modal opens → Continue disabled → scrub close to end (or wait) → Continue enables → click → modal closes → confirm API call fired with the correct actions.
+**Manual verification:** in browser with `COACHING_PHASE_VIDEOS_ENABLED=True` in local settings and a placeholder MP4 in the registry, walk through: Watch → modal opens → Continue disabled → scrub close to end (or wait) → Continue enables → click → modal closes → confirm API call fired with the correct actions.
 
 ---
 
@@ -551,11 +742,12 @@ When the flag is `False`, this enrichment short-circuits — the handler behaves
 **Spec section:** Core design decisions 7 + 9 + composer disable rule.
 **Scope:** New React component for `SESSION_BREAK` — renders "I'm Ready" button that dispatches `{message: "I'm ready", actions: [END_BREAK()]}` (canned-response pattern, same as `IntroCannedResponseComponent`). Extend composer-disable hook with the unacked-SESSION_VIDEO clause.
 **Files likely touched:**
-- `client/src/components/chat/components/SessionBreakComponent.tsx` (new)
-- Component registry
-- `client/src/components/chat/Composer.tsx` (extend disable rule)
-- `client/src/hooks/useComposerDisabled.ts` (new or extend) — pin the rule in one place
-- Tests
+- `client/src/pages/chat/components/coach-message-with-component/SessionBreakComponent.tsx` — new (mirror `IntroCannedResponseComponent.tsx` exactly — it's the canned-response pattern)
+- `client/src/pages/chat/components/coach-message-with-component/CoachMessageWithComponent.tsx` — add `case ComponentType.SESSION_BREAK:` arm
+- **Composer file** (located in PR 15) — extend the disable rule to also fire when latest coach message is an unacked SESSION_VIDEO
+- `client/src/hooks/use-composer-disabled.ts` — new hook centralizing the disable logic (recommended — keeps the rule in one place for testability)
+- `client/src/hooks/__tests__/use-composer-disabled.test.ts` — new
+- `client/src/pages/chat/components/__tests__/SessionBreakComponent.test.tsx` — new
 
 **Tests required to pass before push:**
 - [ ] `SessionBreakComponent renders I'm Ready button`
@@ -595,10 +787,10 @@ When the flag is `False`, this enrichment short-circuits — the handler behaves
 
 **Branch:** `casey/cpv-20-s3-upload-registry-urls`
 **Spec section:** Core design decision 5.
-**Scope:** Upload all 12 video files to the project's S3 bucket (same pattern as user images — match key prefix convention). Populate `SESSION_VIDEOS[video_key]["url"]` with the resulting S3 URL for each entry.
+**Scope:** Upload all 12 video files to the project's S3 bucket (same pattern as user images — match key prefix convention used by `apps/reference_images/` or `apps/identities/` image storage). Populate `SESSION_VIDEOS[video_key]["url"]` with the resulting S3 URL for each entry.
 **Files likely touched:**
-- `server/apps/<coach>/constants/session_videos.py` — fill in URLs
-- Upload script (one-off or committed) under `scripts/` or `aws/`
+- `server/apps/coach_states/constants/session_videos.py` — fill in URLs
+- Upload script — one-off bash or Python script. Place at the repo root or under an existing `scripts/` directory if one exists. Reference the existing S3 upload pattern by grepping for `boto3` or `s3.upload_file` in `server/apps/reference_images/` — mirror that.
 
 **Tests required to pass before push:**
 - [ ] All 12 S3 URLs respond `200 OK` to `curl -I` (smoke)
@@ -644,15 +836,18 @@ When the flag is `False`, this enrichment short-circuits — the handler behaves
 
 ---
 
-## PR 22 — Flip flag in staging + prod (ops only — no code PR)
+## PR 22 — Flip flag to `True`
 
-**Branch:** none — Render dashboard env-var change only.
+**Branch:** `casey/cpv-22-flip-flag`
 **Spec section:** prerequisite for cleanup PRs.
-**Scope:** Set `COACHING_PHASE_VIDEOS_ENABLED=true` in the staging service environment, smoke test, then set the same in the production service environment, smoke test again. No code changes. No PR — this is a deploy ticket / dashboard change tracked here for sequencing.
+**Scope:** **One-line code change** flipping `COACHING_PHASE_VIDEOS_ENABLED = False` → `True` in `server/settings/common.py`. This matches the Summer Program pattern — the flag is hardcoded in the settings file, so flipping it is a PR + merge + deploy, not an env-var change in the Render dashboard. Smoke test in staging (post-merge auto-deploy) before merging to prod (or before promoting the build to prod if staging/prod are separate deploys).
+**Files likely touched:**
+- `server/settings/common.py` — the one-line flip
 
 **Verification required before marking complete:**
-- [ ] `COACHING_PHASE_VIDEOS_ENABLED=true` set in staging service env vars (verified via Render dashboard or API)
-- [ ] `COACHING_PHASE_VIDEOS_ENABLED=true` set in production service env vars (verified)
+- [ ] PR merged with single-line diff: `COACHING_PHASE_VIDEOS_ENABLED = False` → `True`
+- [ ] Staging auto-deploys the change; `GET /api/v1/core/public/coaching-phase-videos/` on staging returns `{"enabled": true}`
+- [ ] Production deploys the change; `GET /api/v1/core/public/coaching-phase-videos/` on prod returns `{"enabled": true}`
 - [ ] Staging smoke (manual):
   - [ ] Create a new test user → see welcome video card as first message
   - [ ] Walk through INTRODUCTION → first session boundary → see LLM transition message with intro card attached → ACK → LLM continues in new session
@@ -669,29 +864,42 @@ When the flag is `False`, this enrichment short-circuits — the handler behaves
 
 ---
 
-## PR 23 — Remove flag plumbing
+## PR 23 — Remove flag plumbing (OPTIONAL — see notes)
 
 **Branch:** `casey/cpv-23-remove-flag-plumbing`
 **Spec section:** cleanup (not in spec).
-**Scope:** Now that the flag is permanently `true` in all environments, remove the conditional plumbing. Delete the `COACHING_PHASE_VIDEOS_ENABLED` Django setting. Delete the `videos_enabled()` helper. Collapse every `if videos_enabled():` branch to its on-branch (delete the dead off-branch). Remove `videos_enabled: bool` from the user-state endpoint response (frontend no longer needs it). Tests that asserted "flag off → old behavior" are deleted.
-**Files likely touched:**
-- `server/settings.py`
-- `server/apps/<core>/utils/feature_flags.py` — delete the helper
-- `server/apps/users/views/user_state.py` — remove field
-- `server/apps/<coach>/handlers/transition_phase.py` — collapse flag check
-- `server/apps/<coach>/handlers/end_break.py` — collapse flag check
-- `server/apps/chat_messages/utils/ensure_initial_message_exists.py` — collapse to on-branch
-- `server/apps/<coach>/utils/session_video_injection.py` — collapse flag check
 
-**Tests required to pass before push:**
+**Decision required before claiming this PR:** the Summer Program pattern we copied in PR 1 does **not** remove its flag after rollout — it stays in `settings/common.py` as a long-lived kill switch. Two options:
+
+- **Option A — keep the flag (default, matches Summer Program exactly).** Skip this PR entirely. The flag stays at `True`, the endpoint stays public, the `if settings.COACHING_PHASE_VIDEOS_ENABLED:` branches stay. If videos ever break in prod, ops can flip the boolean to `False` and redeploy in minutes. Cost: a handful of dead-looking `if` branches and an endpoint that always returns `{"enabled": true}`.
+- **Option B — remove the flag (clean cut).** Run this PR. Justified if we're confident we'll never want to disable the feature again. Delete the constant, the helper, the ViewSet, the URL route, the tests, and every `if settings.COACHING_PHASE_VIDEOS_ENABLED:` branch (collapsing to the on-branch). The `INITIAL_MESSAGE` constant (the off-branch in `ensure_initial_message_exists`) is then dead — PR 24 removes it.
+
+**If running Option B (scope of this PR):**
+- `server/settings/common.py` — delete the `COACHING_PHASE_VIDEOS_ENABLED` constant + comment
+- `server/apps/core/functions/public/get_coaching_phase_videos.py` — delete
+- `server/apps/core/functions/public/__init__.py` and `server/apps/core/functions/__init__.py` — drop the re-export (delete the file entirely if it becomes empty)
+- `server/apps/core/views/coaching_phase_videos_view_set.py` — delete
+- `server/apps/core/views/__init__.py` — drop the re-export
+- `server/apps/api_urls.py` — drop the `core/public/coaching-phase-videos` route registration
+- `server/apps/core/tests/test_get_coaching_phase_videos.py` — delete
+- `server/apps/core/tests/test_coaching_phase_videos_endpoint.py` — delete
+- `server/services/action_handler/actions/transition_phase.py` — collapse flag check, keep only the videos-on branch
+- `server/services/action_handler/actions/end_break.py` (or `actions/persistent_components/end_break.py` if you moved it in PR 14) — collapse flag check
+- `server/apps/chat_messages/utils/ensure_initial_message_exists.py` — collapse to on-branch
+- `server/apps/coach_states/utils/session_video_helpers.py` — collapse flag check (if it grew one)
+
+**Tests required to pass before push (Option B only):**
 - [ ] `grep -rn "COACHING_PHASE_VIDEOS_ENABLED" .` returns no hits
-- [ ] `grep -rn "videos_enabled" server/ client/src/` returns no hits
+- [ ] `grep -rn "get_coaching_phase_videos" .` returns no hits
+- [ ] `grep -rn "coaching-phase-videos" .` returns no hits in URL config / route files
 - [ ] Backend test suite green — all previously-flag-on tests now pass without conditional setup
 - [ ] Frontend test suite green
-- [ ] `test_user_state_response_no_longer_includes_videos_enabled_field` (positive removal test)
+- [ ] `GET /api/v1/core/public/coaching-phase-videos/` returns 404 (route removed) — verified via test or manual curl
 - [ ] Manual smoke in staging — full flow still works identically to PR 22's smoke
 
-**Manual verification:** repeat PR 22's staging smoke walkthrough — behavior must be identical. Confirm no regressions visible in browser dev-tools network tab.
+**Manual verification:** repeat PR 22's staging smoke walkthrough — behavior must be identical. Confirm `GET /api/v1/core/public/coaching-phase-videos/` is gone.
+
+**Recommendation:** default to **Option A** (skip this PR) unless we have a strong reason to remove the flag. Kill switches are cheap; rebuilding one under pressure is not.
 
 ---
 
@@ -701,8 +909,9 @@ When the flag is `False`, this enrichment short-circuits — the handler behaves
 **Spec section:** "Net surface area" — `ensure_initial_message_exists` rewrite says delete `INITIAL_MESSAGE`.
 **Scope:** Pure dead-code cleanup. The constant has been unreachable since PR 12's on-branch became the only branch in PR 23. Delete the constant, any dead imports referencing it, and any tests that asserted on its content. Keep this PR minimal — one constant, its imports, any tests using it.
 **Files likely touched:**
-- `server/apps/chat_messages/constants.py` — delete `INITIAL_MESSAGE` (and the file entirely if it becomes empty)
-- Any file with `from chat_messages.constants import INITIAL_MESSAGE` — drop the import
+- `server/apps/chat_messages/constants/initial_messages.py` — delete `INITIAL_MESSAGE` (the file also exports `INITIAL_MESSAGE_OLD` — keep `INITIAL_MESSAGE_OLD` unless explicitly told otherwise, since the docstring notes it's "preserved for reference")
+- `server/apps/chat_messages/constants/__init__.py` — drop the `INITIAL_MESSAGE` re-export and remove `"INITIAL_MESSAGE"` from `__all__`
+- Any file with `from apps.chat_messages.constants import INITIAL_MESSAGE` — drop the import
 - Any test using `INITIAL_MESSAGE` — delete the test (these only existed to assert the old welcome-text behavior)
 
 **Tests required to pass before push:**

--- a/notes/coaching-phase-videos.md
+++ b/notes/coaching-phase-videos.md
@@ -83,63 +83,93 @@ SESSION_VIDEOS = {
 
 Frontend `<video src>` streams directly from S3. HTTP range requests work, so basic seeking is supported. CloudFront later if mobile scrubbing is bad. Source files at `dev-coach/videos/`.
 
-### 6. Videos are server-injected — the LLM never invokes them
+### 6. Videos are server-injected via action handlers — the LLM never decides when
 
-This is the heart of the design. Videos are **not** an LLM tool. The server detects video-relevant moments deterministically and injects video cards as coach messages. The LLM has no awareness videos exist.
+This is the heart of the design. Videos are **not** an LLM tool. The server emits video cards deterministically by enriching the action handlers that already mark session boundaries (`transition_phase`, `END_BREAK`) and by seeding the very first one at chat creation. The LLM has no awareness videos exist as a feature.
 
-**Three injection points** in `server/apps/coach/functions/public/process_message.py` and `server/apps/chat_messages/utils/ensure_initial_message_exists.py`:
+**Three injection points — all in action handlers:**
 
 **A) Welcome injection — `ensure_initial_message_exists`:**
+
 Instead of seeding the hardcoded `INITIAL_MESSAGE` text, seed a coach message carrying a `SESSION_VIDEO` ComponentConfig for `welcome_session_intro`, with `text=""` (no greeting text on the card itself). The greeting ("Hi, I'm Leigh-Ann...") is produced by the LLM the first time it runs — which is after the user clicks Continue on the welcome video. The old `INITIAL_MESSAGE` constant is deleted.
 
-**B) Intro injection — in `process_message`, between `apply_user_component_actions` and `build_coach_prompt`:**
+**B) `transition_phase` handler enrichment:**
+
+After the phase transition runs, consult the `SESSIONS` map. The handler returns at most one component, which is **attached as the `component_config` of the LLM's coach response message** (existing message-with-component pattern — no new message row is created).
+
+Precedence: outro wins over intro when both would apply.
 
 ```python
-# If current_phase is the first phase of a session AND that session's intro
-# has not been acknowledged yet, inject the intro video card as the coach
-# response and skip the LLM call. (Fires after END_BREAK closes a break, and
-# for any first user message in a new session that hasn't seen its intro yet.)
-if pending_session_intro(coach_state):
-    coach_message = inject_session_intro_video(coach_state)
-    return success_response(coach_message)
+# pseudocode — inside transition_phase action handler, after phase change applied
+leaving_session  = session_of(old_phase)
+entering_session = session_of(new_phase)
+
+if is_last_phase_of_session(old_phase) and SESSIONS[leaving_session]["outro"]:
+    outro_key = SESSIONS[leaving_session]["outro"]
+    return SessionVideoComponent(
+        video_key=outro_key,
+        continue_actions=[
+            ACKNOWLEDGE_SESSION_VIDEO(outro_key),
+            START_BREAK(leaving_session),
+        ],
+    )
+
+if (is_first_phase_of_session(new_phase)
+    and SESSIONS[entering_session]["intro"]
+    and SESSIONS[entering_session]["intro"] not in coach_state.shown_videos):
+    intro_key = SESSIONS[entering_session]["intro"]
+    return SessionVideoComponent(
+        video_key=intro_key,
+        continue_actions=[ACKNOWLEDGE_SESSION_VIDEO(intro_key)],
+    )
+
+return None
 ```
 
-When the user clicks Continue on the intro card, the frontend dispatches `{message: null, actions: [ACK(intro_key)]}`. The server saves no user ChatMessage (see "process_message null-message contract" below), runs ACK, sees that the intro is now in `shown_videos`, falls through the gate, and the LLM finally runs in the new phase — producing the session's first prompt as a second consecutive coach message after the (now-acked) video card.
+The LLM's transition text and the video card live in the same `ChatMessage` row. The frontend renders them together in one bubble.
 
-**C) Outro injection — in `process_message`, immediately after `apply_coach_response_actions`:**
+**C) `END_BREAK` handler enrichment:**
+
+After stamping `ended_at`, check whether the user is now at the start of a new session whose intro hasn't been acked. If so, return the intro video component. The skip-LLM-on-component rule then fires — the LLM doesn't run this turn. The user acks the intro; the LLM speaks in the new session on the next turn.
 
 ```python
-# Capture old_phase BEFORE the LLM's actions run; capture new_phase after.
-# If the LLM's transition_phase moved us OUT of the last phase of a session that
-# has an outro, append a SECOND coach message carrying the outro video card.
-# The LLM's text response is KEPT as its in-prompt sign-off; the outro card
-# appears beneath it.
-if just_left_session_with_outro(old_phase, new_phase):
-    inject_session_outro_video(updated_coach_state, leaving_session=session_of(old_phase))
+# pseudocode — inside END_BREAK action handler, after ended_at stamped
+current_session = session_of(coach_state.current_phase)
+intro_key       = SESSIONS[current_session]["intro"]
+
+if (is_first_phase_of_session(coach_state.current_phase)
+    and intro_key
+    and intro_key not in coach_state.shown_videos):
+    return SessionVideoComponent(
+        video_key=intro_key,
+        continue_actions=[ACKNOWLEDGE_SESSION_VIDEO(intro_key)],
+    )
+
+return None
 ```
 
-The `leaving_session` argument is critical: by the time the outro is injected, `current_phase` has already moved into the *next* session, so the helper needs the session being left in order to look up the right outro video key and bake the correct `START_BREAK(session_key=...)` action into the card's Continue button.
-
-**process_message null-message contract:**
-- `message=None` (programmatic-only, from action-only button clicks like video Continue): no user ChatMessage is saved; user actions still apply; LLM is called only if no component_config was returned by user actions AND no intro gate fired.
+**`process_message` null-message contract:**
+- `message=None` (programmatic-only, from action-only button clicks like video Continue): no user ChatMessage is saved; user actions still apply; LLM is called only if no component_config was returned by user actions.
 - `message=""` (empty string): treated as a real user message — saved as a ChatMessage with empty content. The user shouldn't be able to send this through the UI, but if they do it's handled normally.
 - `message="any text"`: normal user message, saved as ChatMessage.
 
-**Skip-LLM rule** (after `apply_user_component_actions`): skip the LLM call iff (a) a `component_config` was returned by any user action (e.g., `START_BREAK` returning `SESSION_BREAK`), or (b) the intro gate fired. Otherwise call the LLM — even if no user message was added this turn. The LLM responds based on chat history alone, which works because of component serialization (see below).
+**Skip-LLM rule** (after `apply_user_component_actions`): skip the LLM call iff a `component_config` was returned by any user action (e.g., `END_BREAK` returning a `SESSION_VIDEO`, or `START_BREAK` returning a `SESSION_BREAK`). Otherwise call the LLM — even if no user message was added this turn. The LLM responds based on chat history alone, which works because of component serialization (see Decision 10).
 
 **What's NOT in this design:**
 - No `SHOW_SESSION_INTRO_VIDEO` / `SHOW_SESSION_OUTRO_VIDEO` actions
 - No per-session context key
 - No prompt edits, no gate paragraphs
+- **No pre-LLM intro gate or post-LLM outro hook in `process_message`** — handlers carry the logic
+- **No multi-message coach response shape** — coach responses remain a single coach message with optional component_config
 - The LLM has zero involvement with videos (it neither triggers them nor knows they exist as a feature — it just sees acknowledged-video markers in serialized chat history, see Decision 10)
 
 ### 7. Three user-button actions
 
-Only the user's button clicks invoke actions. The server injects the components; the user closes the loop. **All parameters are baked into the buttons by the server when constructing each card — the LLM never sets any of them.**
+Only the user's button clicks invoke actions. The server emits the components; the user closes the loop. **All parameters are baked into the buttons by the server when constructing each card — the LLM never sets any of them.**
 
 - `ACKNOWLEDGE_SESSION_VIDEO(video_key: str)` — appends `video_key` to `shown_videos`. Idempotent. Fires on the video modal's Continue button (see Decision 8 for button timing).
-- `START_BREAK(session_key: str)` — creates a `Break` row with `triggered_by_session = session_key`, returns a `SESSION_BREAK` ComponentConfig. Fires as the second action on the outro video's Continue button. The `session_key` identifies the session being left (NOT the user's current session, which has already advanced by this point — see Decision 6.C).
-- `END_BREAK()` — zero-param. Stamps `ended_at` on the user's single open `Break`. Fires as the only action on the break card's "I'm Ready" button.
+- `START_BREAK(session_key: str)` — creates a `Break` row with `triggered_by_session = session_key`, returns a `SESSION_BREAK` ComponentConfig. Fires as the second action on the outro video's Continue button. The `session_key` identifies the session being left (NOT the user's current session, which has already advanced by this point — see Decision 6.B).
+- `END_BREAK()` — zero-param. Stamps `ended_at` on the user's single open `Break`. May return a `SESSION_VIDEO` ComponentConfig for the new session's intro (see Decision 6.C). Fires as the only action on the break card's "I'm Ready" button.
 
 **Two dispatch patterns — distinct on purpose:**
 
@@ -148,11 +178,11 @@ Only the user's button clicks invoke actions. The server injects the components;
 
 **Button action chains:**
 
-- **Intro video** Continue → `{message: null, actions: [ACKNOWLEDGE_SESSION_VIDEO(video_key)]}`. The intro-injection hook stops firing because the key is now in `shown_videos`; the gate falls through and the LLM runs in the new phase. The LLM's response appears as a second consecutive coach message after the (now-acked) video card.
-- **Outro video** Continue → `{message: null, actions: [ACKNOWLEDGE_SESSION_VIDEO(video_key), START_BREAK(session_key)]}`. `START_BREAK` returns the `SESSION_BREAK` component config; the skip-LLM rule fires; the break card is saved as a third consecutive coach message after the LLM's transition text + the outro card.
-- **Break card "I'm Ready"** → `{message: "I'm ready", actions: [END_BREAK()]}`. Saves "I'm ready" as a user message, closes the break, and the intro-injection hook in the same `process_message` call injects the next session's intro card.
+- **Intro video** Continue → `{message: null, actions: [ACKNOWLEDGE_SESSION_VIDEO(video_key)]}`. ACK runs, returns no component, no skip-LLM trigger. The LLM runs in the (already-current) phase and produces the session's first prompt as the next coach message.
+- **Outro video** Continue → `{message: null, actions: [ACKNOWLEDGE_SESSION_VIDEO(video_key), START_BREAK(session_key)]}`. ACK runs. `START_BREAK` returns the `SESSION_BREAK` component config; the skip-LLM rule fires; the break card is saved as the next coach message.
+- **Break card "I'm Ready"** → `{message: "I'm ready", actions: [END_BREAK()]}`. Saves "I'm ready" as a user message. `END_BREAK` closes the break and returns the next session's intro video component. The skip-LLM rule fires; the intro card is saved as the next coach message.
 
-**Important: `transition_phase` runs ONCE per session boundary — when the LLM emits it before the outro plays.** It does not appear in any of the user-button chains. By the time the user is interacting with the outro or break card, `current_phase` already reflects the next session. This is what makes `START_BREAK` need an explicit `session_key` parameter (the session being left, not the current one).
+**Important: `transition_phase` runs ONCE per session boundary — when the LLM emits it.** It does not appear in any of the user-button chains. The handler attaches the outro card (when leaving a session that has one) or the intro card (when leaving a session without an outro and entering one with an intro) to the LLM's transition coach message. By the time the user is interacting with the outro or break card, `current_phase` already reflects the next session. This is what makes `START_BREAK` need an explicit `session_key` parameter (the session being left, not the current one).
 
 ### 8. UI: thin card + modal player with threshold-gated Continue button
 
@@ -196,7 +226,9 @@ class Break(models.Model):
 
 Because videos and breaks are server-injected and the LLM has no awareness of them, the chat history must carry enough narrative signal that the LLM can pick up the thread after a session boundary. Without this, the LLM is blind: it sees an unexplained "I'm ready" with no preceding question.
 
-**`get_recent_chat_messages_for_prompt` is updated to render `component_config` into bracketed textual descriptions when serializing for the LLM.** The DB row is unchanged; only the LLM-facing string representation changes. Suggested formats:
+**`get_recent_chat_messages_for_prompt` is updated to render `component_config` into bracketed textual descriptions when serializing for the LLM.** The DB row is unchanged; only the LLM-facing string representation changes. Coach messages that have both text AND a `component_config` (the common case for transition turns) are serialized with both: the LLM's text first, then the bracketed component description on a new line.
+
+Suggested formats:
 
 - Acked video: `[Showed user the "<video_name>" video. User watched it.]`
 - Unacked video: `[Showed user the "<video_name>" video. User has not watched it yet.]`
@@ -205,7 +237,7 @@ Because videos and breaks are server-injected and the LLM has no awareness of th
 
 `shown_videos` and the Break table are the sources of truth for acked/closed state at serialization time.
 
-**Also bump the default history `count` from 5 to 10.** A single session boundary can fill 3–5 slots with video/break/intro bubbles, leaving zero room for actual session content. 10 is a defensive minimum.
+**Also bump the default history `count` from 5 to 10.** A single session boundary can fill several slots with video/break/intro bubbles, leaving zero room for actual session content. 10 is a defensive minimum.
 
 This is the only piece of "LLM-aware" code in the design, and it's deliberately confined to a serialization helper. The LLM still has no actions, no context keys, and no awareness that videos exist as a feature — it just reads narration in chat history.
 
@@ -215,23 +247,24 @@ For Get-to-Know → Brainstorming. Other boundaries follow the same pattern.
 
 | # | Trigger | What happens | ChatMessage rows written | CoachState / Break delta |
 |---|---|---|---|---|
-| 0 | First-ever app open | `ensure_initial_message_exists` seeds welcome video card | COACH: `text=""`, SESSION_VIDEO(welcome_session_intro) | — |
-| 1 | User clicks Continue on welcome | Frontend `{message: null, actions: [ACK(welcome_session_intro)]}`. No user msg. ACK runs. Gate falls through. LLM runs in INTRODUCTION. | COACH: "Hi, I'm Leigh-Ann..." | `shown_videos += welcome_session_intro` |
-| ~ | Normal back-and-forth in INTRODUCTION | LLM converses with user, eventually emits `transition_phase(GET_TO_KNOW_YOU)` | (many USER/COACH rows) | `current_phase = GET_TO_KNOW_YOU` |
-| 2 | User's next typed message in GET_TO_KNOW_YOU | Gate fires: `pending_session_intro` TRUE. Skip LLM. Inject. | USER: "OK!", COACH: SESSION_VIDEO(get_to_know_session_intro) | — |
-| 3 | User clicks Continue on get-to-know intro | `{message: null, actions: [ACK]}`. No user msg. ACK runs. Gate falls through. LLM runs in GET_TO_KNOW_YOU. | COACH: "Now let me ask you about..." | `shown_videos += get_to_know_session_intro` |
-| ~ | Normal back-and-forth through GET_TO_KNOW_YOU + IDENTITY_WARMUP | LLM converses, eventually transitions to IDENTITY_BRAINSTORMING | (many USER/COACH rows) | `current_phase = IDENTITY_BRAINSTORMING` |
-| 4 | LLM transition turn (the boundary) | LLM responds with "Beautiful work, take a moment" + `transition_phase`. After `apply_coach_response_actions`, outro detection fires. Outro card injected as second coach message. | COACH: "Beautiful work...", COACH: SESSION_VIDEO(get_to_know_session_outro) | `current_phase = IDENTITY_BRAINSTORMING` |
-| 5 | User clicks Continue on outro | `{message: null, actions: [ACK(outro_key), START_BREAK("get_to_know_session")]}`. No user msg. ACK runs. START_BREAK returns SESSION_BREAK component → skip-LLM rule fires. | COACH: SESSION_BREAK | `shown_videos += outro`; Break row opens; `on_break = true`; composer disabled |
-| 6 | User clicks "I'm Ready" on break (maybe hours later) | `{message: "I'm ready", actions: [END_BREAK()]}`. User msg saved. END_BREAK closes break. Gate fires: `pending_session_intro` TRUE for brainstorming. Skip LLM. Inject. | USER: "I'm ready", COACH: SESSION_VIDEO(brainstorming_session_intro) | Break `ended_at` stamped; `on_break = false`; composer disabled (unacked video latest) |
-| 7 | User clicks Continue on brainstorming intro | `{message: null, actions: [ACK(brainstorming_session_intro)]}`. No user msg. ACK runs. Gate falls through. LLM runs in IDENTITY_BRAINSTORMING. | COACH: "Welcome to brainstorming!..." | `shown_videos += brainstorming intro`; composer re-enabled |
+| 0 | First-ever app open | `ensure_initial_message_exists` seeds welcome video card | COACH: `text=""`, component=`SESSION_VIDEO(welcome_session_intro)` | — |
+| 1 | User clicks Continue on welcome | Frontend `{message: null, actions: [ACK(welcome_session_intro)]}`. No user msg. ACK runs, returns no component. LLM runs in INTRODUCTION. | COACH: "Hi, I'm Leigh-Ann..." | `shown_videos += welcome_session_intro` |
+| ~ | Normal back-and-forth in INTRODUCTION | LLM converses with user | (many USER/COACH rows) | — |
+| 2 | LLM transition turn (INTRODUCTION → GET_TO_KNOW_YOU) | LLM emits text "Let's move on to getting to know you" + `transition_phase(GET_TO_KNOW_YOU)`. Handler: leaving `welcome_session` has no outro; entering `get_to_know_session` has unacked intro → **attaches** `SESSION_VIDEO(get_to_know_session_intro)` to the LLM's message. | COACH: `text="Let's move on..."`, component=`SESSION_VIDEO(get_to_know_session_intro)` | `current_phase = GET_TO_KNOW_YOU` |
+| 3 | User clicks Continue on get-to-know intro | `{message: null, actions: [ACK]}`. No user msg. ACK runs, returns no component. LLM runs in GET_TO_KNOW_YOU. | COACH: "Now let me ask you about..." | `shown_videos += get_to_know_session_intro` |
+| ~ | Normal back-and-forth through GET_TO_KNOW_YOU + IDENTITY_WARMUP | LLM converses | (many USER/COACH rows) | — |
+| 4 | LLM transition turn (IDENTITY_WARMUP → IDENTITY_BRAINSTORMING) | LLM emits text "Beautiful work, take a moment" + `transition_phase(IDENTITY_BRAINSTORMING)`. Handler: leaving `get_to_know_session` has outro → **attaches** `SESSION_VIDEO(get_to_know_session_outro)` to the LLM's message. | COACH: `text="Beautiful work..."`, component=`SESSION_VIDEO(get_to_know_session_outro)` | `current_phase = IDENTITY_BRAINSTORMING` |
+| 5 | User clicks Continue on outro | `{message: null, actions: [ACK(outro_key), START_BREAK("get_to_know_session")]}`. No user msg. ACK runs. START_BREAK returns SESSION_BREAK component → skip-LLM rule fires. | COACH: component=`SESSION_BREAK` | `shown_videos += outro`; Break row opens; `on_break = true`; composer disabled |
+| 6 | User clicks "I'm Ready" on break (maybe hours later) | `{message: "I'm ready", actions: [END_BREAK()]}`. User msg saved. END_BREAK closes break, sees `current_phase` is first phase of `brainstorming_session` with unacked intro → returns `SESSION_VIDEO(brainstorming_session_intro)`. Skip-LLM rule fires. | USER: "I'm ready"; COACH: component=`SESSION_VIDEO(brainstorming_session_intro)` | Break `ended_at` stamped; `on_break = false`; composer disabled (unacked video latest) |
+| 7 | User clicks Continue on brainstorming intro | `{message: null, actions: [ACK(brainstorming_session_intro)]}`. No user msg. ACK runs, returns no component. LLM runs in IDENTITY_BRAINSTORMING. | COACH: "Welcome to brainstorming!..." | `shown_videos += brainstorming intro`; composer re-enabled |
 | 8+ | Normal IDENTITY_BRAINSTORMING conversation | ... | ... | ... |
 
 **Key invariants:**
+- **At most one coach message per server response.** Coach messages may carry text + component together in a single row (steps 2, 4) — there is no multi-message response shape.
 - One user-message bubble per boundary ("I'm ready" at step 6). Everything else is coach-driven.
-- LLM is called at steps 1, 3, 4, 7 (and during normal conversation). LLM is *not* called at steps 0, 2, 5, 6.
-- Two or three consecutive coach messages per boundary is normal (steps 4–5, 6–7, 0–1).
-- The video DB rows from steps 0, 2, 4, 6 never change after the ACK — only `shown_videos` updates, and the frontend re-derives Watch vs Watch Again from that.
+- LLM is called at steps 1, 2, 3, 4, 7 (and during normal conversation). LLM is *not* called at steps 0, 5, 6.
+- Multiple consecutive coach messages between user-typed inputs is normal (steps 4 → 5; step 6 user msg → step 6 coach component → step 7 coach text).
+- The video DB rows never change after the ACK — only `shown_videos` updates, and the frontend re-derives Watch vs Watch Again from that.
 
 ## Sessions & videos
 
@@ -261,6 +294,8 @@ Files at `dev-coach/videos/` (renamed to match session keys). Number prefix = pl
 | Idea | Why rejected |
 |---|---|
 | LLM-driven `SHOW_SESSION_INTRO/OUTRO_VIDEO` actions | Server can derive video timing deterministically from phase transitions. Removes prompt-engineering surface and eliminates the hallucination risk entirely |
+| Pre-LLM intro gate / post-LLM outro hook in `process_message` | Earlier draft of this spec. Replaced by handler enrichment (`transition_phase`, `END_BREAK`) because handlers already own the deterministic boundary signal and avoid surgery on `process_message`'s core flow |
+| Multi-message coach response shape (response carries a list of coach messages) | Earlier draft of this spec. Not needed once the outro/intro card rides on the same `ChatMessage` row as the LLM's transition text via `component_config` |
 | Per-session context key + prompt gates | Not needed once videos are server-injected. The LLM never sees video state |
 | Narrative-only break / no break state | Break is a real, backend-tracked, soft-blocking concept |
 | `current_session` field on `CoachState` | Derivable from `current_phase` + `SESSIONS` map |
@@ -275,7 +310,7 @@ Files at `dev-coach/videos/` (renamed to match session keys). Number prefix = pl
 
 1. **Modal close behavior** — modal renders a Continue button that's disabled until 20s before the video ends (or the 50% mark for videos shorter than 30s). ACK fires on Continue click. Closing the modal early via Esc/backdrop is allowed and fires no action.
 2. **Video file naming** — files renamed on disk to match session keys (see Sessions & videos table above). Registry maps `video_key → {name, url}`; filename and key are kept in sync as a convention.
-3. **Response shape for outro turn** — `process_message` returns multiple coach messages when an outro is injected. The LLM's transition text and the outro video card are saved as two separate ChatMessage rows and both returned in the response. Frontend renders them in order. (See Decision 6.C and the lifecycle walkthrough.)
+3. **Outro turn response shape** — the outro card rides on the same `ChatMessage` as the LLM's transition text via `component_config`. The `transition_phase` action handler attaches the component when it runs; no new message row is created and no multi-message response shape is needed. See Decision 6.B and the lifecycle walkthrough.
 
 ## Edge cases explicitly out of scope for v1
 
@@ -291,24 +326,25 @@ Files at `dev-coach/videos/` (renamed to match session keys). Number prefix = pl
 | **Migration: `shown_videos`** | ArrayField on `CoachState` |
 | **Migration: `Break` model** | `user`, `started_at`, `ended_at`, `triggered_by_session`, `coach_message` |
 | **Video registry** | Static dict `video_key → { name, url }` |
-| **Server injection hooks** | `pending_session_intro`, `inject_session_intro_video`, `just_left_session_with_outro`, `inject_session_outro_video` — all wired into `process_message` (intro hook between user-action and LLM call; outro hook immediately after `apply_coach_response_actions` returns) |
-| **`process_message` null-message contract** | Accept `message: None` programmatically (no user ChatMessage saved; user actions still apply). `message=""` still treated as a real user message. Skip-LLM rule: skip iff user action returned a component_config OR intro gate fired. |
+| **`transition_phase` handler enrichment** | After phase change, consult `SESSIONS` map and return outro component (if leaving a session with an outro) or intro component (if leaving a session without an outro and entering one with an unacked intro). Outro wins over intro on precedence. Component attaches to the LLM's coach response message via existing `component_config` field. |
+| **`END_BREAK` handler enrichment** | After closing break, if `current_phase` is first phase of a session with an unacked intro, return the intro component. Triggers skip-LLM rule. |
 | **`ensure_initial_message_exists` rewrite** | Seed welcome video card (text="", no greeting) instead of `INITIAL_MESSAGE` text. Delete the `INITIAL_MESSAGE` constant. |
-| **`get_recent_chat_messages_for_prompt` rewrite** | Serialize `component_config` into bracketed descriptions for the LLM. Bump default count from 5 → 10. |
+| **`process_message` null-message contract** | Accept `message: None` programmatically (no user ChatMessage saved; user actions still apply). `message=""` still treated as a real user message. Skip-LLM rule: skip iff a user action returned a `component_config`. |
+| **`get_recent_chat_messages_for_prompt` rewrite** | Serialize `component_config` into bracketed descriptions for the LLM (including coach messages that have both text and a component). Bump default count from 5 → 10. |
 | **Action: `ACKNOWLEDGE_SESSION_VIDEO(video_key)`** | Appends to `shown_videos`; key set by server, not LLM |
 | **Action: `START_BREAK(session_key)`** | Creates Break row (`triggered_by_session = session_key`), returns SESSION_BREAK component. `session_key` is set by the server when building the outro card's button. |
-| **Action: `END_BREAK()`** | Stamps `ended_at` on open Break |
+| **Action: `END_BREAK()`** | Stamps `ended_at` on open Break, optionally returns intro video component (Decision 6.C) |
 | **ActionType enum** | 3 new values |
 | **ComponentType enum** | 2 new: `SESSION_VIDEO`, `SESSION_BREAK` |
 | **API field** | `on_break: bool` on coach response AND user-state endpoint |
-| **API response shape** | Coach response now returns a list of coach messages (to support outro injected alongside LLM text), not a single message |
 | **React: video card** | Thin card + modal player with threshold-gated Continue button (20s before end, or 50% for short videos); same component drives active (Watch) and persisted (Watch Again) state |
 | **React: break card** | "I'm Ready" button (canned-response pattern: dispatches `{message: "I'm ready", actions: [END_BREAK()]}`); composer disabled while open via `on_break` |
 | **React: composer disable rule** | Disable composer when latest coach message is an unacked SESSION_VIDEO, OR when `on_break === true` |
 | **S3 upload** | One-time upload of the 12 video files |
+| **Docs update** | Update `docs/docs/coach/phases.md`, `docs/docs/core-systems/action-handler/actions/transition-phase.md`, `docs/docs/core-systems/component-renderer/persistent-components.md`, plus new action docs for ACK / START_BREAK / END_BREAK. |
 | **Procedure doc** | NOP-style "Add a Session Video" Procedures MCP doc. First-class deliverable. |
 
-**Explicitly NOT in scope:** prompt edits, per-session context key, SHOW actions. The LLM is untouched (the serialization helper is a *read-side* shim, not a prompt edit).
+**Explicitly NOT in scope:** prompt edits, per-session context key, SHOW actions, pre-LLM gate / post-LLM hook in `process_message`, multi-message response shape. The LLM is untouched (the serialization helper is a *read-side* shim, not a prompt edit).
 
 ## Pointers to existing Procedures docs the next agent should read first
 
@@ -320,21 +356,13 @@ Files at `dev-coach/videos/` (renamed to match session keys). Number prefix = pl
 
 ## Next step in the workflow
 
-Hand this document to the **plan agent** as the spec. The lifecycle walkthrough above is the ground truth for the runtime flow; the Net surface area table is the ground truth for what to build.
+The PR breakdown lives at [`notes/coaching-phase-videos-prs.md`](./coaching-phase-videos-prs.md). The lifecycle walkthrough above is the ground truth for the runtime flow; the Net surface area table is the ground truth for what to build.
 
-Non-negotiable instructions for the plan agent:
+Non-negotiable instructions for implementation:
 
 1. Treat the session/video mapping as mutable data. Nothing outside the `SESSIONS` map / video registry should name specific videos or sessions.
 2. The plan must produce the "Add a Session Video" Procedures MCP doc alongside the code PRs.
 3. The break is part of the flow — not a stretch goal.
-4. **Do not add SHOW video actions, context keys, or prompt edits.** Videos are server-injected. The only LLM-facing change is the read-side serialization helper in `get_recent_chat_messages_for_prompt`.
+4. **Do not add SHOW video actions, context keys, prompt edits, pre/post-LLM injection hooks in `process_message`, or multi-message response shapes.** Videos are server-injected via action handlers. The only LLM-facing change is the read-side serialization helper in `get_recent_chat_messages_for_prompt`.
 5. Preserve the `message: None` vs `message: ""` distinction in `process_message` — `None` is programmatic-only, `""` is treated as a real user message.
-
-Likely PR decomposition (plan agent has final say). **Order matters** — later PRs depend on earlier ones:
-
-1. **Foundation:** `SESSIONS` map + helpers in `coaching_phase.py`, `shown_videos` migration on `CoachState`, `Break` model migration, video registry skeleton, new ActionType + ComponentType enum values.
-2. **User-button actions:** `ACKNOWLEDGE_SESSION_VIDEO`, `START_BREAK`, `END_BREAK` handlers (needed before injection helpers can wire buttons to them).
-3. **Server injection layer + process_message overhaul:** intro-injection + outro-injection helpers wired into `process_message`, `process_message` null-message contract + skip-LLM rule, `ensure_initial_message_exists` rewrite (delete `INITIAL_MESSAGE`), `get_recent_chat_messages_for_prompt` component serialization + count bump, `on_break` API field on coach response + user-state endpoint, multi-message response shape.
-4. **Frontend:** video card + modal player with threshold-gated Continue button + break card; composer disable wired to `on_break` AND unacked-video-is-latest; multi-message response handling.
-5. **Content:** S3 upload + populate the full video registry.
-6. **Docs:** the "Add a Session Video" Procedures MCP doc.
+6. The outro/intro card rides on the same `ChatMessage` row as the LLM's transition text via `component_config`. Do not introduce a list-of-coach-messages response shape.

--- a/notes/coaching-phase-videos.md
+++ b/notes/coaching-phase-videos.md
@@ -1,36 +1,58 @@
-# Coaching Phase Videos — Brain Dump
+# Coaching Phase Videos — Feature Spec
 
 ## Purpose
 
-Show Leigh Ann's pre-recorded videos to clients at the **start and end of certain coaching phases**. Intro videos preview what's coming; outro videos explain the value of taking a break before the next group of phases begins.
+Show Leigh Ann's pre-recorded videos at the **start and end of each coaching session** (a session = one or more consecutive phases that belong together). Videos are **server-injected** based on phase transitions — the LLM never decides when a video plays.
 
-The videos appear inline in the chat window like part of the conversation. The user can revisit any previously shown video.
+Videos appear inline in chat as thin cards. The user can revisit any previously shown video.
 
-## Core design decisions (locked)
+## Reframe: pattern first, mapping second
 
-### 1. "Sessions" do not exist in code
+The deliverable is the **architecture pattern + a reusable procedure for adding a video at a determined point in time** — not a one-time wiring of these specific 12 videos.
 
-Sessions are a **developer concept** for thinking about which videos belong together. They never manifest in models, enums, config maps, or migrations.
+When Leigh Ann delivers or swaps a video:
 
-What actually exists in code: **phases**, some of which have an intro video, an outro video, both, or neither. Whether two videos are "the same session" is only meaningful to humans writing prompts and naming files.
+1. Upload the file to S3.
+2. Edit the `intro` / `outro` key for the relevant session in the `SESSIONS` map.
+3. Edit the entry in the video registry (`video_key → { name, url }`).
 
-### 2. Video keys are `<phase>_<position>`
+No code changes, no migrations, no enum updates, no frontend work, **no prompt edits**.
 
-Every video has a unique key of the form `<phase_value>_intro` or `<phase_value>_outro`. Examples:
+The implementation plan **must include** a Procedures MCP doc — `procedure / dev-coach / coach / add-session-video` — walking through the procedure. First-class deliverable.
 
-- `identity_brainstorming_intro`
-- `identity_brainstorming_outro`
-- `i_am_statement_intro`
-- `i_am_statement_outro`
+## Core design decisions
 
-This string is:
-- The key in the `shown_videos` array on `CoachState`
-- The parameter to the action that shows / acknowledges a video
-- The lookup key in the static video registry
+### 1. Sessions are codified as metadata on `CoachingPhase`
+
+A `SESSIONS` map lives next to the `CoachingPhase` enum in `server/enums/coaching_phase.py`. Session keys carry the `_session` suffix so they're never confused with phase values.
+
+```python
+SESSIONS = {
+    "welcome_session":        {"phases": [CoachingPhase.INTRODUCTION],                                               "intro": "welcome_session_intro",       "outro": None},
+    "get_to_know_session":    {"phases": [CoachingPhase.GET_TO_KNOW_YOU, CoachingPhase.IDENTITY_WARMUP],             "intro": "get_to_know_session_intro",   "outro": "get_to_know_session_outro"},
+    "brainstorming_session":  {"phases": [CoachingPhase.IDENTITY_BRAINSTORMING, CoachingPhase.BRAINSTORMING_REVIEW], "intro": "brainstorming_session_intro", "outro": "brainstorming_session_outro"},
+    "refinement_session":     {"phases": [CoachingPhase.IDENTITY_REFINEMENT, CoachingPhase.ANYTHING_MISSING],        "intro": "refinement_session_intro",    "outro": "refinement_session_outro"},
+    "commitment_session":     {"phases": [CoachingPhase.IDENTITY_COMMITMENT],                                        "intro": "commitment_session_intro",    "outro": "commitment_session_outro"},
+    "i_am_session":           {"phases": [CoachingPhase.I_AM_STATEMENT],                                             "intro": "i_am_session_intro",          "outro": "i_am_session_outro"},
+    "visualization_session":  {"phases": [CoachingPhase.IDENTITY_VISUALIZATION],                                     "intro": "visualization_session_intro", "outro": None},
+}
+```
+
+Helpers in the same module:
+- `session_of(phase) → session_key`
+- `is_first_phase_of_session(phase) → bool` (intro trigger)
+- `is_last_phase_of_session(phase) → bool` (outro / break trigger)
+
+`welcome_session` and `visualization_session` are intro-only by design — no break after welcome, no break after the final session.
+
+### 2. Video keys are `<session_key>_intro` or `<session_key>_outro`
+
+Examples: `brainstorming_session_intro`, `i_am_session_outro`. This string is:
+- The entry stored in `coach_state.shown_videos`
+- The `video_key` parameter to `ACKNOWLEDGE_SESSION_VIDEO` (set by the server when building the card, never by the LLM)
+- The lookup key in the video registry
 
 ### 3. Storage on CoachState mirrors `asked_questions`
-
-Add a new field to `CoachState`:
 
 ```python
 shown_videos = ArrayField(
@@ -41,170 +63,278 @@ shown_videos = ArrayField(
 )
 ```
 
-One migration. No `Video` DB model. No `Session` model.
+One migration. No `Video` DB model.
 
-### 4. The video registry is a static Python config
+### 4. Video registry is a static Python config
 
-A static `dict` (or similar) maps `video_key → { name, url, phase, position }`. Lives somewhere in `server/` (likely under `enums/` or `services/` — decide during implementation).
-
-Example shape:
+`video_key → { name, url }`. The `SESSIONS` map already encodes which video belongs where; the registry just resolves keys to display data.
 
 ```python
 SESSION_VIDEOS = {
-    "identity_brainstorming_intro": {
-        "name": "Identity Brainstorming Intro",
+    "brainstorming_session_intro": {
+        "name": "Brainstorming Intro",
         "url": "https://<bucket>.s3.amazonaws.com/...",
-        "phase": CoachingPhase.IDENTITY_BRAINSTORMING,
-        "position": "intro",
     },
     ...
 }
 ```
 
-No DB model. No admin editing. The set of coaching videos is small and fixed; if non-developers ever need to edit it, we can promote to a `Video` model later.
-
 ### 5. Video hosting: S3, same pattern as user images
 
-Don't serve videos through Django/Gunicorn — workers streaming large files will choke the backend. Use the same S3 setup that already hosts per-user images. The frontend `<video src>` streams directly from S3 (HTTP range requests work, so basic seeking is supported). Add CloudFront later if mobile scrubbing is bad.
+Frontend `<video src>` streams directly from S3. HTTP range requests work, so basic seeking is supported. CloudFront later if mobile scrubbing is bad. Source files at `dev-coach/videos/`.
 
-Files to upload are in `/Users/work/Downloads/NeoVita Video Files/`.
+### 6. Videos are server-injected — the LLM never invokes them
 
-### 6. Two new actions
+This is the heart of the design. Videos are **not** an LLM tool. The server detects video-relevant moments deterministically and injects video cards as coach messages. The LLM has no awareness videos exist.
 
-**`SHOW_SESSION_VIDEO(video_key)`**
-- Returns a persistent `ComponentConfig` of type `SESSION_VIDEO`
-- Looks up `name` / `url` from the registry
-- Component is rendered in the chat as a **thin card**, not an inline player (see UI section below)
+**Three injection points** in `server/apps/coach/functions/public/process_message.py` and `server/apps/chat_messages/utils/ensure_initial_message_exists.py`:
 
-**`ACKNOWLEDGE_SESSION_VIDEO(video_key)`**
-- Appends `video_key` to `coach_state.shown_videos`
-- This is the **gate**. Recording happens on acknowledgment, NOT on display, so a refresh mid-video doesn't skip the gate.
-- Idempotent (no duplicates).
+**A) Welcome injection — `ensure_initial_message_exists`:**
+Instead of seeding the hardcoded `INITIAL_MESSAGE` text, seed a coach message carrying a `SESSION_VIDEO` ComponentConfig for `welcome_session_intro`, with `text=""` (no greeting text on the card itself). The greeting ("Hi, I'm Leigh-Ann...") is produced by the LLM the first time it runs — which is after the user clicks Continue on the welcome video. The old `INITIAL_MESSAGE` constant is deleted.
 
-### 7. The acknowledgment is what unblocks the coach
+**B) Intro injection — in `process_message`, between `apply_user_component_actions` and `build_coach_prompt`:**
 
-The video's "Continue" button (or auto-fire on the player's `ended` event — frontend's choice) carries the acknowledgment action.
-
-- **Intro video** Continue button → `[ACKNOWLEDGE_SESSION_VIDEO]`. Coach then proceeds with phase content.
-- **Outro video** Continue button → `[ACKNOWLEDGE_SESSION_VIDEO, transition_phase]`. Records + advances to the next phase. This is the documented multi-action persistent-component pattern — persistence-style action goes first.
-
-### 8. Per-phase context key (NOT a generic boolean, NOT the array)
-
-Add ONE new context key whose getter is phase-scoped. It reads `coach_state.current_phase`, consults the registry to find that phase's intro and/or outro video(s), and renders zero/one/two lines naming the specific video by name and its seen status.
-
-Proposed key name: `session_video_status` (open to better names — pick during implementation).
-
-Example renderings:
-
-For Identity Brainstorming, before intro is acknowledged:
-```
-Identity Brainstorming intro video — seen: No
+```python
+# If current_phase is the first phase of a session AND that session's intro
+# has not been acknowledged yet, inject the intro video card as the coach
+# response and skip the LLM call. (Fires after END_BREAK closes a break, and
+# for any first user message in a new session that hasn't seen its intro yet.)
+if pending_session_intro(coach_state):
+    coach_message = inject_session_intro_video(coach_state)
+    return success_response(coach_message)
 ```
 
-For a phase with no videos:
+When the user clicks Continue on the intro card, the frontend dispatches `{message: null, actions: [ACK(intro_key)]}`. The server saves no user ChatMessage (see "process_message null-message contract" below), runs ACK, sees that the intro is now in `shown_videos`, falls through the gate, and the LLM finally runs in the new phase — producing the session's first prompt as a second consecutive coach message after the (now-acked) video card.
+
+**C) Outro injection — in `process_message`, immediately after `apply_coach_response_actions`:**
+
+```python
+# Capture old_phase BEFORE the LLM's actions run; capture new_phase after.
+# If the LLM's transition_phase moved us OUT of the last phase of a session that
+# has an outro, append a SECOND coach message carrying the outro video card.
+# The LLM's text response is KEPT as its in-prompt sign-off; the outro card
+# appears beneath it.
+if just_left_session_with_outro(old_phase, new_phase):
+    inject_session_outro_video(updated_coach_state, leaving_session=session_of(old_phase))
 ```
-(no session videos for this phase)
-```
 
-The prompt author writes the gate sentence ("IMPORTANT - do not proceed until the intro video is shown") above the context key in the phase's prompt. The context key supplies only the named status.
+The `leaving_session` argument is critical: by the time the outro is injected, `current_phase` has already moved into the *next* session, so the helper needs the session being left in order to look up the right outro video key and bake the correct `START_BREAK(session_key=...)` action into the card's Continue button.
 
-**Critical:** the raw `shown_videos` array is never exposed to a prompt. Per-phase resolution lives in the getter.
+**process_message null-message contract:**
+- `message=None` (programmatic-only, from action-only button clicks like video Continue): no user ChatMessage is saved; user actions still apply; LLM is called only if no component_config was returned by user actions AND no intro gate fired.
+- `message=""` (empty string): treated as a real user message — saved as a ChatMessage with empty content. The user shouldn't be able to send this through the UI, but if they do it's handled normally.
+- `message="any text"`: normal user message, saved as ChatMessage.
 
-### 9. UI: thin card + modal player
+**Skip-LLM rule** (after `apply_user_component_actions`): skip the LLM call iff (a) a `component_config` was returned by any user action (e.g., `START_BREAK` returning `SESSION_BREAK`), or (b) the intro gate fired. Otherwise call the LLM — even if no user message was added this turn. The LLM responds based on chat history alone, which works because of component serialization (see below).
 
-Don't put a full `<video>` player inline in the chat — it'd clog history visually.
+**What's NOT in this design:**
+- No `SHOW_SESSION_INTRO_VIDEO` / `SHOW_SESSION_OUTRO_VIDEO` actions
+- No per-session context key
+- No prompt edits, no gate paragraphs
+- The LLM has zero involvement with videos (it neither triggers them nor knows they exist as a feature — it just sees acknowledged-video markers in serialized chat history, see Decision 10)
 
-**Active state (latest message, not yet acknowledged):**
-- Renders a thin card: `<Video Name>` + `[ Watch ]` button
-- Clicking opens a modal containing the `<video>` element
-- On video `ended` (or modal Continue button), fires the acknowledgment action
-- Modal closes; coach proceeds
+### 7. Three user-button actions
+
+Only the user's button clicks invoke actions. The server injects the components; the user closes the loop. **All parameters are baked into the buttons by the server when constructing each card — the LLM never sets any of them.**
+
+- `ACKNOWLEDGE_SESSION_VIDEO(video_key: str)` — appends `video_key` to `shown_videos`. Idempotent. Fires on the video modal's Continue button (see Decision 8 for button timing).
+- `START_BREAK(session_key: str)` — creates a `Break` row with `triggered_by_session = session_key`, returns a `SESSION_BREAK` ComponentConfig. Fires as the second action on the outro video's Continue button. The `session_key` identifies the session being left (NOT the user's current session, which has already advanced by this point — see Decision 6.C).
+- `END_BREAK()` — zero-param. Stamps `ended_at` on the user's single open `Break`. Fires as the only action on the break card's "I'm Ready" button.
+
+**Two dispatch patterns — distinct on purpose:**
+
+- **Video Continue button**: action-only. Frontend dispatches `{message: null, actions: [...]}`. No user ChatMessage is saved. The video is the coach's content; clicking Continue is acknowledgment, not conversation. This means there is no user-message bubble between the video card and whatever comes next.
+- **Break "I'm Ready" button**: canned-response pattern (same as the existing `IntroCannedResponseComponent`). Frontend dispatches `{message: "I'm ready", actions: [END_BREAK()]}`. The button's label becomes a real user ChatMessage that appears in chat history. This is the *only* place in the video flow where a user message is auto-fired by a button click.
+
+**Button action chains:**
+
+- **Intro video** Continue → `{message: null, actions: [ACKNOWLEDGE_SESSION_VIDEO(video_key)]}`. The intro-injection hook stops firing because the key is now in `shown_videos`; the gate falls through and the LLM runs in the new phase. The LLM's response appears as a second consecutive coach message after the (now-acked) video card.
+- **Outro video** Continue → `{message: null, actions: [ACKNOWLEDGE_SESSION_VIDEO(video_key), START_BREAK(session_key)]}`. `START_BREAK` returns the `SESSION_BREAK` component config; the skip-LLM rule fires; the break card is saved as a third consecutive coach message after the LLM's transition text + the outro card.
+- **Break card "I'm Ready"** → `{message: "I'm ready", actions: [END_BREAK()]}`. Saves "I'm ready" as a user message, closes the break, and the intro-injection hook in the same `process_message` call injects the next session's intro card.
+
+**Important: `transition_phase` runs ONCE per session boundary — when the LLM emits it before the outro plays.** It does not appear in any of the user-button chains. By the time the user is interacting with the outro or break card, `current_phase` already reflects the next session. This is what makes `START_BREAK` need an explicit `session_key` parameter (the session being left, not the current one).
+
+### 8. UI: thin card + modal player with threshold-gated Continue button
+
+**Active state (unacknowledged):**
+- Thin card: `<Video Name>` + `[ Watch ]` button
+- Click opens a modal containing the `<video>` element
+- The modal renders a **Continue button** that is disabled until the video reaches a threshold: 20 seconds before the end, OR the 50% mark for videos shorter than 30 seconds. This prevents users from skipping past the content while still letting them dismiss the modal once they've watched it.
+- Clicking Continue fires the bundled actions (`ACKNOWLEDGE_SESSION_VIDEO` and, for outros, also `START_BREAK`) and closes the modal.
+- Closing the modal early (Esc / backdrop click) is allowed — no actions fire, the card stays in active state, they can re-open via Watch.
+- **Composer disabled rule**: while an unacknowledged video card is the latest coach message, the chat composer is disabled. Frontend derives this from `latestMessage.component?.type === SESSION_VIDEO && !shownVideos.includes(latestMessage.component.video_key)`. The user must watch the video (to the threshold) and click Continue before they can type.
 
 **Persisted state (historical, replayable):**
-- Identical thin card: `<Video Name>` + `[ Watch Again ]` button
-- Same modal player, but **no backend action attached** — purely a frontend modal-opener
-- The persisted `component_config` stored on `ChatMessage` only needs `{ video_name, video_url }`
+- Same thin card; `[ Watch ]` button is replaced by `[ Watch Again ]` (label change only — derived from `video_key in shown_videos`)
+- Modal opens, no Continue button rendered, **no backend action on close**
+- Same `component_config` row in the DB — only the frontend rendering differs
 
-**Deviation from existing convention to flag:** The current persistent-components docs say to strip ALL buttons from historical components. We're keeping a `Watch Again` button, but it's frontend-only (opens a modal; no backend interaction). Worth a one-line callout in the spec so it doesn't look like a mistake.
+**Convention deviation to flag in the spec:** persistent-component docs say to strip all buttons from historical components. We keep `Watch Again` because it's frontend-only and doesn't dispatch any action.
 
-### 10. The "break" between sessions is purely narrative
+### 9. Break is a backend-tracked, soft-blocking persistent component
 
-No break screen. No timer. No state.
+After an outro is acknowledged, a `Break` row opens, a `SESSION_BREAK` persistent component renders, and the chat composer is disabled until the user clicks "I'm Ready."
 
-The outro video's *content* tells the client to pause as long as they need. Whenever they return and engage, the next phase's prompt gate fires and the next intro video plays. The pause = the user closing the app, exactly what the outro instructs.
+**Soft block:** no timer, no enforcement. "I'm Ready" is available immediately. The block exists to make pausing the *default* action.
+
+**State (backend only — frontend computes nothing):**
+
+```python
+class Break(models.Model):
+    user = FK(User)
+    started_at = DateTimeField(auto_now_add=True)
+    ended_at = DateTimeField(null=True, blank=True)
+    triggered_by_session = CharField(max_length=255)  # e.g., "brainstorming_session"
+    coach_message = FK(ChatMessage, null=True)
+```
+
+"On a break?" → `Break.objects.filter(user=u, ended_at__isnull=True).exists()`. Duration computed, not stored.
+
+**API:** `on_break: bool` is derived from `Break.objects.filter(user=u, ended_at__isnull=True).exists()` and exposed on **both** the coach response AND the user-state endpoint (so the composer is correctly disabled on initial chat load / refresh, not only after a message round-trip). Frontend disables composer when true.
+
+### 10. LLM continuity via component serialization
+
+Because videos and breaks are server-injected and the LLM has no awareness of them, the chat history must carry enough narrative signal that the LLM can pick up the thread after a session boundary. Without this, the LLM is blind: it sees an unexplained "I'm ready" with no preceding question.
+
+**`get_recent_chat_messages_for_prompt` is updated to render `component_config` into bracketed textual descriptions when serializing for the LLM.** The DB row is unchanged; only the LLM-facing string representation changes. Suggested formats:
+
+- Acked video: `[Showed user the "<video_name>" video. User watched it.]`
+- Unacked video: `[Showed user the "<video_name>" video. User has not watched it yet.]`
+- Closed break: `[Offered user a break. User took it and returned when ready.]`
+- Open break: `[Offered user a break. User has not returned yet.]`
+
+`shown_videos` and the Break table are the sources of truth for acked/closed state at serialization time.
+
+**Also bump the default history `count` from 5 to 10.** A single session boundary can fill 3–5 slots with video/break/intro bubbles, leaving zero room for actual session content. 10 is a defensive minimum.
+
+This is the only piece of "LLM-aware" code in the design, and it's deliberately confined to a serialization helper. The LLM still has no actions, no context keys, and no awareness that videos exist as a feature — it just reads narration in chat history.
+
+## Lifecycle walkthrough (single session boundary, end-to-end)
+
+For Get-to-Know → Brainstorming. Other boundaries follow the same pattern.
+
+| # | Trigger | What happens | ChatMessage rows written | CoachState / Break delta |
+|---|---|---|---|---|
+| 0 | First-ever app open | `ensure_initial_message_exists` seeds welcome video card | COACH: `text=""`, SESSION_VIDEO(welcome_session_intro) | — |
+| 1 | User clicks Continue on welcome | Frontend `{message: null, actions: [ACK(welcome_session_intro)]}`. No user msg. ACK runs. Gate falls through. LLM runs in INTRODUCTION. | COACH: "Hi, I'm Leigh-Ann..." | `shown_videos += welcome_session_intro` |
+| ~ | Normal back-and-forth in INTRODUCTION | LLM converses with user, eventually emits `transition_phase(GET_TO_KNOW_YOU)` | (many USER/COACH rows) | `current_phase = GET_TO_KNOW_YOU` |
+| 2 | User's next typed message in GET_TO_KNOW_YOU | Gate fires: `pending_session_intro` TRUE. Skip LLM. Inject. | USER: "OK!", COACH: SESSION_VIDEO(get_to_know_session_intro) | — |
+| 3 | User clicks Continue on get-to-know intro | `{message: null, actions: [ACK]}`. No user msg. ACK runs. Gate falls through. LLM runs in GET_TO_KNOW_YOU. | COACH: "Now let me ask you about..." | `shown_videos += get_to_know_session_intro` |
+| ~ | Normal back-and-forth through GET_TO_KNOW_YOU + IDENTITY_WARMUP | LLM converses, eventually transitions to IDENTITY_BRAINSTORMING | (many USER/COACH rows) | `current_phase = IDENTITY_BRAINSTORMING` |
+| 4 | LLM transition turn (the boundary) | LLM responds with "Beautiful work, take a moment" + `transition_phase`. After `apply_coach_response_actions`, outro detection fires. Outro card injected as second coach message. | COACH: "Beautiful work...", COACH: SESSION_VIDEO(get_to_know_session_outro) | `current_phase = IDENTITY_BRAINSTORMING` |
+| 5 | User clicks Continue on outro | `{message: null, actions: [ACK(outro_key), START_BREAK("get_to_know_session")]}`. No user msg. ACK runs. START_BREAK returns SESSION_BREAK component → skip-LLM rule fires. | COACH: SESSION_BREAK | `shown_videos += outro`; Break row opens; `on_break = true`; composer disabled |
+| 6 | User clicks "I'm Ready" on break (maybe hours later) | `{message: "I'm ready", actions: [END_BREAK()]}`. User msg saved. END_BREAK closes break. Gate fires: `pending_session_intro` TRUE for brainstorming. Skip LLM. Inject. | USER: "I'm ready", COACH: SESSION_VIDEO(brainstorming_session_intro) | Break `ended_at` stamped; `on_break = false`; composer disabled (unacked video latest) |
+| 7 | User clicks Continue on brainstorming intro | `{message: null, actions: [ACK(brainstorming_session_intro)]}`. No user msg. ACK runs. Gate falls through. LLM runs in IDENTITY_BRAINSTORMING. | COACH: "Welcome to brainstorming!..." | `shown_videos += brainstorming intro`; composer re-enabled |
+| 8+ | Normal IDENTITY_BRAINSTORMING conversation | ... | ... | ... |
+
+**Key invariants:**
+- One user-message bubble per boundary ("I'm ready" at step 6). Everything else is coach-driven.
+- LLM is called at steps 1, 3, 4, 7 (and during normal conversation). LLM is *not* called at steps 0, 2, 5, 6.
+- Two or three consecutive coach messages per boundary is normal (steps 4–5, 6–7, 0–1).
+- The video DB rows from steps 0, 2, 4, 6 never change after the ACK — only `shown_videos` updates, and the frontend re-derives Watch vs Watch Again from that.
+
+## Sessions & videos
+
+Files at `dev-coach/videos/` (renamed to match session keys). Number prefix = play order; remainder of the filename = the video key (dashes → underscores).
+
+| # | File | Session | Position | Phases in session |
+|---|---|---|---|---|
+| 01 | `01-welcome-session-intro.mov`            | `welcome_session`        | intro | INTRODUCTION |
+| 02 | `02-get-to-know-session-intro.mov`        | `get_to_know_session`    | intro | GET_TO_KNOW_YOU → IDENTITY_WARMUP |
+| 03 | `03-get-to-know-session-outro.mov`        | `get_to_know_session`    | outro | (fires after IDENTITY_WARMUP) |
+| 04 | `04-brainstorming-session-intro.mov`      | `brainstorming_session`  | intro | IDENTITY_BRAINSTORMING → BRAINSTORMING_REVIEW |
+| 05 | `05-brainstorming-session-outro.mov`      | `brainstorming_session`  | outro | (fires after BRAINSTORMING_REVIEW) |
+| 06 | `06-refinement-session-intro.mov`         | `refinement_session`     | intro | IDENTITY_REFINEMENT → ANYTHING_MISSING |
+| 07 | `07-refinement-session-outro.mov`         | `refinement_session`     | outro | (fires after ANYTHING_MISSING) |
+| 08 | `08-commitment-session-intro.mov`         | `commitment_session`     | intro | IDENTITY_COMMITMENT |
+| 09 | `09-commitment-session-outro.mov`         | `commitment_session`     | outro | (fires after IDENTITY_COMMITMENT) |
+| 10 | `10-i-am-session-intro.mov`               | `i_am_session`           | intro | I_AM_STATEMENT |
+| 11 | `11-i-am-session-outro.mov`               | `i_am_session`           | outro | (fires after I_AM_STATEMENT) |
+| 12 | `12-visualization-session-intro.mov`      | `visualization_session`  | intro | IDENTITY_VISUALIZATION |
+
+**Asymmetry (intentional):** `welcome_session` and `visualization_session` are intro-only — no outro, no break.
+
+**Caveat:** the mapping is mutable. The architecture treats the `SESSIONS` map and registry as data.
 
 ## Rejected alternatives (do not re-propose)
 
 | Idea | Why rejected |
 |---|---|
-| `current_session` field on CoachState | Sessions don't exist in code; derivable from `current_phase` if ever needed |
-| `SESSIONS` map / enum | Same — sessions are a human concept, not a code one |
-| Generic `INTRO_VIDEO_SEEN` / `OUTRO_VIDEO_SEEN` booleans | Confusing — "which one?" Replaced with self-describing phase-scoped status that names the video |
-| Exposing the raw `shown_videos` array as a context key | Invites prompt mistakes — each prompt only cares about its own phase's videos |
-| Full inline `<video>` player as the persistent component | Clogs chat history visually. Replaced with thin card + modal |
-| Break screen / timer / locked state between sessions | Pause is narrative-only; user decides when to come back |
-| New `Video` DB model | Set of videos is small and fixed; static registry is enough |
+| LLM-driven `SHOW_SESSION_INTRO/OUTRO_VIDEO` actions | Server can derive video timing deterministically from phase transitions. Removes prompt-engineering surface and eliminates the hallucination risk entirely |
+| Per-session context key + prompt gates | Not needed once videos are server-injected. The LLM never sees video state |
+| Narrative-only break / no break state | Break is a real, backend-tracked, soft-blocking concept |
+| `current_session` field on `CoachState` | Derivable from `current_phase` + `SESSIONS` map |
+| Parallel `SessionType` enum | Sessions live as metadata next to `CoachingPhase`, not as a parallel enum |
+| Exposing the raw `shown_videos` array as a context key | Moot — no context key at all in current design |
+| Full inline `<video>` player as the persistent component | Clogs chat history. Thin card + modal instead |
+| New `Video` DB model | Set is small and fixed; static registry is enough |
 | Serving video through Django | Will choke backend workers. S3 direct |
-| Recording video as "shown" on display | Refresh mid-video would skip the gate. Record on acknowledgment instead |
+| Recording video as "shown" on display | Refresh mid-video would skip the gate. Record on acknowledgment |
 
-## Video inventory
+## Resolved questions (previously open)
 
-Files at `/Users/work/Downloads/NeoVita Video Files/`:
+1. **Modal close behavior** — modal renders a Continue button that's disabled until 20s before the video ends (or the 50% mark for videos shorter than 30s). ACK fires on Continue click. Closing the modal early via Esc/backdrop is allowed and fires no action.
+2. **Video file naming** — files renamed on disk to match session keys (see Sessions & videos table above). Registry maps `video_key → {name, url}`; filename and key are kept in sync as a convention.
+3. **Response shape for outro turn** — `process_message` returns multiple coach messages when an outro is injected. The LLM's transition text and the outro video card are saved as two separate ChatMessage rows and both returned in the response. Frontend renders them in order. (See Decision 6.C and the lifecycle walkthrough.)
 
-| File | Likely phase | Likely position |
-|---|---|---|
-| `welcome video 1.mov` | Introduction | intro (part 1?) |
-| `Welcome video 2.mov` | Introduction | intro (part 2?) |
-| `Welcome video outro .mov` | (end of opening session) | outro |
-| `identity branstorming intro .mov` | Identity Brainstorming | intro |
-| `identity brainstorming outro.mov` | Identity Brainstorming | outro |
-| `identity refienement intro.mov` | Identity Refinement | intro |
-| `identity refinement outro.mov` | Identity Refinement | outro |
-| `identity commitment intro.mov` | Identity Commitment | intro |
-| `identity commitment outro.mov` | Identity Commitment | outro |
-| `I am statement intro .mov` | I Am Statement | intro |
-| `i am statements outro.mov` | I Am Statement | outro |
-| `Movie on 5-7-26 at 5.38 PM.mov` | unknown | unknown |
+## Edge cases explicitly out of scope for v1
 
-Phases with **no** video (per current inventory): `get_to_know_you`, `identity_warm_up`, `brainstorming_review`, `anything_missing`, `identity_visualization`. The registry simply omits them.
-
-## Open questions for the next agent / for Casey
-
-1. **welcome video 1 vs welcome video 2** — sequential parts of the Introduction intro, or one is for a different phase (e.g., Get To Know You)?
-2. **Welcome video outro** — which phase's *exit* does this play on? End of Introduction? End of Identity Warm-Up? (This is the boundary of the first "session".)
-3. **Movie on 5-7-26 at 5.38 PM.mov** — what is this? A re-record, a test, a real phase video, or trash?
-4. Are the silent phases above truly silent, or are some of those waiting on videos Leigh Ann hasn't sent yet?
-5. Confirm the static registry approach is right vs. promoting to a `Video` model (likely Yes — static is enough for now).
-6. Confirm the deviation from the "strip all buttons from historical components" convention (the `Watch Again` modal-opener button) is acceptable.
-7. Final name for the new context key (`session_video_status` is a placeholder).
-8. Modal close behavior — does the Continue button fire on `ended`, on click, or both?
+- Mid-watch chat reload showing an "unacked" video in serialized history (rare; serialization helper just renders "User has not watched it yet" — no special UX).
+- Modal early-close + retry flow optimization.
+- Anything beyond the threshold-Continue / Watch-Again / composer-disable behavior.
 
 ## Net surface area to build
 
 | Piece | Notes |
 |---|---|
-| **DB migration** | Add `shown_videos` ArrayField to `CoachState` |
-| **Video registry** | Static Python dict; one module |
-| **Action** | `SHOW_SESSION_VIDEO(video_key)` — returns ComponentConfig of type `SESSION_VIDEO` |
-| **Action** | `ACKNOWLEDGE_SESSION_VIDEO(video_key)` — appends to `shown_videos`, idempotent |
-| **Action enum** | Two new `ActionType` values |
-| **Component type enum** | One new `ComponentType.SESSION_VIDEO` |
-| **Context key** | One new per-phase status key (e.g., `session_video_status`) + its getter |
-| **React component** | Thin card + modal player; same component drives active and persisted |
-| **Persistence** | Reuses existing `component_config` on `ChatMessage` and dual-rendering detection |
-| **Prompt edits** | Each phase that has an intro/outro video: a gate paragraph at top (intro) and instruction on completion (outro) |
-| **S3 upload** | One-time upload of video files to the existing S3 bucket |
+| **`SESSIONS` map + helpers** | In `server/enums/coaching_phase.py` |
+| **Migration: `shown_videos`** | ArrayField on `CoachState` |
+| **Migration: `Break` model** | `user`, `started_at`, `ended_at`, `triggered_by_session`, `coach_message` |
+| **Video registry** | Static dict `video_key → { name, url }` |
+| **Server injection hooks** | `pending_session_intro`, `inject_session_intro_video`, `just_left_session_with_outro`, `inject_session_outro_video` — all wired into `process_message` (intro hook between user-action and LLM call; outro hook immediately after `apply_coach_response_actions` returns) |
+| **`process_message` null-message contract** | Accept `message: None` programmatically (no user ChatMessage saved; user actions still apply). `message=""` still treated as a real user message. Skip-LLM rule: skip iff user action returned a component_config OR intro gate fired. |
+| **`ensure_initial_message_exists` rewrite** | Seed welcome video card (text="", no greeting) instead of `INITIAL_MESSAGE` text. Delete the `INITIAL_MESSAGE` constant. |
+| **`get_recent_chat_messages_for_prompt` rewrite** | Serialize `component_config` into bracketed descriptions for the LLM. Bump default count from 5 → 10. |
+| **Action: `ACKNOWLEDGE_SESSION_VIDEO(video_key)`** | Appends to `shown_videos`; key set by server, not LLM |
+| **Action: `START_BREAK(session_key)`** | Creates Break row (`triggered_by_session = session_key`), returns SESSION_BREAK component. `session_key` is set by the server when building the outro card's button. |
+| **Action: `END_BREAK()`** | Stamps `ended_at` on open Break |
+| **ActionType enum** | 3 new values |
+| **ComponentType enum** | 2 new: `SESSION_VIDEO`, `SESSION_BREAK` |
+| **API field** | `on_break: bool` on coach response AND user-state endpoint |
+| **API response shape** | Coach response now returns a list of coach messages (to support outro injected alongside LLM text), not a single message |
+| **React: video card** | Thin card + modal player with threshold-gated Continue button (20s before end, or 50% for short videos); same component drives active (Watch) and persisted (Watch Again) state |
+| **React: break card** | "I'm Ready" button (canned-response pattern: dispatches `{message: "I'm ready", actions: [END_BREAK()]}`); composer disabled while open via `on_break` |
+| **React: composer disable rule** | Disable composer when latest coach message is an unacked SESSION_VIDEO, OR when `on_break === true` |
+| **S3 upload** | One-time upload of the 12 video files |
+| **Procedure doc** | NOP-style "Add a Session Video" Procedures MCP doc. First-class deliverable. |
+
+**Explicitly NOT in scope:** prompt edits, per-session context key, SHOW actions. The LLM is untouched (the serialization helper is a *read-side* shim, not a prompt edit).
 
 ## Pointers to existing Procedures docs the next agent should read first
 
-- `system / dev-coach / coach / phases` — the full phase model
-- `system / dev-coach / core-systems / component-renderer / persistent-components` — the persistence pattern this feature reuses
-- `system / dev-coach / core-systems / component-renderer / overview` — base component system
-- `system / dev-coach / core-systems / action-handler / overview` — action registry pattern
-- `system / dev-coach / core-systems / prompt-manager / context-keys / asked-questions` — the gate pattern this mirrors
-- `system / dev-coach / core-systems / action-handler / actions / update-asked-questions` — the storage pattern this mirrors
-- `system / dev-coach / core-systems / action-handler / actions / transition-phase` — what the outro button's second action invokes
+- `system / dev-coach / coach / phases`
+- `system / dev-coach / core-systems / component-renderer / persistent-components`
+- `system / dev-coach / core-systems / component-renderer / overview`
+- `system / dev-coach / core-systems / action-handler / overview`
+- `system / dev-coach / core-systems / action-handler / actions / transition-phase`
 
 ## Next step in the workflow
 
-Per the standard workflow: feed this brain-dump to the `/decompose` agent to break it into atomic PRs (likely: 1) DB migration + video registry, 2) actions + component type, 3) frontend component + modal, 4) context key + prompt edits, 5) S3 upload + final wiring — but decompose will decide).
+Hand this document to the **plan agent** as the spec. The lifecycle walkthrough above is the ground truth for the runtime flow; the Net surface area table is the ground truth for what to build.
+
+Non-negotiable instructions for the plan agent:
+
+1. Treat the session/video mapping as mutable data. Nothing outside the `SESSIONS` map / video registry should name specific videos or sessions.
+2. The plan must produce the "Add a Session Video" Procedures MCP doc alongside the code PRs.
+3. The break is part of the flow — not a stretch goal.
+4. **Do not add SHOW video actions, context keys, or prompt edits.** Videos are server-injected. The only LLM-facing change is the read-side serialization helper in `get_recent_chat_messages_for_prompt`.
+5. Preserve the `message: None` vs `message: ""` distinction in `process_message` — `None` is programmatic-only, `""` is treated as a real user message.
+
+Likely PR decomposition (plan agent has final say). **Order matters** — later PRs depend on earlier ones:
+
+1. **Foundation:** `SESSIONS` map + helpers in `coaching_phase.py`, `shown_videos` migration on `CoachState`, `Break` model migration, video registry skeleton, new ActionType + ComponentType enum values.
+2. **User-button actions:** `ACKNOWLEDGE_SESSION_VIDEO`, `START_BREAK`, `END_BREAK` handlers (needed before injection helpers can wire buttons to them).
+3. **Server injection layer + process_message overhaul:** intro-injection + outro-injection helpers wired into `process_message`, `process_message` null-message contract + skip-LLM rule, `ensure_initial_message_exists` rewrite (delete `INITIAL_MESSAGE`), `get_recent_chat_messages_for_prompt` component serialization + count bump, `on_break` API field on coach response + user-state endpoint, multi-message response shape.
+4. **Frontend:** video card + modal player with threshold-gated Continue button + break card; composer disable wired to `on_break` AND unacked-video-is-latest; multi-message response handling.
+5. **Content:** S3 upload + populate the full video registry.
+6. **Docs:** the "Add a Session Video" Procedures MCP doc.


### PR DESCRIPTION
## Summary
- Adds `notes/coaching-phase-videos.md` — feature spec for showing pre-recorded session videos at coaching phase boundaries. Uses **handler-driven injection** (Approach C): `transition_phase` and `END_BREAK` action handlers attach video components to coach messages; the LLM has zero awareness videos exist.
- Adds `notes/coaching-phase-videos-prs.md` — 25-PR implementation plan with a verified Codebase paths reference, the action-handler registration contract, and per-PR file lists with concrete paths.
- Includes the locked-in Summer Program flag pattern for `COACHING_PHASE_VIDEOS_ENABLED` (hardcoded boolean in `settings/common.py`, exposed via `GET /api/v1/core/public/coaching-phase-videos/`).

## Scope
**Documentation only.** No production code changes. Implementation lands as the 25 separate PRs against `main` per the plan.

## Test plan
- [ ] N/A — planning artifacts only

🤖 Generated with [Claude Code](https://claude.com/claude-code)