### PR TITLE
feat(cpv): Add SESSIONS map + helpers to coaching_phase enum (PR 2/25)

### DIFF
--- a/notes/coaching-phase-videos-prs.md
+++ b/notes/coaching-phase-videos-prs.md
@@ -139,7 +139,7 @@ def my_action(
 | #   | Title                                                                       | Branch                                       | Status | Claim | PR  | Logical deps |
 |-----|-----------------------------------------------------------------------------|----------------------------------------------|--------|-------|-----|--------------|
 | 1   | Feature flag scaffold                                                       | `casey/cpv-01-feature-flag`                  | `[✓]`  | casey 2026-05-24 | [#89](https://github.com/Discovita/dev-coach/pull/89) merged `5e3919d` 2026-05-24 | — |
-| 2   | SESSIONS map + helpers                                                      | `casey/cpv-02-sessions-map`                  | `[ ]`  | —     | —   | — |
+| 2   | SESSIONS map + helpers                                                      | `casey/cpv-02-sessions-map`                  | `[~]`  | casey 2026-05-24 | —   | — |
 | 3   | `CoachState.shown_videos` migration                                         | `casey/cpv-03-shown-videos-migration`        | `[ ]`  | —     | —   | — |
 | 4   | `Break` model + migration                                                   | `casey/cpv-04-break-model`                   | `[ ]`  | —     | —   | — |
 | 5   | Video registry + new enum values                                            | `casey/cpv-05-video-registry-enums`          | `[ ]`  | —     | —   | 2 |

--- a/notes/coaching-phase-videos-prs.md
+++ b/notes/coaching-phase-videos-prs.md
@@ -139,7 +139,7 @@ def my_action(
 | #   | Title                                                                       | Branch                                       | Status | Claim | PR  | Logical deps |
 |-----|-----------------------------------------------------------------------------|----------------------------------------------|--------|-------|-----|--------------|
 | 1   | Feature flag scaffold                                                       | `casey/cpv-01-feature-flag`                  | `[✓]`  | casey 2026-05-24 | [#89](https://github.com/Discovita/dev-coach/pull/89) merged `5e3919d` 2026-05-24 | — |
-| 2   | SESSIONS map + helpers                                                      | `casey/cpv-02-sessions-map`                  | `[~]`  | casey 2026-05-24 | —   | — |
+| 2   | SESSIONS map + helpers                                                      | `casey/cpv-02-sessions-map`                  | `[👀]` | casey 2026-05-24 | [#90](https://github.com/Discovita/dev-coach/pull/90) | — |
 | 3   | `CoachState.shown_videos` migration                                         | `casey/cpv-03-shown-videos-migration`        | `[ ]`  | —     | —   | — |
 | 4   | `Break` model + migration                                                   | `casey/cpv-04-break-model`                   | `[ ]`  | —     | —   | — |
 | 5   | Video registry + new enum values                                            | `casey/cpv-05-video-registry-enums`          | `[ ]`  | —     | —   | 2 |

--- a/server/enums/__tests__/test_coaching_phase.py
+++ b/server/enums/__tests__/test_coaching_phase.py
@@ -1,0 +1,156 @@
+"""
+Tests for the SESSIONS map + helpers in `enums/coaching_phase.py`.
+
+Pure data + functions — no Django ORM access, no DB hits, no fixtures.
+"""
+
+import pytest
+
+from enums.coaching_phase import (
+    SESSIONS,
+    CoachingPhase,
+    is_first_phase_of_session,
+    is_last_phase_of_session,
+    session_of,
+)
+
+# Every CoachingPhase value EXCEPT SYSTEM_CONTEXT should appear in SESSIONS.
+# SYSTEM_CONTEXT is a meta-phase, not a real coaching phase.
+_REAL_PHASES = [p for p in CoachingPhase if p != CoachingPhase.SYSTEM_CONTEXT]
+
+
+# ---------------------------------------------------------------------------
+# SESSIONS map structure
+# ---------------------------------------------------------------------------
+
+
+class TestSessionsMapCoverage:
+    """Every real CoachingPhase appears in exactly one session."""
+
+    def test_sessions_map_covers_every_coaching_phase_exactly_once(self):
+        seen: list[CoachingPhase] = []
+        for meta in SESSIONS.values():
+            seen.extend(meta["phases"])
+        assert sorted(seen, key=lambda p: p.value) == sorted(
+            _REAL_PHASES, key=lambda p: p.value
+        )
+        # No duplicates across sessions
+        assert len(seen) == len(set(seen)), "A phase appears in more than one session"
+
+    def test_sessions_map_excludes_system_context(self):
+        for meta in SESSIONS.values():
+            assert CoachingPhase.SYSTEM_CONTEXT not in meta["phases"]
+
+
+# ---------------------------------------------------------------------------
+# session_of
+# ---------------------------------------------------------------------------
+
+
+# Build (phase, expected_session_key) pairs from the SESSIONS map so the
+# parametrization stays in sync with whatever the map says.
+_PHASE_TO_SESSION = [
+    (phase, session_key)
+    for session_key, meta in SESSIONS.items()
+    for phase in meta["phases"]
+]
+
+
+class TestSessionOf:
+    @pytest.mark.parametrize("phase,expected_session", _PHASE_TO_SESSION)
+    def test_session_of_returns_correct_session(self, phase, expected_session):
+        assert session_of(phase) == expected_session
+
+    def test_session_of_raises_for_unknown_phase(self):
+        # SYSTEM_CONTEXT is a valid CoachingPhase but is intentionally not in
+        # any session — session_of should raise.
+        with pytest.raises(ValueError):
+            session_of(CoachingPhase.SYSTEM_CONTEXT)
+
+
+# ---------------------------------------------------------------------------
+# is_first_phase_of_session
+# ---------------------------------------------------------------------------
+
+
+_FIRST_PHASES = [meta["phases"][0] for meta in SESSIONS.values()]
+_NON_FIRST_PHASES = [
+    phase
+    for meta in SESSIONS.values()
+    for phase in meta["phases"][1:]
+]
+
+
+class TestIsFirstPhaseOfSession:
+    @pytest.mark.parametrize("phase", _FIRST_PHASES)
+    def test_is_first_phase_of_session_true_for_first_phase(self, phase):
+        assert is_first_phase_of_session(phase) is True
+
+    @pytest.mark.parametrize("phase", _NON_FIRST_PHASES)
+    def test_is_first_phase_of_session_false_for_non_first_phases(self, phase):
+        assert is_first_phase_of_session(phase) is False
+
+    def test_is_first_phase_of_session_false_for_system_context(self):
+        assert is_first_phase_of_session(CoachingPhase.SYSTEM_CONTEXT) is False
+
+
+# ---------------------------------------------------------------------------
+# is_last_phase_of_session
+# ---------------------------------------------------------------------------
+
+
+_LAST_PHASES = [meta["phases"][-1] for meta in SESSIONS.values()]
+_NON_LAST_PHASES = [
+    phase
+    for meta in SESSIONS.values()
+    for phase in meta["phases"][:-1]
+]
+
+
+class TestIsLastPhaseOfSession:
+    @pytest.mark.parametrize("phase", _LAST_PHASES)
+    def test_is_last_phase_of_session_true_for_last_phase(self, phase):
+        assert is_last_phase_of_session(phase) is True
+
+    @pytest.mark.parametrize("phase", _NON_LAST_PHASES)
+    def test_is_last_phase_of_session_false_for_non_last_phases(self, phase):
+        assert is_last_phase_of_session(phase) is False
+
+    def test_is_last_phase_of_session_false_for_system_context(self):
+        assert is_last_phase_of_session(CoachingPhase.SYSTEM_CONTEXT) is False
+
+
+# ---------------------------------------------------------------------------
+# Asymmetric sessions sanity (intro-only by design)
+# ---------------------------------------------------------------------------
+
+
+class TestAsymmetricSessions:
+    def test_welcome_session_outro_is_none(self):
+        assert SESSIONS["welcome_session"]["outro"] is None
+
+    def test_visualization_session_outro_is_none(self):
+        assert SESSIONS["visualization_session"]["outro"] is None
+
+
+# ---------------------------------------------------------------------------
+# Naming convention guard
+# ---------------------------------------------------------------------------
+
+
+class TestSessionKeyNaming:
+    def test_session_keys_all_end_with_underscore_session_suffix(self):
+        for session_key in SESSIONS.keys():
+            assert session_key.endswith("_session"), (
+                f"Session key {session_key!r} must end with '_session'"
+            )
+
+    def test_intro_keys_match_session_key_prefix(self):
+        for session_key, meta in SESSIONS.items():
+            if meta["intro"] is not None:
+                assert meta["intro"] == f"{session_key}_intro"
+
+    def test_outro_keys_match_session_key_prefix(self):
+        for session_key, meta in SESSIONS.items():
+            if meta["outro"] is not None:
+                assert meta["outro"] == f"{session_key}_outro"

--- a/server/enums/coaching_phase.py
+++ b/server/enums/coaching_phase.py
@@ -1,3 +1,5 @@
+from typing import List, Optional, TypedDict
+
 from django.db import models
 
 
@@ -38,3 +40,112 @@ class CoachingPhase(models.TextChoices):
         Get a human-readable string representation of the identity category.
         """
         return self.label
+
+
+# ---------------------------------------------------------------------------
+# Coaching sessions
+# ---------------------------------------------------------------------------
+# A "session" groups one or more consecutive CoachingPhases that belong
+# together for the purpose of intro/outro video boundaries and breaks. The
+# SESSIONS map is the source of truth for which phases form which session
+# and which video keys are attached to each side.
+#
+# - The session key is the dict key (suffixed `_session` so callers never
+#   confuse it with a CoachingPhase value).
+# - `phases` is the ordered list of CoachingPhase members in this session.
+# - `intro` / `outro` are video keys; `None` means no video on that side.
+#
+# SYSTEM_CONTEXT is intentionally absent — it is a meta-phase used only to
+# control system context for the LLM, not a real coaching phase.
+
+
+class SessionMeta(TypedDict):
+    phases: List[CoachingPhase]
+    intro: Optional[str]
+    outro: Optional[str]
+
+
+SESSIONS: dict[str, SessionMeta] = {
+    "welcome_session": {
+        "phases": [CoachingPhase.INTRODUCTION],
+        "intro": "welcome_session_intro",
+        "outro": None,
+    },
+    "get_to_know_session": {
+        "phases": [CoachingPhase.GET_TO_KNOW_YOU, CoachingPhase.IDENTITY_WARMUP],
+        "intro": "get_to_know_session_intro",
+        "outro": "get_to_know_session_outro",
+    },
+    "brainstorming_session": {
+        "phases": [
+            CoachingPhase.IDENTITY_BRAINSTORMING,
+            CoachingPhase.BRAINSTORMING_REVIEW,
+        ],
+        "intro": "brainstorming_session_intro",
+        "outro": "brainstorming_session_outro",
+    },
+    "refinement_session": {
+        "phases": [
+            CoachingPhase.IDENTITY_REFINEMENT,
+            CoachingPhase.ANYTHING_MISSING,
+        ],
+        "intro": "refinement_session_intro",
+        "outro": "refinement_session_outro",
+    },
+    "commitment_session": {
+        "phases": [CoachingPhase.IDENTITY_COMMITMENT],
+        "intro": "commitment_session_intro",
+        "outro": "commitment_session_outro",
+    },
+    "i_am_session": {
+        "phases": [CoachingPhase.I_AM_STATEMENT],
+        "intro": "i_am_session_intro",
+        "outro": "i_am_session_outro",
+    },
+    "visualization_session": {
+        "phases": [CoachingPhase.IDENTITY_VISUALIZATION],
+        "intro": "visualization_session_intro",
+        "outro": None,
+    },
+}
+
+
+def session_of(phase: CoachingPhase) -> str:
+    """
+    Return the session key that contains `phase`.
+
+    Raises ValueError if `phase` does not belong to any session (e.g.,
+    SYSTEM_CONTEXT, which is a meta-phase, not a coaching phase).
+    """
+    for session_key, meta in SESSIONS.items():
+        if phase in meta["phases"]:
+            return session_key
+    raise ValueError(
+        f"Phase {phase!r} does not belong to any session in SESSIONS."
+    )
+
+
+def is_first_phase_of_session(phase: CoachingPhase) -> bool:
+    """
+    True iff `phase` is the first phase listed in its session.
+
+    The intro-video trigger boundary. Returns False for phases not in any
+    session (e.g., SYSTEM_CONTEXT).
+    """
+    for meta in SESSIONS.values():
+        if meta["phases"] and meta["phases"][0] == phase:
+            return True
+    return False
+
+
+def is_last_phase_of_session(phase: CoachingPhase) -> bool:
+    """
+    True iff `phase` is the last phase listed in its session.
+
+    The outro-video / break trigger boundary. Returns False for phases not
+    in any session (e.g., SYSTEM_CONTEXT).
+    """
+    for meta in SESSIONS.values():
+        if meta["phases"] and meta["phases"][-1] == phase:
+            return True
+    return False


### PR DESCRIPTION
## Summary

PR 2 in the [Coaching Phase Videos series](../blob/main/notes/coaching-phase-videos-prs.md). Codifies coaching "sessions" as metadata sitting next to the `CoachingPhase` enum — pure data + functions, no behavior change anywhere else.

- New `SESSIONS` dict at `server/enums/coaching_phase.py` with 7 sessions covering all 10 real coaching phases (`SYSTEM_CONTEXT` is intentionally excluded — it's a meta-phase, not a real phase)
- New `SessionMeta` TypedDict making the entry shape explicit (`phases`, `intro`, `outro`)
- Three helpers in the same module:
  - `session_of(phase) → str` — raises `ValueError` for non-session phases (e.g. `SYSTEM_CONTEXT`)
  - `is_first_phase_of_session(phase) → bool` — the intro-video trigger boundary
  - `is_last_phase_of_session(phase) → bool` — the outro / break trigger boundary
- 40 pytest tests in `server/enums/__tests__/test_coaching_phase.py`

Session keys all end with the `_session` suffix so they're never confused with `CoachingPhase` values. Intro/outro video keys are derived from the session key (`<key>_intro`, `<key>_outro`) and asserted to match in the naming convention tests.

## Asymmetric sessions (intentional)

| Session | Intro | Outro |
|---|---|---|
| `welcome_session` | ✅ | ❌ |
| `visualization_session` | ✅ | ❌ |

No break after the welcome video, no break after the final session.

## Test plan

- [x] `pytest enums/__tests__/test_coaching_phase.py` — 40/40 passing inside backend container
- [x] Full backend suite (`pytest --ignore=apps/test_scenario/admin --ignore=apps/test_scenario/models --ignore=apps/test_scenario/views`) — 694/694 passing (was 654; +40 from this PR)
- [x] Plan file updated: status row → `[~]` for this PR

## Notes for follow-up PRs

- `session_of` raises for `SYSTEM_CONTEXT` by design. Handlers that call it (PR 13's `transition_phase` enrichment, PR 14's `END_BREAK` enrichment) should never pass `SYSTEM_CONTEXT` since it isn't a real coaching phase — but if they do, a `ValueError` will surface the bug instead of silently doing the wrong thing.
- The two boolean predicates return `False` (rather than raise) for non-session phases. That keeps caller code in handlers free of `try/except` around predicate checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)