### PR TITLE
fix(cpv): polish discovered during local feature testing

### DIFF
--- a/client/src/pages/chat/components/ChatMessages.tsx
+++ b/client/src/pages/chat/components/ChatMessages.tsx
@@ -51,15 +51,17 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
               let componentToRender = null;
 
               if (isLastCoachMessage) {
-                // Prefer the in-memory cache (`componentConfig`, set by
-                // `useChatMessages.onSuccess` after a POST). Fall back to
-                // `message.component_config` so server-seeded cards — the
-                // welcome SESSION_VIDEO on fresh chat load, post-END_BREAK
-                // intro cards on refresh, etc. — render before any API
-                // round-trip populates the cache.
-                componentToRender = !isProcessingMessage
-                  ? componentConfig || message.component_config || null
-                  : null;
+                // Prefer the in-memory cache when not processing (freshest
+                // server response). Fall through to `message.component_config`
+                // for server-seeded cards (welcome SESSION_VIDEO,
+                // post-END_BREAK intros) — those represent persisted
+                // history and stay visible even during in-flight requests,
+                // so clicking Continue doesn't blink the card out while
+                // we wait for the response.
+                componentToRender =
+                  (!isProcessingMessage && componentConfig) ||
+                  message.component_config ||
+                  null;
               } else {
                 // For all other coach messages, ONLY check message.component_config
                 componentToRender = message.component_config || null;

--- a/client/src/pages/chat/components/__tests__/ChatMessages.test.tsx
+++ b/client/src/pages/chat/components/__tests__/ChatMessages.test.tsx
@@ -192,10 +192,11 @@ describe("ChatMessages", () => {
       expect(screen.queryByTestId("coach-with-component")).not.toBeInTheDocument();
     });
 
-    it("suppresses component rendering while processing, even with cache or seed present", () => {
-      // While a POST is in flight, the LoadingBubbles bubble owns the
-      // visual real estate; the next message's component will render
-      // once processing flips false.
+    it("keeps server-seeded component visible during processing (no blink on Continue click)", () => {
+      // The welcome SESSION_VIDEO card is persisted on the message row.
+      // While the ACK click is in flight, the card must stay visible —
+      // blanking it makes the UI flicker as it disappears + reappears
+      // around the refetch. LoadingBubbles still appears beneath.
       renderChatMessages(
         [
           {
@@ -206,6 +207,28 @@ describe("ChatMessages", () => {
           },
         ],
         { isProcessingMessage: true }
+      );
+      expect(screen.getByTestId("coach-with-component")).toBeInTheDocument();
+      expect(screen.getByTestId("loading-bubbles")).toBeInTheDocument();
+    });
+
+    it("suppresses cache-only component while processing (legacy SHOW_XXX behavior)", () => {
+      // No message.component_config; component came from in-memory
+      // cache only (legacy SHOW_COMBINE_IDENTITIES-style flow). While
+      // a POST is in flight, blank it so it's clear the previous
+      // interactive choice is being processed.
+      renderChatMessages(
+        [
+          {
+            role: "coach",
+            content: "Pick one",
+            timestamp: "2025-01-01T00:00:00Z",
+          },
+        ],
+        {
+          isProcessingMessage: true,
+          componentConfig: combineIdentitiesConfig,
+        }
       );
       expect(screen.queryByTestId("coach-with-component")).not.toBeInTheDocument();
       expect(screen.getByTestId("loading-bubbles")).toBeInTheDocument();

--- a/client/src/pages/chat/components/coach-message-with-component/SessionVideoCard.tsx
+++ b/client/src/pages/chat/components/coach-message-with-component/SessionVideoCard.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Play } from "lucide-react";
 import type {
   ComponentAction,
   ComponentConfig,
@@ -97,13 +98,12 @@ export const SessionVideoCard: React.FC<SessionVideoCardProps> = ({
           backgroundColor: "var(--nv-pale-lavender, #eae6fb)",
         }}
       >
-        <span className="text-[18px] font-medium leading-[1.5] text-black">
-          {videoName}
-        </span>
+        {/* Circular play-icon "thumbnail" — visual signal that this card is a video. */}
         <button
           type="button"
+          aria-label={acknowledged ? "Watch video again" : "Watch video"}
           onClick={() => setOpen(true)}
-          className="px-3 py-1.5 text-sm font-medium rounded-md transition-colors cursor-pointer"
+          className="flex items-center justify-center w-10 h-10 rounded-full transition-colors cursor-pointer shrink-0"
           style={{
             backgroundColor: "var(--nv-royal-purple, #531e96)",
             color: "white",
@@ -117,6 +117,29 @@ export const SessionVideoCard: React.FC<SessionVideoCardProps> = ({
               "var(--nv-royal-purple, #531e96)";
           }}
         >
+          <Play className="w-5 h-5 ml-0.5" fill="currentColor" />
+        </button>
+        <span className="text-[18px] font-medium leading-[1.5] text-black">
+          {videoName}
+        </span>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md transition-colors cursor-pointer"
+          style={{
+            backgroundColor: "var(--nv-royal-purple, #531e96)",
+            color: "white",
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor =
+              "var(--nv-violet-blue, #6a5ffb)";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor =
+              "var(--nv-royal-purple, #531e96)";
+          }}
+        >
+          <Play className="w-3.5 h-3.5" fill="currentColor" aria-hidden="true" />
           {acknowledged ? "Watch Again" : "Watch"}
         </button>
       </div>

--- a/client/src/pages/chat/components/coach-message-with-component/SessionVideoModal.tsx
+++ b/client/src/pages/chat/components/coach-message-with-component/SessionVideoModal.tsx
@@ -87,6 +87,7 @@ export const SessionVideoModal: React.FC<SessionVideoModalProps> = ({
           data-testid="session-video-element"
           src={videoUrl}
           controls
+          autoPlay
           preload="metadata"
           className="w-full max-h-[70vh] bg-black"
           onTimeUpdate={(e) => {

--- a/server/apps/users/functions/public/reset_user_coaching_data.py
+++ b/server/apps/users/functions/public/reset_user_coaching_data.py
@@ -12,7 +12,7 @@ from django.db import transaction
 from apps.actions.models import Action
 from apps.chat_messages.models import ChatMessage
 from apps.chat_messages.utils import ensure_initial_message_exists
-from apps.coach_states.models import CoachState
+from apps.coach_states.models import Break, CoachState
 from apps.identities.models import Identity
 from apps.user_notes.models import UserNote
 from apps.users.models import User
@@ -56,6 +56,12 @@ def reset_user_coaching_data(user: User) -> List[ChatMessage]:
     # Delete all actions for the user
     Action.objects.filter(user=user).delete()
 
+    # Coaching Phase Videos: delete all Break rows so a refreshed user
+    # never inherits `on_break=true` from the prior session. Also resets
+    # `triggered_by_session` history (not relied on elsewhere, but kept
+    # consistent — coaching data should look truly fresh post-reset).
+    Break.objects.filter(user=user).delete()
+
     # Reset the user's CoachState
     try:
         coach_state = CoachState.objects.get(user=user)
@@ -67,6 +73,11 @@ def reset_user_coaching_data(user: User) -> List[ChatMessage]:
         coach_state.who_you_are = []
         coach_state.who_you_want_to_be = []
         coach_state.asked_questions = []
+        # Coaching Phase Videos: clear acknowledged videos so the welcome
+        # card (and every subsequent intro/outro) re-fires on the reset
+        # chat — otherwise `transition_phase` / `end_break` would skip
+        # them because their keys are still in shown_videos.
+        coach_state.shown_videos = []
         coach_state.save()
     except CoachState.DoesNotExist:
         pass  # User may not have a CoachState yet

--- a/server/apps/users/tests/test_reset_user_coaching_data.py
+++ b/server/apps/users/tests/test_reset_user_coaching_data.py
@@ -10,7 +10,7 @@ from rest_framework.test import APIClient, APITestCase
 
 from apps.actions.models import Action
 from apps.chat_messages.models import ChatMessage
-from apps.coach_states.models import CoachState
+from apps.coach_states.models import Break, CoachState
 from apps.identities.models import Identity
 from apps.user_notes.models import UserNote
 from apps.users.functions import reset_user_coaching_data
@@ -72,7 +72,19 @@ class ResetUserCoachingDataFunctionTests(TestCase):
         self.coach_state.who_you_are = ["Creative", "Ambitious"]
         self.coach_state.who_you_want_to_be = ["Leader"]
         self.coach_state.asked_questions = ["question1"]
+        # Coaching Phase Videos state — must be cleared on reset.
+        self.coach_state.shown_videos = [
+            "welcome_session_intro",
+            "get_to_know_session_intro",
+        ]
         self.coach_state.save()
+
+        # Coaching Phase Videos: pre-existing Break rows must be deleted
+        # on reset so a refreshed user never inherits `on_break=true`.
+        Break.objects.create(
+            user=self.user,
+            triggered_by_session="get_to_know_session",
+        )
 
     def test_deletes_all_chat_messages(self):
         """Test that all chat messages are deleted."""
@@ -124,6 +136,25 @@ class ResetUserCoachingDataFunctionTests(TestCase):
         self.assertEqual(self.coach_state.who_you_want_to_be, [])
         self.assertEqual(self.coach_state.asked_questions, [])
 
+    def test_resets_shown_videos(self):
+        """Coaching Phase Videos: shown_videos must be cleared so the welcome
+        card (and downstream intros/outros) re-fires on the reset chat."""
+        self.assertEqual(len(self.coach_state.shown_videos), 2)
+
+        reset_user_coaching_data(self.user)
+
+        self.coach_state.refresh_from_db()
+        self.assertEqual(self.coach_state.shown_videos, [])
+
+    def test_deletes_all_breaks(self):
+        """Coaching Phase Videos: Break rows must be deleted so the user
+        is not stuck `on_break=true` after a reset."""
+        self.assertEqual(Break.objects.filter(user=self.user).count(), 1)
+
+        reset_user_coaching_data(self.user)
+
+        self.assertEqual(Break.objects.filter(user=self.user).count(), 0)
+
     def test_handles_user_without_coach_state(self):
         """Test that function handles user without coach state gracefully."""
         user_no_state = User.objects.create_user(
@@ -162,11 +193,22 @@ class ResetUserCoachingDataFunctionTests(TestCase):
             state=IdentityState.ACCEPTED,
             category=IdentityCategory.PASSIONS,
         )
+        Break.objects.create(
+            user=other_user,
+            triggered_by_session="get_to_know_session",
+        )
+        other_state, _ = CoachState.objects.get_or_create(user=other_user)
+        other_state.shown_videos = ["welcome_session_intro"]
+        other_state.save()
 
         reset_user_coaching_data(self.user)
 
         self.assertEqual(ChatMessage.objects.filter(user=other_user).count(), 1)
         self.assertEqual(Identity.objects.filter(user=other_user).count(), 1)
+        # Coaching Phase Videos: per-user isolation of the new resets.
+        self.assertEqual(Break.objects.filter(user=other_user).count(), 1)
+        other_state.refresh_from_db()
+        self.assertEqual(other_state.shown_videos, ["welcome_session_intro"])
 
     def test_atomic_transaction(self):
         """Test that operation is atomic (all or nothing)."""


### PR DESCRIPTION
## Summary

Second follow-up to the Coaching Phase Videos FE PRs (16/17/18) and the reset path (PR 12 era). Each fix was surfaced by exercising the feature locally with `COACHING_PHASE_VIDEOS_ENABLED=True`. Small individually; together they make the welcome → ack → break → resume loop feel finished.

### 1. No-blink on video Continue (`ChatMessages.tsx`)

After PR 109 fixed the *fresh-load* render, clicking Continue on the welcome video made the card vanish for ~the request round-trip, then reappear once refetch landed. Root cause: the `!isProcessingMessage` guard blanked the seed-fallback path the same way it blanks cache-only components.

Fix: split the two cases. Cache wins when present and not processing; otherwise fall through to `message.component_config` even while processing. Legacy cache-only components (combine identities et al.) keep the blank-during-processing behavior.

```typescript
componentToRender =
  (!isProcessingMessage && componentConfig) ||
  message.component_config ||
  null;
```

Test reshaped from one combined assertion into two distinct ones:
- `keeps server-seeded component visible during processing (no blink on Continue click)` — locks the new behavior.
- `suppresses cache-only component while processing (legacy SHOW_XXX behavior)` — locks that we didn't change anything for legacy components.

### 2. Video autoplay (`SessionVideoModal.tsx`)

Added `autoPlay` to the `<video>` element. Browsers allow unprompted autoplay because the modal opens in response to the user's Watch click. No `muted` workaround needed.

### 3. "This is a video" affordance (`SessionVideoCard.tsx`)

Card now reads as obviously-video:
- Circular play-icon thumbnail to the left of the video name (clickable, opens modal).
- Small play icon inside the Watch / Watch Again button.

Uses `lucide-react`'s `Play` icon (already in the dep set). Existing tests still pass — accessible names for the new thumbnail (`"Watch video"` / `"Watch video again"`) don't collide with the existing label-based queries.

### 4. Reset clears Coaching Phase Videos state (`reset_user_coaching_data.py`)

The reset path predates the videos feature; PR 3 added `shown_videos` and PR 4 added `Break` rows, but the reset function never touched either. Consequences:
- A reset user kept their acknowledged-videos list — fresh chat would not re-show the welcome card (FE thought it was already acked) AND `transition_phase` / `end_break` would skip every intro/outro that had ever been watched.
- A reset user mid-break stayed `on_break=true` — composer disabled forever on the new chat.

Fix: delete all `Break.objects.filter(user=user)` and set `coach_state.shown_videos = []`. Mirrors the existing pattern for chat_messages, identities, user_notes, actions. New tests:
- `test_resets_shown_videos` — pre-populates with two keys, asserts empty after reset.
- `test_deletes_all_breaks` — pre-creates a Break row, asserts zero after.
- `test_does_not_affect_other_users` extended with Break + shown_videos isolation checks.

## Test plan

- [x] FE: **263/263** (was 256 → +6 ChatMessages routing tests in PR 109, +1 split on the seed-vs-cache during-processing distinction in this PR).
- [x] `tsc --noEmit` clean.
- [x] BE: **14/14** `test_reset_user_coaching_data.py` (was 12; +2 new). The pre-existing `test_adds_initial_message` still fails — PR 12 replaced `INITIAL_MESSAGE` with the welcome SESSION_VIDEO card seed, so the mock is a no-op; assertion compares `""` to `"Welcome back!"`. **Out of scope** here; PR 24 (delete `INITIAL_MESSAGE`) will remove the test.
- [x] Manual smoke (with local flag flip):
  - Fresh chat → welcome card renders with play-icon thumbnail + Watch button.
  - Click Watch → modal opens → video autoplays.
  - Watch to threshold, click Continue → card stays visible during request → greeting message appears beneath it. No blink.
  - Reset chat → welcome card returns with Watch (not Watch Again), proving `shown_videos` was cleared.

## Why this is not numbered

Continues the unnumbered-follow-up convention from PR 109 (#109). The PR 1-25 plan in `notes/coaching-phase-videos-prs.md` is the architectural rollout; these are bug fixes / UX polish discovered during real exercise of the feature. Treating them as separate unnumbered follow-ups keeps the numbered series stable.

**Test scenario gap (NOT in this PR)**: the freeze/instantiate pipeline in `apps/test_scenario/` doesn't gather or recreate `shown_videos` or `Break` rows. That's a meaningful new section pair (analogous to identities/user_notes with FK resolution against chat messages) and will land as a separate PR (111) after this one merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)