### PR TITLE
feat(cpv): SessionVideoCard + modal shell (PR 16/25)

### DIFF
--- a/client/src/pages/chat/components/__tests__/CoachMessageWithComponent.test.tsx
+++ b/client/src/pages/chat/components/__tests__/CoachMessageWithComponent.test.tsx
@@ -52,6 +52,14 @@ vi.mock(
     ),
   })
 );
+vi.mock(
+  "@/pages/chat/components/coach-message-with-component/SessionVideoCard",
+  () => ({
+    SessionVideoCard: ({ coachMessage }: { coachMessage: React.ReactNode }) => (
+      <div data-testid="session-video-card">{coachMessage}</div>
+    ),
+  })
+);
 
 const mockOnSend = vi.fn();
 
@@ -101,6 +109,11 @@ describe("CoachMessageWithComponent", () => {
   it("renders IAmStatementsSummaryComponent for I_AM_STATEMENTS_SUMMARY", () => {
     renderWithConfig(ComponentType.I_AM_STATEMENTS_SUMMARY);
     expect(screen.getByTestId("iam-summary")).toBeInTheDocument();
+  });
+
+  it("renders SessionVideoCard for SESSION_VIDEO (PR 16)", () => {
+    renderWithConfig(ComponentType.SESSION_VIDEO);
+    expect(screen.getByTestId("session-video-card")).toBeInTheDocument();
   });
 
   it("renders children as fallback for unknown component type", () => {

--- a/client/src/pages/chat/components/__tests__/SessionVideoCard.test.tsx
+++ b/client/src/pages/chat/components/__tests__/SessionVideoCard.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * Tests for SessionVideoCard + SessionVideoModal — the Coaching Phase
+ * Videos thin card + modal player (PR 16 shell).
+ *
+ * Scope: visual shell only. PR 16 deliberately does NOT render a Continue
+ * button, threshold-gate anything, or dispatch any backend actions on
+ * close — those are PR 17's responsibility. The negative tests in this
+ * file lock that split.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CoachingPhase } from "@/enums/coachingPhase";
+import { ComponentType } from "@/enums/componentType";
+import { SessionVideoCard } from "@/pages/chat/components/coach-message-with-component/SessionVideoCard";
+import { createQueryWrapper } from "@/tests/query-wrapper";
+import type { CoachState } from "@/types/coachState";
+import type { ComponentConfig } from "@/types/componentConfig";
+
+vi.mock("@/hooks/use-coach-state", () => ({
+  useCoachState: vi.fn(),
+}));
+
+import { useCoachState } from "@/hooks/use-coach-state";
+
+const baseCoachState: CoachState = {
+  id: "cs-1",
+  user: "user-1",
+  current_phase: CoachingPhase.INTRODUCTION,
+  who_you_are: null,
+  who_you_want_to_be: null,
+  asked_questions: null,
+  updated_at: "2025-01-01",
+  shown_videos: [],
+};
+
+function mockCoachState(state: Partial<CoachState> = {}) {
+  vi.mocked(useCoachState).mockReturnValue({
+    coachState: { ...baseCoachState, ...state },
+    isLoading: false,
+    isError: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    refetchCoachState: vi.fn() as any,
+  });
+}
+
+function buildConfig(overrides: Partial<ComponentConfig> = {}): ComponentConfig {
+  return {
+    component_type: ComponentType.SESSION_VIDEO,
+    video_key: "welcome_session_intro",
+    video_name: "Welcome",
+    video_url:
+      "https://discovita-dev-coach-staging.s3.amazonaws.com/media/session-videos/01-welcome-session-intro.mov",
+    ...overrides,
+  };
+}
+
+function renderCard(
+  config: ComponentConfig = buildConfig(),
+  coachMessage: React.ReactNode = null
+) {
+  const { wrapper: Wrapper } = createQueryWrapper();
+  return render(
+    <Wrapper>
+      <SessionVideoCard coachMessage={coachMessage} config={config} />
+    </Wrapper>
+  );
+}
+
+describe("SessionVideoCard — shell (PR 16)", () => {
+  beforeEach(() => {
+    vi.mocked(useCoachState).mockReset();
+    mockCoachState();
+  });
+
+  // --- Card surface --------------------------------------------------
+
+  it("renders the video name from component_config.video_name", () => {
+    renderCard(buildConfig({ video_name: "Brainstorming Intro" }));
+    expect(screen.getByText("Brainstorming Intro")).toBeInTheDocument();
+  });
+
+  it("renders a Watch button when video_key is NOT in shown_videos", () => {
+    mockCoachState({ shown_videos: ["some_other_video"] });
+    renderCard();
+    expect(
+      screen.getByRole("button", { name: "Watch" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Watch Again" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders Watch Again when video_key IS in shown_videos", () => {
+    mockCoachState({ shown_videos: ["welcome_session_intro"] });
+    renderCard();
+    expect(
+      screen.getByRole("button", { name: "Watch Again" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Watch" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("treats undefined shown_videos as 'never acked' (Watch label)", () => {
+    // Graceful for older backend responses that omit the field.
+    mockCoachState({ shown_videos: undefined });
+    renderCard();
+    expect(
+      screen.getByRole("button", { name: "Watch" })
+    ).toBeInTheDocument();
+  });
+
+  // --- Modal lifecycle ------------------------------------------------
+
+  it("opens the modal on Watch click and renders a <video> with the right src", () => {
+    renderCard();
+    expect(screen.queryByTestId("session-video-modal")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Watch" }));
+
+    expect(screen.getByTestId("session-video-modal")).toBeInTheDocument();
+    const videoEl = screen.getByTestId("session-video-element") as HTMLVideoElement;
+    expect(videoEl).toBeInTheDocument();
+    expect(videoEl.getAttribute("src")).toBe(
+      "https://discovita-dev-coach-staging.s3.amazonaws.com/media/session-videos/01-welcome-session-intro.mov"
+    );
+  });
+
+  it("closes the modal on Escape", () => {
+    renderCard();
+    fireEvent.click(screen.getByRole("button", { name: "Watch" }));
+    expect(screen.getByTestId("session-video-modal")).toBeInTheDocument();
+
+    fireEvent.keyDown(document.body, { key: "Escape" });
+
+    expect(screen.queryByTestId("session-video-modal")).not.toBeInTheDocument();
+  });
+
+  it("does NOT render a Continue button (PR 17 territory)", () => {
+    renderCard();
+    fireEvent.click(screen.getByRole("button", { name: "Watch" }));
+
+    // Negative test that locks the PR 16 / PR 17 split.
+    expect(
+      screen.queryByRole("button", { name: /continue/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("Watch button has no actions in component_config (no dispatch wiring yet)", () => {
+    // Asserts at the data-shape level that PR 16 doesn't ship any
+    // action plumbing on the card itself. PR 17 will add the modal's
+    // Continue button + bundled actions on the same component_config.
+    const config = buildConfig();
+    expect(config.buttons).toBeUndefined();
+  });
+
+  // --- Coach text passthrough ----------------------------------------
+
+  it("renders the coach message text above the card when content is non-empty", () => {
+    // Mirror what ChatMessages.tsx actually passes — a MarkdownRenderer-
+    // shaped element with a `content` prop. The card's
+    // `extractContentString` helper inspects that prop to decide whether
+    // to render the text bubble.
+    const Fake = ({ content }: { content: string }) => (
+      <div data-testid="coach-text">{content}</div>
+    );
+    renderCard(buildConfig(), <Fake content="Let's move to brainstorming." />);
+    expect(
+      screen.getByText("Let's move to brainstorming.")
+    ).toBeInTheDocument();
+  });
+
+  it("suppresses the text bubble when coachMessage's content prop is empty (welcome card)", () => {
+    const Fake = ({ content }: { content: string }) => (
+      <div data-testid="coach-text">{content || "should-not-render"}</div>
+    );
+    renderCard(buildConfig(), <Fake content="" />);
+    // Element exists in the React tree only if the card chose to render
+    // the text bubble — which it shouldn't when content is empty.
+    expect(screen.queryByTestId("coach-text")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/pages/chat/components/coach-message-with-component/CoachMessageWithComponent.tsx
+++ b/client/src/pages/chat/components/coach-message-with-component/CoachMessageWithComponent.tsx
@@ -8,6 +8,7 @@ import { NestIdentitiesConfirmation } from "@/pages/chat/components/coach-messag
 import { ArchiveIdentityConfirmation } from "@/pages/chat/components/coach-message-with-component/ArchiveIdentityConfirmation";
 import { SuggestIAmStatementComponent } from "@/pages/chat/components/coach-message-with-component/SuggestIAmStatementComponent";
 import { IAmStatementsSummaryComponent } from "@/pages/chat/components/coach-message-with-component/IAmStatementsSummaryComponent";
+import { SessionVideoCard } from "@/pages/chat/components/coach-message-with-component/SessionVideoCard";
 
 export interface CoachMessageWithComponentProps {
   children: React.ReactNode;
@@ -76,6 +77,10 @@ export const CoachMessageWithComponent: React.FC<
           disabled={disabled}
           testUserId={testUserId}
         />
+      );
+    case ComponentType.SESSION_VIDEO:
+      return (
+        <SessionVideoCard coachMessage={children} config={componentConfig} />
       );
     default:
       return <>{children}</>;

--- a/client/src/pages/chat/components/coach-message-with-component/SessionVideoCard.tsx
+++ b/client/src/pages/chat/components/coach-message-with-component/SessionVideoCard.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from "react";
+import type { ComponentConfig } from "@/types/componentConfig";
+import { useCoachState } from "@/hooks/use-coach-state";
+import { CoachMessage } from "@/pages/chat/components/CoachMessage";
+import { SessionVideoModal } from "@/pages/chat/components/coach-message-with-component/SessionVideoModal";
+
+/**
+ * Coaching Phase Videos — `SessionVideoCard` (PR 16 shell).
+ *
+ * Renders the thin video card the LLM (or the welcome / break flow)
+ * emits inline in chat:
+ *
+ *   ┌──────────────────────────────────────┐
+ *   │  <Video Name>             [ Watch ]  │
+ *   └──────────────────────────────────────┘
+ *
+ * The button label derives from `coachState.shown_videos`:
+ *   - "Watch"        when the video_key has NOT been acknowledged
+ *   - "Watch Again"  when it HAS been acknowledged
+ *
+ * Click → opens the modal player (`SessionVideoModal`). The modal in
+ * PR 16 is shell-only: Esc / backdrop / X close it with no action
+ * dispatch. PR 17 adds the threshold-gated Continue button + actions.
+ *
+ * If the coach message also carries text (the transition-turn case where
+ * the LLM speaks AND a card is attached to the same row), it's rendered
+ * above the card via a regular `<CoachMessage>` bubble. For the welcome
+ * card + post-break intro card cases (`content === ""`), the text bubble
+ * is suppressed and only the thin card renders.
+ *
+ * Per spec Decision 8 — `Watch Again` keeps its button even on historical
+ * cards because it's frontend-only (opens the same modal, no actions
+ * fire). This is the intentional deviation from the "strip all buttons
+ * from historical components" persistent-component convention.
+ */
+export interface SessionVideoCardProps {
+  coachMessage: React.ReactNode;
+  config: ComponentConfig;
+}
+
+function extractContentString(node: React.ReactNode): string {
+  // ChatMessages passes `<MarkdownRenderer content={message.content} />` as
+  // children. Inspect the `content` prop to decide whether to render a
+  // text bubble above the card. Defensive: if the shape changes, fall back
+  // to showing the bubble (safer than hiding LLM text).
+  if (React.isValidElement(node)) {
+    const props = (node as React.ReactElement).props as
+      | { content?: unknown }
+      | undefined;
+    if (props && typeof props.content === "string") {
+      return props.content;
+    }
+  }
+  return "";
+}
+
+export const SessionVideoCard: React.FC<SessionVideoCardProps> = ({
+  coachMessage,
+  config,
+}) => {
+  const { coachState } = useCoachState();
+  const [open, setOpen] = useState(false);
+
+  const videoName = config.video_name ?? "Session Video";
+  const videoUrl = config.video_url ?? "";
+  const videoKey = config.video_key;
+
+  const acknowledged =
+    videoKey !== undefined &&
+    Array.isArray(coachState?.shown_videos) &&
+    coachState!.shown_videos!.includes(videoKey);
+
+  const textContent = extractContentString(coachMessage);
+  const hasText = textContent.trim().length > 0;
+
+  return (
+    <div className="_SessionVideoCard-wrapper">
+      {hasText && <CoachMessage>{coachMessage}</CoachMessage>}
+
+      <div
+        data-testid="session-video-card"
+        className="_SessionVideoCard mb-4 p-3.5 pr-4 pl-4 rounded-t-[18px] rounded-br-[18px] rounded-bl-[6px] w-fit max-w-[100%] shadow-sm animate-fadeIn break-words mr-auto flex items-center gap-4"
+        style={{
+          fontFamily: "'Montserrat', sans-serif",
+          backgroundColor: "var(--nv-pale-lavender, #eae6fb)",
+        }}
+      >
+        <span className="text-[18px] font-medium leading-[1.5] text-black">
+          {videoName}
+        </span>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="px-3 py-1.5 text-sm font-medium rounded-md transition-colors cursor-pointer"
+          style={{
+            backgroundColor: "var(--nv-royal-purple, #531e96)",
+            color: "white",
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor =
+              "var(--nv-violet-blue, #6a5ffb)";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor =
+              "var(--nv-royal-purple, #531e96)";
+          }}
+        >
+          {acknowledged ? "Watch Again" : "Watch"}
+        </button>
+      </div>
+
+      <SessionVideoModal
+        open={open}
+        onOpenChange={setOpen}
+        videoName={videoName}
+        videoUrl={videoUrl}
+      />
+    </div>
+  );
+};

--- a/client/src/pages/chat/components/coach-message-with-component/SessionVideoModal.tsx
+++ b/client/src/pages/chat/components/coach-message-with-component/SessionVideoModal.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+/**
+ * Modal player for a single Coaching Phase Video (PR 16 shell).
+ *
+ * Renders a `<video>` element with controls + the video name as the
+ * dialog title. Closes on Escape, backdrop click, or the close (X) button
+ * provided by `DialogContent`. NONE of those close paths fire any backend
+ * action — PR 16 is the visual shell only.
+ *
+ * PR 17 will add the threshold-gated Continue button + action dispatch
+ * (ACK for intros, ACK + START_BREAK for outros).
+ */
+export interface SessionVideoModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  videoName: string;
+  videoUrl: string;
+}
+
+export const SessionVideoModal: React.FC<SessionVideoModalProps> = ({
+  open,
+  onOpenChange,
+  videoName,
+  videoUrl,
+}) => {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        data-testid="session-video-modal"
+        className="sm:max-w-3xl p-0 overflow-hidden"
+      >
+        <DialogHeader className="px-6 pt-6">
+          <DialogTitle>{videoName}</DialogTitle>
+          <DialogDescription className="sr-only">
+            Watch the {videoName} video.
+          </DialogDescription>
+        </DialogHeader>
+        <video
+          data-testid="session-video-element"
+          src={videoUrl}
+          controls
+          preload="metadata"
+          className="w-full max-h-[70vh] bg-black"
+        >
+          <track kind="captions" />
+        </video>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/client/src/types/coachState.ts
+++ b/client/src/types/coachState.ts
@@ -16,6 +16,15 @@ export interface CoachState {
   who_you_are: string[] | null;
   who_you_want_to_be: string[] | null;
   asked_questions: GetToKnowYouQuestions[] | null;
+  /**
+   * Coaching Phase Videos (PR 3 backend / PR 16 FE): list of session-video
+   * keys (e.g. `welcome_session_intro`) the user has acknowledged. The
+   * Watch / Watch Again label on the `SessionVideoCard` derives from
+   * whether `component.video_key` is in this list. PR 18's composer-
+   * disable rule also reads this to determine if the latest video card
+   * is acked.
+   */
+  shown_videos?: string[];
   metadata?: {
     [k: string]: unknown;
   };

--- a/notes/coaching-phase-videos-prs.md
+++ b/notes/coaching-phase-videos-prs.md
@@ -153,7 +153,7 @@ def my_action(
 | 13  | `transition_phase` handler enrichment — outro/intro auto-emit (flag-gated)  | `casey/cpv-13-transition-phase-enrichment`   | `[✓]`  | casey 2026-05-25 | [#101](https://github.com/Discovita/dev-coach/pull/101) merged `04310be` 2026-05-25 | 1, 2, 5 |
 | 14  | `END_BREAK` handler enrichment — intro auto-emit (flag-gated)               | `casey/cpv-14-end-break-enrichment`          | `[✓]`  | casey 2026-05-25 | [#102](https://github.com/Discovita/dev-coach/pull/102) merged `939a882` 2026-05-25 | 1, 2, 5, 8 |
 | 15  | FE: `on_break` composer disable + read shape                                | `casey/cpv-15-fe-on-break-composer`          | `[✓]`  | casey 2026-05-25 | [#103](https://github.com/Discovita/dev-coach/pull/103) merged `3547967` 2026-05-25 | 9 |
-| 16  | FE: `SessionVideoCard` + modal shell                                        | `casey/cpv-16-fe-session-video-card`         | `[~]`  | casey 2026-05-25 | —   | 5 |
+| 16  | FE: `SessionVideoCard` + modal shell                                        | `casey/cpv-16-fe-session-video-card`         | `[👀]` | casey 2026-05-25 | [#105](https://github.com/Discovita/dev-coach/pull/105) | 5 |
 | 17  | FE: video modal threshold gate + action dispatch                            | `casey/cpv-17-fe-session-video-modal-action` | `[ ]`  | —     | —   | 6, 7, 16 |
 | 18  | FE: `SessionBreakComponent` + unacked-video composer rule                   | `casey/cpv-18-fe-session-break-composer`     | `[ ]`  | —     | —   | 8, 15, 17 |
 | 19  | Rename `dev-coach/videos/` files to match session keys                      | n/a — local-only (videos/ is gitignored)     | `[✓]`  | casey 2026-05-25 | n/a — no commit needed (see Discoveries 2026-05-25 PR 19) | — |
@@ -959,6 +959,18 @@ When `settings.COACHING_PHASE_VIDEOS_ENABLED` is `False`, this enrichment short-
 ### 2026-05-25 — casey — PR 19
 
 - **No commit, no PR opened.** `videos/` is gitignored (see `.gitignore:64-65` — "Coaching session video source files (uploaded to S3, not committed)"). The 12 files at `videos/01-..` through `videos/12-..` are already named per the spec's "Sessions & videos" table — the renames happened locally at an earlier point (the historical `mv` commands are visible in `.claude/settings.local.json` permission grants). No code references the old or new filenames (only the spec docs do, which are authoritative-source). PR 20's upload script will reference these names directly. Marking the row `[✓]` with no PR.
+
+### 2026-05-25 — casey — PR 16
+
+- **Renderer's `children` is `<MarkdownRenderer content={message.content} />` — not a string.** `ChatMessages.tsx` passes the markdown element directly; the renderer doesn't have a `text` prop. To decide whether to show a coach-text bubble above the card (welcome / post-break cards have empty content, transition cards don't), `SessionVideoCard.extractContentString` inspects `children.props.content`. Brittle if the wrapping shape ever changes — a future refactor could push that decision back to `ChatMessages.tsx` and pass a clean prop, but for one consumer it's overkill today. Flagged in the PR body.
+- **Card visual mimics CoachMessage bubble styling** (lavender background, Montserrat, animate-fadeIn, rounded corners with the asymmetric `rounded-bl-[6px]`) so it visually reads as another coach message. Width is `max-w-[100%]` (vs `max-w-[75%]` for regular coach text) because the card carries video name + button on a single row and needs the extra horizontal room.
+- **shadcn `DialogContent` renders the X close button by default** (`showCloseButton={true}` default). Esc + backdrop close are handled by radix automatically. PR 16 takes all three close paths for free — no custom keyboard or click handlers needed.
+- **`<video controls preload="metadata">`** — `preload="metadata"` avoids streaming the full video on modal mount (just fetches enough for the player UI: duration, poster frame). The user clicks the native play control to start the actual stream. Total tax on opening the modal: tiny.
+- **Watch Again deviation from persistent-component convention.** Spec Decision 8 calls this out: persistent-component docs say to strip all buttons from historical components, but the Watch Again button stays because it's frontend-only (no actions dispatch). PR 21 (docs update) should document this exception in `core-systems/component-renderer/persistent-components.md`.
+- **`CoachState.shown_videos?: string[]` added to FE type.** Backend exposed it via `CoachStateSerializer` back in PR 3, but the FE type never reflected it. The card's Watch / Watch Again label derives from this, and PR 18's composer-disable unacked-video clause will read it too.
+- **Existing `CoachMessageWithComponent.test.tsx` needed a new vi.mock entry.** Adding a renderer arm requires a corresponding mock here, otherwise the renderer test imports the real component (which then tries to call `useCoachState` outside a QueryClient and fails). Pattern for future component PRs: copy an existing `vi.mock` block, swap the path + testid.
+- **`SessionVideoModal` only renders when the card's `open` state is true** (radix `Dialog` returns null when closed). Test asserts that with `screen.queryByTestId("session-video-modal")` before click → null, after click → present. After Esc → null again. Clean lifecycle.
+- **Frontend suite at 211 after PR 16** (was 200 after PR 15; net +11: 10 in new `SessionVideoCard.test.tsx` + 1 new arm test in `CoachMessageWithComponent.test.tsx`).
 
 ### 2026-05-25 — casey — PR 20
 

--- a/notes/coaching-phase-videos-prs.md
+++ b/notes/coaching-phase-videos-prs.md
@@ -153,11 +153,11 @@ def my_action(
 | 13  | `transition_phase` handler enrichment — outro/intro auto-emit (flag-gated)  | `casey/cpv-13-transition-phase-enrichment`   | `[✓]`  | casey 2026-05-25 | [#101](https://github.com/Discovita/dev-coach/pull/101) merged `04310be` 2026-05-25 | 1, 2, 5 |
 | 14  | `END_BREAK` handler enrichment — intro auto-emit (flag-gated)               | `casey/cpv-14-end-break-enrichment`          | `[✓]`  | casey 2026-05-25 | [#102](https://github.com/Discovita/dev-coach/pull/102) merged `939a882` 2026-05-25 | 1, 2, 5, 8 |
 | 15  | FE: `on_break` composer disable + read shape                                | `casey/cpv-15-fe-on-break-composer`          | `[✓]`  | casey 2026-05-25 | [#103](https://github.com/Discovita/dev-coach/pull/103) merged `3547967` 2026-05-25 | 9 |
-| 16  | FE: `SessionVideoCard` + modal shell                                        | `casey/cpv-16-fe-session-video-card`         | `[ ]`  | —     | —   | 5 |
+| 16  | FE: `SessionVideoCard` + modal shell                                        | `casey/cpv-16-fe-session-video-card`         | `[~]`  | casey 2026-05-25 | —   | 5 |
 | 17  | FE: video modal threshold gate + action dispatch                            | `casey/cpv-17-fe-session-video-modal-action` | `[ ]`  | —     | —   | 6, 7, 16 |
 | 18  | FE: `SessionBreakComponent` + unacked-video composer rule                   | `casey/cpv-18-fe-session-break-composer`     | `[ ]`  | —     | —   | 8, 15, 17 |
 | 19  | Rename `dev-coach/videos/` files to match session keys                      | n/a — local-only (videos/ is gitignored)     | `[✓]`  | casey 2026-05-25 | n/a — no commit needed (see Discoveries 2026-05-25 PR 19) | — |
-| 20  | S3 upload + populate registry URLs + ComponentConfig enrichment             | `casey/cpv-20-s3-upload-registry-urls`       | `[👀]` | casey 2026-05-25 | [#104](https://github.com/Discovita/dev-coach/pull/104) | 5, 19 |
+| 20  | S3 upload + populate registry URLs + ComponentConfig enrichment             | `casey/cpv-20-s3-upload-registry-urls`       | `[✓]`  | casey 2026-05-25 | [#104](https://github.com/Discovita/dev-coach/pull/104) merged `8309970` 2026-05-25 | 5, 19 |
 | 21  | Docs update — phases, transition-phase, persistent-components, new actions  | `casey/cpv-21-docs-update`                   | `[ ]`  | —     | —   | 2, 5, 6, 7, 8, 13, 14 |
 | 22  | Flip flag to `True` (one-line code change)                                  | `casey/cpv-22-flip-flag`                     | `[ ]`  | —     | —   | 12–14, 18, 20, 21 |
 | 23  | Remove flag plumbing (OPTIONAL — default skip)                              | `casey/cpv-23-remove-flag-plumbing`          | `[ ]`  | —     | —   | 22 |


### PR DESCRIPTION
## Summary

PR 16 in the [Coaching Phase Videos series](../blob/main/notes/coaching-phase-videos-prs.md). First **user-facing FE work** in this feature — renders the thin inline video card the LLM (or welcome / post-break flow) emits, plus the modal player it opens. Visual shell only — PR 17 will add the threshold-gated Continue button + bundled action dispatch (`ACKNOWLEDGE_SESSION_VIDEO` for intros, `ACK + START_BREAK` for outros).

### Components

**`SessionVideoCard.tsx` (new)**

Thin card with `<Video Name>` + a single button. Label derives from `coachState.shown_videos.includes(component.video_key)`:
- `Watch` when the video has NOT been acknowledged
- `Watch Again` when it HAS been acknowledged

Click → opens the modal. Mirrors the existing chat-bubble visual conventions (pale lavender background, Montserrat font, royal-purple button).

The component inspects its `children`'s `content` prop (matching how `ChatMessages.tsx` actually passes `<MarkdownRenderer content={...} />`) to decide whether to render a coach-text bubble above the card. Needed because the welcome / post-break cards carry `content === ""` and shouldn't render an empty bubble, while transition-turn cards do carry LLM text that should render above the card (per spec Decision 6.B's "text + component on the same row" pattern).

**`SessionVideoModal.tsx` (new)**

Radix `Dialog` wrapper (via shadcn `ui/dialog`) around an HTML `<video controls preload="metadata">` element. The shadcn `DialogContent` provides the X close button + handles Esc / backdrop click natively. **No Continue button. No threshold logic. No action dispatch.** Closing the modal fires zero actions.

### Renderer registration

`CoachMessageWithComponent.tsx`: added the `case ComponentType.SESSION_VIDEO` arm that renders `<SessionVideoCard coachMessage={children} config={componentConfig} />`. The renderer registry now covers SESSION_VIDEO.

### Type

`CoachState.shown_videos?: string[]` — backend exposes this since PR 3 via `CoachStateSerializer`; the FE TS type now reflects it so the card can derive its Watch / Watch Again label.

## Test plan

- [x] `cd client && npm test` — **211/211 passing** (was 200; net +11).
- [x] `npx tsc --noEmit` — clean.
- [x] `SessionVideoCard.test.tsx` (new, 10 tests):
  - renders `video_name` from `component_config`
  - `Watch` label when key not in `shown_videos`
  - `Watch Again` label when key IS in `shown_videos`
  - graceful when `shown_videos` is undefined (defaults to `Watch` — older backend responses)
  - Watch click opens modal with `<video>` carrying the right `src` from `component_config.video_url`
  - Escape closes the modal
  - no Continue button rendered (negative — locks the PR 16/17 split)
  - no `buttons` in `component_config` (negative — no dispatch wiring)
  - renders coach text above card when `content` is non-empty
  - suppresses text bubble when `content` is empty (welcome card case)
- [x] `CoachMessageWithComponent.test.tsx`: added mock + new test asserting the renderer picks `SessionVideoCard` for `SESSION_VIDEO`.

## Manual verification

For a quick visual check before PR 17:

1. With `COACHING_PHASE_VIDEOS_ENABLED=True` in local settings (currently OFF on `main`), reset a test user's chat. The welcome card seeded by `ensure_initial_message_exists` should render as a thin lavender card with title "Welcome" + a `Watch` button.
2. Click `Watch` → modal opens with the 01-welcome-session-intro.mov streaming from S3.
3. Click outside / press Esc / click the X → modal closes. No network requests fired (verify in DevTools).
4. (Cannot easily test the acked-state Watch Again label until PR 17 lands the ACK dispatch — but the test covers it.)

## Notes for follow-up PRs

- **PR 17** adds: threshold-gated Continue button inside the modal (20s before end for videos > 30s; 50% for ≤ 30s), `use-video-threshold` hook, bundled action dispatch on Continue click (`{message: null, actions: [ACK(video_key)]}` for intros; `{message: null, actions: [ACK, START_BREAK(session_key)]}` for outros), modal closes after dispatch. The same `SessionVideoModal` file is the natural edit site.
- **PR 18** adds: `SessionBreakComponent` (canned-response "I'm Ready" button → `END_BREAK()`) AND extends the composer-disable rule with the unacked-SESSION_VIDEO clause (`latestMessage.component?.type === SESSION_VIDEO && !shownVideos.includes(latestMessage.component.video_key)`).
- **Spec deviation worth flagging (intentional)**: per Decision 8, the `Watch Again` button stays on historical cards even though the persistent-component docs say "strip all buttons from historical components." Safe because the button is frontend-only — opens the same modal with zero actions attached. PR 21's docs update should call this out in `component-renderer/persistent-components.md`.
- **`extractContentString` is a small heuristic** that reads `children.props.content`. Brittle if `ChatMessages.tsx` ever changes from `<MarkdownRenderer content={...} />` to a different shape. PR 18 (or a refactor) could push the "should we render the text bubble?" decision back up into the parent and pass a clean prop. Not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)