### PR TITLE
feat(identities): inline edit form on the identity detail page

### DIFF
--- a/client/src/api/identities.ts
+++ b/client/src/api/identities.ts
@@ -68,7 +68,7 @@ export async function reorderIdentities(
  */
 export async function adminUpdateIdentity(
 	identityId: string,
-	data: Partial<Identity>,
+	data: UpdateIdentityRequest,
 ): Promise<Identity> {
 	log.debug(`Admin updating identity ${identityId}`, data);
 	const response = await authFetch(

--- a/client/src/pages/identities/Identity.tsx
+++ b/client/src/pages/identities/Identity.tsx
@@ -1,12 +1,12 @@
+import { useState } from "react";
 import { useIdentities } from "@/hooks/use-identities";
 import { Link, useParams } from "@tanstack/react-router";
-import { IdentityState } from "@/enums/identityState";
-import {
-  getIdentityCategoryDisplayName,
-  getIdentityCategoryColor,
-  getIdentityCategoryIcon,
-} from "@/enums/identityCategory";
+import { Pencil } from "lucide-react";
+import type { IdentityState } from "@/enums/identityState";
 import type { Identity } from "@/types/identity";
+import { Button } from "@/components/ui/button";
+import { IdentityEditForm } from "./components/IdentityEditForm";
+import { CategoryPill } from "./components/CategoryPill";
 
 /**
  * Single Identity Page
@@ -17,165 +17,178 @@ import type { Identity } from "@/types/identity";
  * - Matches Figma design with card-based layout
  */
 export default function Identity() {
-  const { identityId } = useParams({
-    from: "/_authenticated/identities/$identityId",
-  });
-  const { identities, isLoading, isError } = useIdentities();
+	const { identityId } = useParams({
+		from: "/_authenticated/identities/$identityId",
+	});
+	const { identities, isLoading, isError } = useIdentities();
+	const [isEditing, setIsEditing] = useState(false);
 
-  // Find the identity from the cached identities data
-  const identity = identities?.find((identity: Identity) => identity.id === identityId);
+	// Find the identity from the cached identities data
+	const identity = identities?.find(
+		(identity: Identity) => identity.id === identityId,
+	);
 
-  /**
-   * Format state enum value to a readable display name
-   */
-  const formatState = (state?: IdentityState): string => {
-    if (!state) return "Unknown";
-    return state
-      .split("_")
-      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(" ");
-  };
+	/**
+	 * Format state enum value to a readable display name
+	 */
+	const formatState = (state?: IdentityState): string => {
+		if (!state) return "Unknown";
+		return state
+			.split("_")
+			.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+			.join(" ");
+	};
 
-  /**
-   * Format ISO date string to a readable format
-   */
-  const formatDate = (dateString?: string): string => {
-    if (!dateString) return "N/A";
-    try {
-      const date = new Date(dateString);
-      return date.toLocaleDateString("en-US", {
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-      });
-    } catch {
-      return dateString;
-    }
-  };
+	/**
+	 * Format ISO date string to a readable format
+	 */
+	const formatDate = (dateString?: string): string => {
+		if (!dateString) return "N/A";
+		try {
+			const date = new Date(dateString);
+			return date.toLocaleDateString("en-US", {
+				year: "numeric",
+				month: "long",
+				day: "numeric",
+				hour: "2-digit",
+				minute: "2-digit",
+			});
+		} catch {
+			return dateString;
+		}
+	};
 
-  if (isLoading) {
-    return (
-      <div className="space-y-6">
-        <h1 className="text-[32px] font-bold text-[#1e1e1e]">Identity</h1>
-        <div className="text-muted-foreground">Loading identity...</div>
-      </div>
-    );
-  }
+	if (isLoading) {
+		return (
+			<div className="space-y-6">
+				<h1 className="text-[32px] font-bold text-[#1e1e1e]">Identity</h1>
+				<div className="text-muted-foreground">Loading identity...</div>
+			</div>
+		);
+	}
 
-  if (isError) {
-    return (
-      <div className="space-y-6">
-        <h1 className="text-[32px] font-bold text-[#1e1e1e]">Identity</h1>
-        <div className="text-destructive">
-          Failed to load identities. Please try again.
-        </div>
-        <Link
-          to="/identities"
-          className="text-[color:var(--nv-violet-blue)] underline"
-        >
-          Back to Identities
-        </Link>
-      </div>
-    );
-  }
+	if (isError) {
+		return (
+			<div className="space-y-6">
+				<h1 className="text-[32px] font-bold text-[#1e1e1e]">Identity</h1>
+				<div className="text-destructive">
+					Failed to load identities. Please try again.
+				</div>
+				<Link
+					to="/identities"
+					className="text-[color:var(--nv-violet-blue)] underline"
+				>
+					Back to Identities
+				</Link>
+			</div>
+		);
+	}
 
-  if (!identity) {
-    return (
-      <div className="space-y-6">
-        <h1 className="text-[32px] font-bold text-[#1e1e1e]">Identity</h1>
-        <div className="text-destructive">Identity not found.</div>
-        <Link
-          to="/identities"
-          className="text-[color:var(--nv-violet-blue)] underline"
-        >
-          Back to Identities
-        </Link>
-      </div>
-    );
-  }
+	if (!identity) {
+		return (
+			<div className="space-y-6">
+				<h1 className="text-[32px] font-bold text-[#1e1e1e]">Identity</h1>
+				<div className="text-destructive">Identity not found.</div>
+				<Link
+					to="/identities"
+					className="text-[color:var(--nv-violet-blue)] underline"
+				>
+					Back to Identities
+				</Link>
+			</div>
+		);
+	}
 
-  return (
-    <div className="space-y-6 bg-white">
-      {/* Back Button */}
-      <Link
-        to="/identities"
-        className="inline-flex items-center gap-2 text-sm text-[color:var(--nv-violet-blue)] hover:underline mb-2"
-      >
-        <span>←</span>
-        <span>Back to Identities</span>
-      </Link>
+	return (
+		<div className="space-y-6 bg-white">
+			{/* Back Button + Edit toggle */}
+			<div className="flex items-center justify-between gap-3">
+				<Link
+					to="/identities"
+					className="inline-flex items-center gap-2 text-sm text-[color:var(--nv-violet-blue)] hover:underline"
+				>
+					<span>←</span>
+					<span>Back to Identities</span>
+				</Link>
+				{!isEditing && (
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => setIsEditing(true)}
+						className="gap-2"
+						aria-label="Edit identity"
+						title="Edit identity"
+					>
+						<Pencil className="h-4 w-4" />
+						Edit
+					</Button>
+				)}
+			</div>
 
-      {/* Large Image Section */}
-      <div className="relative overflow-hidden rounded-[16px] w-full aspect-video bg-muted flex items-center justify-center">
-        {identity.image?.original ? (
-          <img
-            src={identity.image.original}
-            alt={identity.name}
-            className="w-full h-full object-cover"
-          />
-        ) : (
-          <div className="text-center p-4">
-            <p className="text-sm text-muted-foreground">Image coming soon</p>
-          </div>
-        )}
-      </div>
+			{/* Large Image Section */}
+			<div className="relative overflow-hidden rounded-[16px] w-full aspect-video bg-muted flex items-center justify-center">
+				{identity.image?.original ? (
+					<img
+						src={identity.image.original}
+						alt={identity.name}
+						className="w-full h-full object-cover"
+					/>
+				) : (
+					<div className="text-center p-4">
+						<p className="text-sm text-muted-foreground">Image coming soon</p>
+					</div>
+				)}
+			</div>
 
-      {/* Title, Category, and State Badges */}
-      <div className="flex items-center gap-3 flex-wrap">
-        <h1 className="text-[32px] font-bold text-[#1e1e1e] leading-none">
-          {identity.name}
-        </h1>
-        {identity.category &&
-          (() => {
-            const IconComponent = getIdentityCategoryIcon(
-              String(identity.category)
-            );
-            const colorClasses = getIdentityCategoryColor(
-              String(identity.category)
-            );
-            return (
-              <span
-                className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium ${colorClasses}`}
-              >
-                <IconComponent className="w-3 h-3" />
-                <span>{getIdentityCategoryDisplayName(identity.category)}</span>
-              </span>
-            );
-          })()}
-        {identity.state && (
-          <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">
-            {formatState(identity.state)}
-          </span>
-        )}
-      </div>
+			{isEditing ? (
+				<IdentityEditForm
+					identity={identity}
+					onDone={() => setIsEditing(false)}
+				/>
+			) : (
+				<>
+					{/* Title, Category, and State Badges */}
+					<div className="flex items-center gap-3 flex-wrap">
+						<h1 className="text-[32px] font-bold text-[#1e1e1e] leading-none">
+							{identity.name}
+						</h1>
+						{identity.category && (
+							<CategoryPill category={String(identity.category)} />
+						)}
+						{identity.state && (
+							<span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">
+								{formatState(identity.state)}
+							</span>
+						)}
+					</div>
 
-      {/* I AM Statement Section - Always show */}
-      <div className="bg-white border border-[#dedede] rounded-[16px] p-[24px] space-y-2">
-        <h2 className="text-[20px] font-bold text-[#1e1e1e] leading-none">
-          I AM Statement
-        </h2>
-        {identity.i_am_statement ? (
-          <p className="text-[16px] font-normal text-[#1e1e1e]">
-            {identity.i_am_statement}
-          </p>
-        ) : (
-          <p className="text-sm text-muted-foreground">I Am coming soon</p>
-        )}
-      </div>
+					{/* I AM Statement Section - Always show */}
+					<div className="bg-white border border-[#dedede] rounded-[16px] p-[24px] space-y-2">
+						<h2 className="text-[20px] font-bold text-[#1e1e1e] leading-none">
+							I AM Statement
+						</h2>
+						{identity.i_am_statement ? (
+							<p className="text-[16px] font-normal text-[#1e1e1e]">
+								{identity.i_am_statement}
+							</p>
+						) : (
+							<p className="text-sm text-muted-foreground">I Am coming soon</p>
+						)}
+					</div>
 
-      {/* Metadata Section (Created/Updated timestamps) - Less prominent */}
-      {(identity.created_at || identity.updated_at) && (
-        <div className="text-sm text-muted-foreground space-y-1">
-          {identity.created_at && (
-            <p>Created: {formatDate(identity.created_at)}</p>
-          )}
-          {identity.updated_at && (
-            <p>Updated: {formatDate(identity.updated_at)}</p>
-          )}
-        </div>
-      )}
-    </div>
-  );
+					{/* Metadata Section (Created/Updated timestamps) - Less prominent */}
+					{(identity.created_at || identity.updated_at) && (
+						<div className="text-sm text-muted-foreground space-y-1">
+							{identity.created_at && (
+								<p>Created: {formatDate(identity.created_at)}</p>
+							)}
+							{identity.updated_at && (
+								<p>Updated: {formatDate(identity.updated_at)}</p>
+							)}
+						</div>
+					)}
+				</>
+			)}
+		</div>
+	);
 }

--- a/client/src/pages/identities/components/CategoryPill.tsx
+++ b/client/src/pages/identities/components/CategoryPill.tsx
@@ -1,0 +1,29 @@
+import {
+	getIdentityCategoryColor,
+	getIdentityCategoryDisplayName,
+	getIdentityCategoryIcon,
+} from "@/enums/identityCategory";
+
+/**
+ * Category badge rendered as a colored pill with the category's icon.
+ *
+ * Shared by the identity detail view and the edit-form category dropdown so
+ * the dropdown options match the displayed badge exactly.
+ *
+ * Note on the icon classes: shadcn's Select trigger/item force any svg without
+ * a `size-`/`text-` class to `size-4` / muted-foreground. `size-3 text-current`
+ * opts out of both so the pill keeps its size and category color inside the
+ * dropdown.
+ */
+export function CategoryPill({ category }: { category: string }) {
+	const Icon = getIdentityCategoryIcon(category);
+	const colorClasses = getIdentityCategoryColor(category);
+	return (
+		<span
+			className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium ${colorClasses}`}
+		>
+			<Icon className="size-3 text-current" />
+			<span>{getIdentityCategoryDisplayName(category)}</span>
+		</span>
+	);
+}

--- a/client/src/pages/identities/components/IdentityEditForm.tsx
+++ b/client/src/pages/identities/components/IdentityEditForm.tsx
@@ -1,0 +1,133 @@
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { adminUpdateIdentity, updateIdentity } from "@/api/identities";
+import { useUserTarget } from "@/context/UserTargetContext";
+import type { Identity, UpdateIdentityRequest } from "@/types/identity";
+import { IdentityCategory } from "@/enums/identityCategory";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+} from "@/components/ui/select";
+import { CategoryPill } from "./CategoryPill";
+
+/**
+ * Inline edit form for a single identity's name, category, and I AM statement.
+ *
+ * Mirrors the scene-save pattern in Images.tsx: writes through the regular
+ * endpoint, or the admin endpoint when impersonating a test user, then
+ * invalidates the identities query so both /identities and /iams refresh.
+ * Calls `onDone()` after a successful save or when cancelled.
+ */
+export function IdentityEditForm({
+	identity,
+	onDone,
+}: {
+	identity: Identity;
+	onDone: () => void;
+}) {
+	const { isImpersonating, queryKeyPrefix } = useUserTarget();
+	const queryClient = useQueryClient();
+
+	const [name, setName] = useState(identity.name ?? "");
+	const [category, setCategory] = useState<IdentityCategory>(
+		identity.category as IdentityCategory,
+	);
+	const [iAmStatement, setIAmStatement] = useState(
+		identity.i_am_statement ?? "",
+	);
+	const [isSaving, setIsSaving] = useState(false);
+
+	const handleSave = async () => {
+		if (!identity.id) return;
+		if (!name.trim()) {
+			toast.error("Name can't be empty");
+			return;
+		}
+
+		setIsSaving(true);
+		try {
+			const payload: UpdateIdentityRequest = {
+				name: name.trim(),
+				category,
+				i_am_statement: iAmStatement.trim() || null,
+			};
+
+			if (isImpersonating) {
+				await adminUpdateIdentity(identity.id, payload);
+			} else {
+				await updateIdentity(identity.id, payload);
+			}
+
+			queryClient.invalidateQueries({
+				queryKey: [...queryKeyPrefix, "identities"],
+			});
+			toast.success("Identity updated");
+			onDone();
+		} catch (error) {
+			toast.error("Failed to update identity");
+			console.error("Failed to update identity:", error);
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	return (
+		<div className="space-y-6">
+			<div className="space-y-2">
+				<Label htmlFor="identity-name">Name</Label>
+				<Input
+					id="identity-name"
+					value={name}
+					onChange={(e) => setName(e.target.value)}
+					placeholder="e.g. Creative Visionary"
+				/>
+			</div>
+
+			<div className="space-y-2">
+				<Label htmlFor="identity-category">Category</Label>
+				<Select
+					value={category}
+					onValueChange={(v) => setCategory(v as IdentityCategory)}
+				>
+					<SelectTrigger id="identity-category" className="w-full">
+						<CategoryPill category={category} />
+					</SelectTrigger>
+					<SelectContent>
+						{Object.values(IdentityCategory).map((cat) => (
+							<SelectItem key={cat} value={cat}>
+								<CategoryPill category={cat} />
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</div>
+
+			<div className="space-y-2">
+				<Label htmlFor="identity-i-am">I AM Statement</Label>
+				<Textarea
+					id="identity-i-am"
+					value={iAmStatement}
+					onChange={(e) => setIAmStatement(e.target.value)}
+					rows={4}
+					placeholder="I am ..."
+				/>
+			</div>
+
+			<div className="flex items-center gap-3">
+				<Button onClick={handleSave} disabled={isSaving}>
+					{isSaving ? "Saving..." : "Save"}
+				</Button>
+				<Button variant="outline" onClick={onDone} disabled={isSaving}>
+					Cancel
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/client/src/types/identity.ts
+++ b/client/src/types/identity.ts
@@ -38,10 +38,20 @@ export interface Identity {
 }
 
 /**
- * Request payload for updating an identity's scene details.
+ * Request payload for partially updating an identity. All fields are
+ * optional — only the provided keys are changed (PATCH semantics).
  */
 export interface UpdateIdentityRequest {
+	/** Identity name/title */
+	name?: string;
+	/** I Am statement (null clears it) */
+	i_am_statement?: string | null;
+	/** Category bucket */
+	category?: IdentityCategory;
+	/** Scene: clothing/attire for visualization */
 	clothing?: string | null;
+	/** Scene: mood/feeling for visualization */
 	mood?: string | null;
+	/** Scene: setting/environment for visualization */
 	setting?: string | null;
 }


### PR DESCRIPTION
## What & why

Implements the **"edit i am"** piece of Leigh Ann's *edit identity info* task (the follow-up to #116's reordering). On `/identities/$identityId`, an **Edit** button (pencil, top-right) flips the page into an editable form; **Save** persists and reverts to the read-only view, **Cancel** discards.

Scope is **edit only** — *delete identity* is still deferred.

## Editable fields
- **Name** — text input
- **Category** — dropdown whose options (and the selected trigger value) render as the colored icon **pills**, matching the detail-page badge
- **I AM statement** — textarea

Name is required; clearing the I AM sets it to `null`.

## How it works
- New **`IdentityEditForm`** component owns the draft state + save.
- New shared **`CategoryPill`** component renders the colored, icon'd category badge. The detail view now reuses it too (removed the duplicated inline badge), so the dropdown and the badge always match. (Icon uses `size-3 text-current` so shadcn's Select doesn't override it to muted gray at `size-4`.)
- Save mirrors the existing scene-save pattern in `Images.tsx`: writes via `PATCH /identities/{id}`, or the admin `update-identity` endpoint when impersonating a test user, then invalidates the identities query so **both** `/identities` and `/iams` refresh. Success/failure toasts.
- Broadened `UpdateIdentityRequest` with `name`/`i_am_statement`/`category` (all optional, PATCH semantics) and aligned `adminUpdateIdentity` to that type.

## Notes
- **Frontend-only** — the backend already accepts these fields via `IdentitySerializer(partial=True)`; verified with a validation-only check against a real identity (no data mutated).
- `tsc` clean. The one remaining biome `noRedeclare` warning (`function Identity` vs `import type { Identity }`) **pre-exists on `main`** and is unrelated; this PR actually cleaned up a stale import-type warning in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)