### PR TITLE
feat(cpv): Add COACHING_PHASE_VIDEOS_ENABLED feature flag (PR 1/25)

### DIFF
--- a/notes/coaching-phase-videos-prs.md
+++ b/notes/coaching-phase-videos-prs.md
@@ -138,7 +138,7 @@ def my_action(
 
 | #   | Title                                                                       | Branch                                       | Status | Claim | PR  | Logical deps |
 |-----|-----------------------------------------------------------------------------|----------------------------------------------|--------|-------|-----|--------------|
-| 1   | Feature flag scaffold                                                       | `casey/cpv-01-feature-flag`                  | `[~]`  | casey 2026-05-24 | —   | — |
+| 1   | Feature flag scaffold                                                       | `casey/cpv-01-feature-flag`                  | `[👀]` | casey 2026-05-24 | [#89](https://github.com/Discovita/dev-coach/pull/89) | — |
 | 2   | SESSIONS map + helpers                                                      | `casey/cpv-02-sessions-map`                  | `[ ]`  | —     | —   | — |
 | 3   | `CoachState.shown_videos` migration                                         | `casey/cpv-03-shown-videos-migration`        | `[ ]`  | —     | —   | — |
 | 4   | `Break` model + migration                                                   | `casey/cpv-04-break-model`                   | `[ ]`  | —     | —   | — |

--- a/notes/coaching-phase-videos-prs.md
+++ b/notes/coaching-phase-videos-prs.md
@@ -138,7 +138,7 @@ def my_action(
 
 | #   | Title                                                                       | Branch                                       | Status | Claim | PR  | Logical deps |
 |-----|-----------------------------------------------------------------------------|----------------------------------------------|--------|-------|-----|--------------|
-| 1   | Feature flag scaffold                                                       | `casey/cpv-01-feature-flag`                  | `[ ]`  | —     | —   | — |
+| 1   | Feature flag scaffold                                                       | `casey/cpv-01-feature-flag`                  | `[~]`  | casey 2026-05-24 | —   | — |
 | 2   | SESSIONS map + helpers                                                      | `casey/cpv-02-sessions-map`                  | `[ ]`  | —     | —   | — |
 | 3   | `CoachState.shown_videos` migration                                         | `casey/cpv-03-shown-videos-migration`        | `[ ]`  | —     | —   | — |
 | 4   | `Break` model + migration                                                   | `casey/cpv-04-break-model`                   | `[ ]`  | —     | —   | — |
@@ -949,4 +949,10 @@ When `settings.COACHING_PHASE_VIDEOS_ENABLED` is `False`, this enrichment short-
 
 > Append-only log. Add entries with date + your handle + what you found. The next agent should read this top-to-bottom before starting work.
 
-_(empty)_
+### 2026-05-24 — casey — PR 1
+
+- **Endpoint URL has no trailing slash.** The dev-coach `default_router` is `DefaultRouter(trailing_slash=False)`, so the public endpoint is `GET /api/v1/core/public/coaching-phase-videos` (not `…/`). This diverges from the spec text — the spec was written with a trailing slash matching the Summer Program reference, but in homeschool-backend the router uses `trailing_slash=True`. Match this convention in any FE fetch later.
+- **`pytest server/` from the repo root collects two pre-existing collection errors** (`apps/test_scenario/admin/test_scenario_admin.py` and `apps/test_scenario/models/test_scenario.py`) because they match `test_*.py` but aren't tests. The issue exists on `main` independently of this PR. Workaround when running the full suite: `pytest --ignore=apps/test_scenario/admin --ignore=apps/test_scenario/models --ignore=apps/test_scenario/views`. With those ignores, the full suite is 654 passing on this branch.
+- **Tests must run inside the backend container.** Test settings (`settings.test`) point at `LOCAL_DB_HOST=db` (the Docker compose hostname). Use: `COMPOSE_PROJECT_NAME=dev-coach-local docker compose --profile local -f docker/docker-compose.yml -f docker/docker-compose.local.yml exec backend pytest <path>`.
+- **`apps/core/functions/` did not exist before PR 1.** Created `__init__.py` for both `functions/` and `functions/public/`. The convention is to re-export from `apps.core.functions` (mirroring how `apps.core.views.__init__` aggregates).
+- **No frontend hook added.** Per the PR spec, backend handlers gate their own behavior on `settings.COACHING_PHASE_VIDEOS_ENABLED`. The endpoint exists for future FE wiring (e.g., banner outside chat) but nothing consumes it yet.

--- a/server/apps/api_urls.py
+++ b/server/apps/api_urls.py
@@ -13,7 +13,7 @@ from apps.authentication.views import AuthViewSet
 
 # Local Modules - Admin Viewsets
 from apps.coach.views import AdminCoachViewSet, CoachViewSet
-from apps.core.views import CoreViewSet
+from apps.core.views import CoachingPhaseVideosViewSet, CoreViewSet
 from apps.identities.views import (
     AdminIdentityImageChatViewSet,
     AdminIdentityViewSet,
@@ -35,6 +35,11 @@ brand_web_router = DefaultRouter(trailing_slash=False)  # brand web
 default_router.register(r"auth", AuthViewSet, basename="auth")
 default_router.register(r"prompts", PromptViewSet, basename="prompts")
 default_router.register(r"core", CoreViewSet, basename="core")
+default_router.register(
+    r"core/public/coaching-phase-videos",
+    CoachingPhaseVideosViewSet,
+    basename="core-public-coaching-phase-videos",
+)  # Public Coaching Phase Videos config (feature flag)
 default_router.register(r"coach", CoachViewSet, basename="coach")
 default_router.register(r"user", UserViewSet, basename="user")
 default_router.register(r"identities", IdentityViewSet, basename="identities")

--- a/server/apps/core/functions/__init__.py
+++ b/server/apps/core/functions/__init__.py
@@ -1,0 +1,9 @@
+"""
+Core app functions — public re-exports.
+"""
+
+from apps.core.functions.public.get_coaching_phase_videos import (
+    get_coaching_phase_videos,
+)
+
+__all__ = ["get_coaching_phase_videos"]

--- a/server/apps/core/functions/public/__init__.py
+++ b/server/apps/core/functions/public/__init__.py
@@ -1,0 +1,9 @@
+"""
+Public Core functions — re-exports for consumption by views and other apps.
+"""
+
+from apps.core.functions.public.get_coaching_phase_videos import (
+    get_coaching_phase_videos,
+)
+
+__all__ = ["get_coaching_phase_videos"]

--- a/server/apps/core/functions/public/get_coaching_phase_videos.py
+++ b/server/apps/core/functions/public/get_coaching_phase_videos.py
@@ -1,0 +1,29 @@
+"""
+get_coaching_phase_videos — returns the current Coaching Phase Videos config.
+
+Reads from Django settings. The return shape is the API contract.
+
+Used by:
+- apps/core/views/coaching_phase_videos_view_set.py
+  (GET /api/v1/core/public/coaching-phase-videos)
+"""
+
+from typing import TypedDict
+
+from django.conf import settings
+
+
+class CoachingPhaseVideosConfig(TypedDict):
+    enabled: bool
+
+
+def get_coaching_phase_videos() -> CoachingPhaseVideosConfig:
+    """
+    Return the Coaching Phase Videos config as a JSON-serializable dict.
+
+    Always returns the full shape regardless of whether the feature is
+    enabled — the frontend decides what to render based on `enabled`.
+    """
+    return {
+        "enabled": settings.COACHING_PHASE_VIDEOS_ENABLED,
+    }

--- a/server/apps/core/tests/test_coaching_phase_videos_endpoint.py
+++ b/server/apps/core/tests/test_coaching_phase_videos_endpoint.py
@@ -1,0 +1,54 @@
+"""
+Tests for the GET /api/v1/core/public/coaching-phase-videos endpoint.
+
+Verifies public accessibility and that the feature flag flows through
+from Django settings to the HTTP response.
+"""
+
+from django.test import TestCase, override_settings
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+class CoachingPhaseVideosEndpointTests(TestCase):
+    """Tests for the GET /api/v1/core/public/coaching-phase-videos endpoint."""
+
+    def setUp(self):
+        self.client = APIClient()
+        # trailing_slash=False on default_router
+        self.url = "/api/v1/core/public/coaching-phase-videos"
+
+    def test_returns_200(self):
+        """Should return 200 OK."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_accessible_without_authentication(self):
+        """Should be publicly accessible — no auth required."""
+        self.client.logout()
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_response_has_expected_keys(self):
+        """Should return all documented keys."""
+        response = self.client.get(self.url)
+        self.assertEqual(set(response.data.keys()), {"enabled"})
+
+    @override_settings(COACHING_PHASE_VIDEOS_ENABLED=True)
+    def test_reflects_enabled_flag_when_on(self):
+        """Should reflect COACHING_PHASE_VIDEOS_ENABLED=True in the response."""
+        response = self.client.get(self.url)
+        self.assertTrue(response.data["enabled"])
+
+    @override_settings(COACHING_PHASE_VIDEOS_ENABLED=False)
+    def test_reflects_enabled_flag_when_off(self):
+        """Should still return full shape when the flag is off."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data["enabled"])
+        self.assertEqual(set(response.data.keys()), {"enabled"})
+
+    def test_post_not_allowed(self):
+        """Should reject POST — read-only endpoint."""
+        response = self.client.post(self.url, data={})
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/server/apps/core/tests/test_get_coaching_phase_videos.py
+++ b/server/apps/core/tests/test_get_coaching_phase_videos.py
@@ -1,0 +1,35 @@
+"""
+Tests for the get_coaching_phase_videos function.
+
+Verifies that the function reads Django settings and always returns the
+full config shape regardless of whether the feature is enabled.
+"""
+
+from django.test import TestCase, override_settings
+
+from apps.core.functions import get_coaching_phase_videos
+
+
+class GetCoachingPhaseVideosTests(TestCase):
+    """Tests for the get_coaching_phase_videos function."""
+
+    def test_returns_full_shape(self):
+        """Should return every documented key."""
+        result = get_coaching_phase_videos()
+        self.assertEqual(set(result.keys()), {"enabled"})
+
+    @override_settings(COACHING_PHASE_VIDEOS_ENABLED=True)
+    def test_reflects_enabled_true(self):
+        """Should pass through the feature flag when on."""
+        self.assertTrue(get_coaching_phase_videos()["enabled"])
+
+    @override_settings(COACHING_PHASE_VIDEOS_ENABLED=False)
+    def test_reflects_enabled_false(self):
+        """Should pass through the feature flag when off."""
+        self.assertFalse(get_coaching_phase_videos()["enabled"])
+
+    @override_settings(COACHING_PHASE_VIDEOS_ENABLED=False)
+    def test_returns_full_shape_even_when_disabled(self):
+        """Shape doesn't shrink based on flag."""
+        result = get_coaching_phase_videos()
+        self.assertEqual(set(result.keys()), {"enabled"})

--- a/server/apps/core/views/__init__.py
+++ b/server/apps/core/views/__init__.py
@@ -2,6 +2,9 @@
 Core app viewsets.
 """
 
+from apps.core.views.coaching_phase_videos_view_set import (
+    CoachingPhaseVideosViewSet,
+)
 from apps.core.views.core_view_set import CoreViewSet
 
-__all__ = ["CoreViewSet"]
+__all__ = ["CoachingPhaseVideosViewSet", "CoreViewSet"]

--- a/server/apps/core/views/coaching_phase_videos_view_set.py
+++ b/server/apps/core/views/coaching_phase_videos_view_set.py
@@ -1,0 +1,39 @@
+"""
+CoachingPhaseVideosViewSet — public endpoint exposing the Coaching Phase
+Videos feature config.
+
+Served under /api/v1/core/public/ so future public feature-flagged config
+can slot in under the same namespace (e.g. core/public/<next-feature>/).
+"""
+
+import logging
+
+from rest_framework import status, viewsets
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from apps.core.functions import get_coaching_phase_videos
+
+log = logging.getLogger(__name__)
+
+
+class CoachingPhaseVideosViewSet(viewsets.GenericViewSet):
+    """
+    ViewSet for the public Coaching Phase Videos config.
+
+    Endpoints (trailing_slash=False router):
+        GET /api/v1/core/public/coaching-phase-videos → list()
+    """
+
+    permission_classes = [AllowAny]
+
+    def list(self, request: Request) -> Response:
+        """
+        GET /api/v1/core/public/coaching-phase-videos
+
+        Return the Coaching Phase Videos config. Always returns the full
+        shape; the `enabled` flag tells the frontend whether to render
+        video/break components.
+        """
+        return Response(get_coaching_phase_videos(), status=status.HTTP_200_OK)

--- a/server/settings/common.py
+++ b/server/settings/common.py
@@ -291,3 +291,15 @@ VERSATILEIMAGEFIELD_SETTINGS = {
 CELERY_WORKER_CONCURRENCY = 1               # one fork, one Django copy
 CELERY_WORKER_MAX_TASKS_PER_CHILD = 50      # recycle worker after N tasks
 CELERY_WORKER_MAX_MEMORY_PER_CHILD = 400000  # recycle if RSS exceeds ~400 MB (KB)
+
+#########################################
+# COACHING PHASE VIDEOS
+#########################################
+# Config for the Coaching Phase Videos feature (pre-recorded videos shown at
+# coaching session boundaries). Served publicly to the frontend via
+# GET /api/v1/core/public/coaching-phase-videos so the UI can decide whether
+# to expect / render video and break components.
+#
+# COACHING_PHASE_VIDEOS_ENABLED is the feature flag — flip it to control
+# visibility without an env-var change. Flipping is a code change + deploy.
+COACHING_PHASE_VIDEOS_ENABLED = False


### PR DESCRIPTION
## Summary

First PR in the 25-PR [Coaching Phase Videos series](../blob/main/notes/coaching-phase-videos-prs.md). Sets up the feature flag scaffold using the Summer Program pattern from homeschool-backend.

- New hardcoded boolean `COACHING_PHASE_VIDEOS_ENABLED` in `server/settings/common.py` (default `False`)
- New `get_coaching_phase_videos()` helper (TypedDict config) under `apps/core/functions/public/`
- New `CoachingPhaseVideosViewSet` exposed at `GET /api/v1/core/public/coaching-phase-videos` (AllowAny, list-only — always returns the full shape regardless of flag value)
- Endpoint registered on `default_router` as `core-public-coaching-phase-videos`
- 10 pytest tests covering the helper (shape, flag pass-through both directions) and the endpoint (200, no-auth, expected keys, flag pass-through, POST 405)

Backend handlers in later PRs gate their own behavior on `settings.COACHING_PHASE_VIDEOS_ENABLED` directly. Flipping the flag in PR 22 is a one-line code change + deploy. The endpoint exists for future frontend wiring; nothing consumes it yet.

## Notable differences vs spec

- **URL has no trailing slash** (`/api/v1/core/public/coaching-phase-videos` not `…/`) — the dev-coach `default_router` is `DefaultRouter(trailing_slash=False)`. Spec text was written assuming the homeschool-backend convention (which uses `trailing_slash=True`). Captured in the Discoveries log so PR 15+ frontend fetches match.

## Test plan

- [x] `pytest apps/core/tests/test_get_coaching_phase_videos.py apps/core/tests/test_coaching_phase_videos_endpoint.py` — 10/10 passing inside backend container
- [x] Full backend suite (`pytest --ignore=apps/test_scenario/admin --ignore=apps/test_scenario/models --ignore=apps/test_scenario/views`) — 654/654 passing
- [x] Pre-existing pytest collection errors on `apps/test_scenario/*` confirmed to exist on `main` (unrelated to this PR — documented in Discoveries)
- [x] Manual: `curl http://localhost:8000/api/v1/core/public/coaching-phase-videos` returns `{"enabled": false}` with HTTP 200, no auth
- [x] Plan file updated: status row + Discoveries log entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)