### PR TITLE
feat(identities): reorder while impersonating + side-by-side edit fields

### DIFF
--- a/client/src/api/identities.ts
+++ b/client/src/api/identities.ts
@@ -59,6 +59,36 @@ export async function reorderIdentities(
 }
 
 /**
+ * Reorder another user's identities (admin only).
+ * Used when impersonating a test user, since the regular reorder endpoint is
+ * scoped to the logged-in user.
+ * Calls POST /admin/identities/reorder
+ *
+ * @param userId - The user whose identities to reorder
+ * @param orderedIds - Identity IDs in the desired display order (first = top)
+ * @returns The user's identities in the new order
+ */
+export async function adminReorderIdentities(
+	userId: string,
+	orderedIds: string[],
+): Promise<Identity[]> {
+	log.debug(`Admin reordering identities for user ${userId}`, orderedIds);
+	const response = await authFetch(
+		`${COACH_BASE_URL}/admin/identities/reorder`,
+		{
+			method: "POST",
+			body: JSON.stringify({ user_id: userId, ordered_ids: orderedIds }),
+		},
+	);
+	if (!response.ok) {
+		const errorText = await response.text();
+		log.error(`Failed to admin-reorder identities: ${errorText}`);
+		throw new Error("Failed to reorder identities");
+	}
+	return response.json();
+}
+
+/**
  * Update any identity (admin only, partial update).
  * Used for updating test user identities from admin pages.
  * PATCH /api/v1/admin/identities/update-identity

--- a/client/src/hooks/use-identities.ts
+++ b/client/src/hooks/use-identities.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { fetchIdentities } from "@/api/user";
 import { fetchTestScenarioUserIdentities } from "@/api/testScenarioUser";
-import { reorderIdentities } from "@/api/identities";
+import { adminReorderIdentities, reorderIdentities } from "@/api/identities";
 import { useUserTarget } from "@/context/UserTargetContext";
 import type { Identity } from "@/types/identity";
 
@@ -13,9 +13,9 @@ import type { Identity } from "@/types/identity";
  * and which API endpoint to call. When inside a UserTargetProvider, fetches
  * from the admin test-user endpoint instead of /user/me/.
  *
- * Also exposes a `reorder` mutation (logged-in user only) that optimistically
- * updates the cached order so drag-to-reorder feels instant, then persists via
- * POST /identities/reorder.
+ * Also exposes a `reorder` mutation that optimistically updates the cached
+ * order so drag-to-reorder feels instant, then persists via the regular
+ * endpoint or the admin endpoint when impersonating a test user.
  *
  * Used in: Any component that needs to read the user's identities.
  */
@@ -40,7 +40,10 @@ export function useIdentities() {
 		string[],
 		{ previous: Identity[] | undefined }
 	>({
-		mutationFn: (orderedIds: string[]) => reorderIdentities(orderedIds),
+		mutationFn: (orderedIds: string[]) =>
+			isImpersonating
+				? adminReorderIdentities(targetUserId!, orderedIds)
+				: reorderIdentities(orderedIds),
 		onMutate: async (orderedIds: string[]) => {
 			// Optimistically apply the new order to the cache for an instant UI.
 			await queryClient.cancelQueries({ queryKey: identitiesKey });

--- a/client/src/pages/i_ams/IAms.tsx
+++ b/client/src/pages/i_ams/IAms.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { useIdentities } from "@/hooks/use-identities";
-import { useUserTarget } from "@/context/UserTargetContext";
 import type { Identity } from "@/types/identity";
 import { Link } from "@tanstack/react-router";
 import { getArticle } from "@/utils/getArticle";
@@ -29,8 +28,9 @@ import { CSS } from "@dnd-kit/utilities";
  * Purpose:
  * - Displays the user's identities in a grid layout
  * - Drag-to-reorder: grab a card's handle to change the display order. The
- *   order persists (POST /identities/reorder) and applies to both /iams and
- *   /identities. Reordering is disabled while impersonating a test user.
+ *   order persists and applies to both /iams and /identities. Works for the
+ *   logged-in user and for an admin impersonating a test user (the hook routes
+ *   to the regular or admin reorder endpoint accordingly).
  *
  * Smoothness: the grid renders from local `items` state that we reorder
  * synchronously on drop, so dnd-kit animates into place without waiting on the
@@ -46,13 +46,7 @@ const DEFAULT_I_AM_STATEMENT =
  * page; only the grip handle initiates a drag, so clicking the card still
  * navigates as before.
  */
-function SortableIAmCard({
-	identity,
-	draggable,
-}: {
-	identity: Identity;
-	draggable: boolean;
-}) {
+function SortableIAmCard({ identity }: { identity: Identity }) {
 	const {
 		attributes,
 		listeners,
@@ -60,7 +54,7 @@ function SortableIAmCard({
 		transform,
 		transition,
 		isDragging,
-	} = useSortable({ id: identity.id ?? "", disabled: !draggable });
+	} = useSortable({ id: identity.id ?? "" });
 
 	const style = {
 		transform: CSS.Transform.toString(transform),
@@ -74,18 +68,16 @@ function SortableIAmCard({
 			style={style}
 			className={`group/card relative ${isDragging ? "opacity-90" : ""}`}
 		>
-			{draggable && (
-				<button
-					type="button"
-					aria-label="Drag to reorder"
-					title="Drag to reorder"
-					className="absolute top-2.5 right-2.5 z-10 grid h-7 w-7 cursor-grab touch-none place-items-center rounded-lg border border-white/20 bg-black/45 text-white shadow-md backdrop-blur-md transition-all duration-200 hover:scale-105 hover:bg-black/65 active:scale-95 active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 opacity-100 md:opacity-0 md:group-hover/card:opacity-100 md:focus-visible:opacity-100"
-					{...attributes}
-					{...listeners}
-				>
-					<GripVertical className="h-[14px] w-[14px]" />
-				</button>
-			)}
+			<button
+				type="button"
+				aria-label="Drag to reorder"
+				title="Drag to reorder"
+				className="absolute top-2.5 right-2.5 z-10 grid h-7 w-7 cursor-grab touch-none place-items-center rounded-lg border border-white/20 bg-black/45 text-white shadow-md backdrop-blur-md transition-all duration-200 hover:scale-105 hover:bg-black/65 active:scale-95 active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 opacity-100 md:opacity-0 md:group-hover/card:opacity-100 md:focus-visible:opacity-100"
+				{...attributes}
+				{...listeners}
+			>
+				<GripVertical className="h-[14px] w-[14px]" />
+			</button>
 			<Link
 				to="/identities/$identityId"
 				params={{ identityId: identity.id ?? "" }}
@@ -122,7 +114,6 @@ function SortableIAmCard({
 
 export default function IAms() {
 	const { identities, isLoading, isError, reorderIdentities } = useIdentities();
-	const { isImpersonating } = useUserTarget();
 
 	// Local copy that drives the grid so a drop reorders instantly (smooth
 	// dnd-kit animation) without waiting on the network. We only adopt the
@@ -166,8 +157,6 @@ export default function IAms() {
 		);
 	}
 
-	// Only the logged-in user can persist a reorder (endpoint is user-scoped).
-	const draggable = !isImpersonating;
 	const ids = items.map((identity) => identity.id ?? "");
 
 	const handleDragEnd = (event: DragEndEvent) => {
@@ -184,33 +173,24 @@ export default function IAms() {
 		reorderIdentities(reordered.map((identity) => identity.id ?? ""));
 	};
 
-	const grid = (
-		<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-[32px]">
-			{items.map((identity: Identity, index: number) => (
-				<SortableIAmCard
-					key={identity.id || `identity-${index}`}
-					identity={identity}
-					draggable={draggable}
-				/>
-			))}
-		</div>
-	);
-
 	return (
 		<div className="flex flex-col gap-[32px] bg-white">
-			{draggable ? (
-				<DndContext
-					sensors={sensors}
-					collisionDetection={closestCenter}
-					onDragEnd={handleDragEnd}
-				>
-					<SortableContext items={ids} strategy={rectSortingStrategy}>
-						{grid}
-					</SortableContext>
-				</DndContext>
-			) : (
-				grid
-			)}
+			<DndContext
+				sensors={sensors}
+				collisionDetection={closestCenter}
+				onDragEnd={handleDragEnd}
+			>
+				<SortableContext items={ids} strategy={rectSortingStrategy}>
+					<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-[32px]">
+						{items.map((identity: Identity, index: number) => (
+							<SortableIAmCard
+								key={identity.id || `identity-${index}`}
+								identity={identity}
+							/>
+						))}
+					</div>
+				</SortableContext>
+			</DndContext>
 		</div>
 	);
 }

--- a/client/src/pages/identities/components/IdentityEditForm.tsx
+++ b/client/src/pages/identities/components/IdentityEditForm.tsx
@@ -80,33 +80,36 @@ export function IdentityEditForm({
 
 	return (
 		<div className="space-y-6">
-			<div className="space-y-2">
-				<Label htmlFor="identity-name">Name</Label>
-				<Input
-					id="identity-name"
-					value={name}
-					onChange={(e) => setName(e.target.value)}
-					placeholder="e.g. Creative Visionary"
-				/>
-			</div>
+			{/* Name + Category sit side by side on wider screens, stacked on small */}
+			<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+				<div className="space-y-2">
+					<Label htmlFor="identity-name">Name</Label>
+					<Input
+						id="identity-name"
+						value={name}
+						onChange={(e) => setName(e.target.value)}
+						placeholder="e.g. Creative Visionary"
+					/>
+				</div>
 
-			<div className="space-y-2">
-				<Label htmlFor="identity-category">Category</Label>
-				<Select
-					value={category}
-					onValueChange={(v) => setCategory(v as IdentityCategory)}
-				>
-					<SelectTrigger id="identity-category" className="w-full">
-						<CategoryPill category={category} />
-					</SelectTrigger>
-					<SelectContent>
-						{Object.values(IdentityCategory).map((cat) => (
-							<SelectItem key={cat} value={cat}>
-								<CategoryPill category={cat} />
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
+				<div className="space-y-2">
+					<Label htmlFor="identity-category">Category</Label>
+					<Select
+						value={category}
+						onValueChange={(v) => setCategory(v as IdentityCategory)}
+					>
+						<SelectTrigger id="identity-category" className="w-full">
+							<CategoryPill category={category} />
+						</SelectTrigger>
+						<SelectContent>
+							{Object.values(IdentityCategory).map((cat) => (
+								<SelectItem key={cat} value={cat}>
+									<CategoryPill category={cat} />
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
 			</div>
 
 			<div className="space-y-2">

--- a/server/apps/identities/tests/test_reorder_identities.py
+++ b/server/apps/identities/tests/test_reorder_identities.py
@@ -156,3 +156,71 @@ class ReorderEndpointTests(APITestCase):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class AdminReorderEndpointTests(APITestCase):
+    """Tests for POST /api/v1/admin/identities/reorder (admin impersonation)."""
+
+    URL = "/api/v1/admin/identities/reorder"
+
+    def setUp(self):
+        self.client = APIClient()
+        self.admin = User.objects.create_user(
+            email="admin@example.com", password="testpass123", is_staff=True
+        )
+        self.target = User.objects.create_user(
+            email="target@example.com", password="testpass123"
+        )
+        self.client.force_authenticate(user=self.admin)
+        self.a = _make_identity(self.target, "A")
+        self.b = _make_identity(self.target, "B")
+        self.c = _make_identity(self.target, "C")
+
+    def test_admin_reorders_target_users_identities(self):
+        response = self.client.post(
+            self.URL,
+            {
+                "user_id": str(self.target.id),
+                "ordered_ids": [str(self.c.id), str(self.a.id), str(self.b.id)],
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual([item["name"] for item in response.data], ["C", "A", "B"])
+
+        self.a.refresh_from_db()
+        self.b.refresh_from_db()
+        self.c.refresh_from_db()
+        self.assertEqual((self.c.order, self.a.order, self.b.order), (0, 1, 2))
+
+    def test_missing_user_id_is_rejected(self):
+        response = self.client.post(
+            self.URL,
+            {"ordered_ids": [str(self.a.id)]},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_rejects_identity_not_owned_by_target_user(self):
+        other = User.objects.create_user(
+            email="other@example.com", password="testpass123"
+        )
+        other_identity = _make_identity(other, "Not Theirs")
+        response = self.client.post(
+            self.URL,
+            {
+                "user_id": str(self.target.id),
+                "ordered_ids": [str(self.a.id), str(other_identity.id)],
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_non_admin_is_forbidden(self):
+        self.client.force_authenticate(user=self.target)
+        response = self.client.post(
+            self.URL,
+            {"user_id": str(self.target.id), "ordered_ids": [str(self.a.id)]},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/server/apps/identities/views/admin_identity_view_set.py
+++ b/server/apps/identities/views/admin_identity_view_set.py
@@ -15,9 +15,14 @@ from rest_framework.decorators import action
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 from rest_framework.response import Response
 
+from apps.identities.functions.public import reorder_user_identities
 from apps.identities.models import Identity
-from apps.identities.serializers import IdentitySerializer
+from apps.identities.serializers import (
+    IdentitySerializer,
+    ReorderIdentitiesRequestSerializer,
+)
 from apps.reference_images.models import ReferenceImage
+from apps.users.functions import get_user_identities
 from permissions import IsAdminUser
 from services.image_generation.orchestration import generate_identity_image
 from services.logger import configure_logging
@@ -86,6 +91,61 @@ class AdminIdentityViewSet(viewsets.GenericViewSet):
 
         log.info(f"Admin {request.user.id} updated identity {identity_id}")
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @action(
+        detail=False,
+        methods=["POST"],
+        url_path="reorder",
+        permission_classes=[IsAdminUser],
+    )
+    def reorder(self, request):
+        """
+        Reorder a specific user's identities (admin only).
+        POST /api/v1/admin/identities/reorder
+
+        Used when an admin is impersonating a test user — the regular
+        /identities/reorder endpoint is scoped to request.user, so admins need
+        this to reorder the impersonated user's identities.
+
+        Body (JSON):
+        - user_id: UUID of the user whose identities to reorder
+        - ordered_ids: identity IDs in the desired display order (first = top)
+
+        Returns: 200 OK with the user's identities in the new order.
+        """
+        user_id = request.data.get("user_id")
+        if not user_id:
+            return Response(
+                {"success": False, "error": "user_id is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            target_user = User.objects.get(pk=user_id)
+        except User.DoesNotExist:
+            return Response(
+                {"success": False, "error": f"User with id {user_id} not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        serializer = ReorderIdentitiesRequestSerializer(
+            data=request.data, context={"user": target_user}
+        )
+        serializer.is_valid(raise_exception=True)
+
+        reorder_user_identities(
+            user=target_user,
+            ordered_ids=serializer.validated_data["ordered_ids"],
+        )
+
+        log.info(
+            f"Admin {request.user.id} reordered identities for user {target_user.id}"
+        )
+        identities = get_user_identities(target_user)
+        return Response(
+            IdentitySerializer(identities, many=True).data,
+            status=status.HTTP_200_OK,
+        )
 
     @action(
         detail=False,


### PR DESCRIPTION
## Why

Two follow-ups to the identity reorder (#116) and edit (#117) work:

1. **Reorder didn't work while impersonating a user.** The `/iams` drag was disabled during admin impersonation because `POST /identities/reorder` is scoped to `request.user` — so an admin viewing a test user couldn't reorder that user's tiles, which made the feature useless in that context.
2. The edit form stacked **Name** and **Category** full-width even on wide screens, which looked off.

## Reorder while impersonating

**Backend** — new admin endpoint `POST /api/v1/admin/identities/reorder`:
- Body `{ user_id, ordered_ids }`.
- Reuses `ReorderIdentitiesRequestSerializer` with the **target** user in context (ownership of `ordered_ids` validated against `user_id`, not the admin), then delegates to the existing `reorder_user_identities()` function.
- `IsAdminUser` (staff/superuser) gated, mirroring the other admin identity actions.

**Frontend**:
- `useIdentities` routes the reorder mutation to the admin endpoint with `targetUserId` when impersonating, and the regular endpoint otherwise — the same branching the edit/scene-save already uses. The optimistic update + invalidation key are impersonation-scoped, so they already line up.
- The `/iams` grid is **always draggable** now (removed the `!isImpersonating` gate and the now-dead `draggable` prop plumbing).

**Tests** — 4 new backend tests: admin happy path (order persists, list returned in new order), missing `user_id` → 400, identity not owned by the target user → 400, non-admin → 403. Full reorder suite: 14 passing.

## Edit form layout

`Name` and `Category` now sit side by side on `md+` (`grid grid-cols-1 md:grid-cols-2`) and stack on small screens. The I AM textarea and Save/Cancel are unchanged.

## Notes
- `tsc` clean. The 2 biome `noNonNullAssertion` warnings on `targetUserId!` in `use-identities.ts` follow the pre-existing pattern already in that file (line 30, merged in #116); not a CI gate (both prior PRs merged with it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)