### PR TITLE
feat(identities): delete identity + record edit/delete as user notes

### DIFF
--- a/client/src/api/identities.ts
+++ b/client/src/api/identities.ts
@@ -89,6 +89,46 @@ export async function adminReorderIdentities(
 }
 
 /**
+ * Delete one of the authenticated user's identities.
+ * Calls DELETE /identities/{id}
+ *
+ * @param identityId - The ID of the identity to delete
+ */
+export async function deleteIdentity(identityId: string): Promise<void> {
+	log.debug(`Deleting identity ${identityId}`);
+	const response = await authFetch(
+		`${COACH_BASE_URL}/identities/${identityId}`,
+		{ method: "DELETE" },
+	);
+	if (!response.ok) {
+		const errorText = await response.text();
+		log.error(`Failed to delete identity: ${errorText}`);
+		throw new Error("Failed to delete identity");
+	}
+}
+
+/**
+ * Delete any identity (admin only).
+ * Used when impersonating a test user, since the regular delete endpoint is
+ * scoped to the logged-in user.
+ * Calls DELETE /admin/identities/delete-identity?identity_id={id}
+ *
+ * @param identityId - The ID of the identity to delete
+ */
+export async function adminDeleteIdentity(identityId: string): Promise<void> {
+	log.debug(`Admin deleting identity ${identityId}`);
+	const response = await authFetch(
+		`${COACH_BASE_URL}/admin/identities/delete-identity?identity_id=${identityId}`,
+		{ method: "DELETE" },
+	);
+	if (!response.ok) {
+		const errorText = await response.text();
+		log.error(`Failed to admin-delete identity: ${errorText}`);
+		throw new Error("Failed to delete identity");
+	}
+}
+
+/**
  * Update any identity (admin only, partial update).
  * Used for updating test user identities from admin pages.
  * PATCH /api/v1/admin/identities/update-identity

--- a/client/src/pages/identities/Identity.tsx
+++ b/client/src/pages/identities/Identity.tsx
@@ -6,6 +6,7 @@ import type { IdentityState } from "@/enums/identityState";
 import type { Identity } from "@/types/identity";
 import { Button } from "@/components/ui/button";
 import { IdentityEditForm } from "./components/IdentityEditForm";
+import { IdentityDeleteButton } from "./components/IdentityDeleteButton";
 import { CategoryPill } from "./components/CategoryPill";
 
 /**
@@ -111,17 +112,20 @@ export default function Identity() {
 					<span>Back to Identities</span>
 				</Link>
 				{!isEditing && (
-					<Button
-						variant="outline"
-						size="sm"
-						onClick={() => setIsEditing(true)}
-						className="gap-2"
-						aria-label="Edit identity"
-						title="Edit identity"
-					>
-						<Pencil className="h-4 w-4" />
-						Edit
-					</Button>
+					<div className="flex items-center gap-2">
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => setIsEditing(true)}
+							className="gap-2"
+							aria-label="Edit identity"
+							title="Edit identity"
+						>
+							<Pencil className="h-4 w-4" />
+							Edit
+						</Button>
+						<IdentityDeleteButton identity={identity} />
+					</div>
 				)}
 			</div>
 

--- a/client/src/pages/identities/components/IdentityDeleteButton.tsx
+++ b/client/src/pages/identities/components/IdentityDeleteButton.tsx
@@ -1,0 +1,101 @@
+import { useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Trash2 } from "lucide-react";
+import { adminDeleteIdentity, deleteIdentity } from "@/api/identities";
+import { useUserTarget } from "@/context/UserTargetContext";
+import type { Identity } from "@/types/identity";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+
+/**
+ * Delete affordance for the identity detail page: a destructive trash button
+ * that opens a confirmation dialog. On confirm it deletes via the regular
+ * endpoint, or the admin endpoint when impersonating a test user, then
+ * invalidates the identities query and navigates back to the list.
+ */
+export function IdentityDeleteButton({ identity }: { identity: Identity }) {
+	const { isImpersonating, queryKeyPrefix } = useUserTarget();
+	const queryClient = useQueryClient();
+	const navigate = useNavigate();
+
+	const [open, setOpen] = useState(false);
+	const [isDeleting, setIsDeleting] = useState(false);
+
+	const handleDelete = async () => {
+		if (!identity.id) return;
+
+		setIsDeleting(true);
+		try {
+			if (isImpersonating) {
+				await adminDeleteIdentity(identity.id);
+			} else {
+				await deleteIdentity(identity.id);
+			}
+
+			queryClient.invalidateQueries({
+				queryKey: [...queryKeyPrefix, "identities"],
+			});
+			toast.success("Identity deleted");
+			setOpen(false);
+			navigate({ to: "/identities" });
+		} catch (error) {
+			toast.error("Failed to delete identity");
+			console.error("Failed to delete identity:", error);
+		} finally {
+			setIsDeleting(false);
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>
+				<Button
+					variant="outline"
+					size="sm"
+					className="gap-2 text-destructive hover:text-destructive"
+					aria-label="Delete identity"
+					title="Delete identity"
+				>
+					<Trash2 className="h-4 w-4" />
+					Delete
+				</Button>
+			</DialogTrigger>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Delete this identity?</DialogTitle>
+					<DialogDescription>
+						This permanently deletes
+						{identity.name ? ` "${identity.name}"` : " this identity"} and its
+						image. This can't be undone.
+					</DialogDescription>
+				</DialogHeader>
+				<DialogFooter>
+					<Button
+						variant="outline"
+						onClick={() => setOpen(false)}
+						disabled={isDeleting}
+					>
+						Cancel
+					</Button>
+					<Button
+						variant="destructive"
+						onClick={handleDelete}
+						disabled={isDeleting}
+					>
+						{isDeleting ? "Deleting..." : "Delete"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/server/apps/identities/functions/public/__init__.py
+++ b/server/apps/identities/functions/public/__init__.py
@@ -5,6 +5,11 @@ User-facing business logic functions for identity image generation.
 """
 
 from .continue_image_chat import continue_image_chat
+from .record_identity_activity import (
+    capture_identity_fields,
+    record_identity_delete_note,
+    record_identity_edit_note,
+)
 from .reorder_user_identities import reorder_user_identities
 from .start_image_chat import start_image_chat
 
@@ -12,4 +17,7 @@ __all__ = [
     "start_image_chat",
     "continue_image_chat",
     "reorder_user_identities",
+    "capture_identity_fields",
+    "record_identity_edit_note",
+    "record_identity_delete_note",
 ]

--- a/server/apps/identities/functions/public/record_identity_activity.py
+++ b/server/apps/identities/functions/public/record_identity_activity.py
@@ -1,0 +1,74 @@
+"""
+Record UserNotes for identity edits/deletes the user makes through the app.
+
+These actions happen OUTSIDE the coaching conversation (on the Identities
+pages), so the coaching agent would otherwise have no idea they occurred. We
+write a plain-language UserNote so the agent can reference them naturally — the
+same channel the Sentinel uses for things it learns in-conversation.
+"""
+
+from apps.user_notes.functions.public import create_user_note
+from enums.identity_category import IdentityCategory
+
+
+def _category_label(value):
+    """Human-readable category label, falling back to the raw value."""
+    try:
+        return IdentityCategory(value).label
+    except ValueError:
+        return str(value)
+
+
+def capture_identity_fields(identity):
+    """Snapshot the user-facing fields we track for edit notes."""
+    return {
+        "name": identity.name,
+        "category": identity.category,
+        "i_am_statement": identity.i_am_statement,
+    }
+
+
+def record_identity_edit_note(user, before, identity):
+    """
+    Create a note describing how ``identity`` changed vs the ``before`` snapshot.
+
+    Only name / category / I Am statement changes are described — scene/image
+    fields (clothing, mood, setting) are intentionally ignored since they aren't
+    relevant to the coaching conversation. Returns the UserNote, or None when
+    no tracked field changed.
+    """
+    name = identity.name or before.get("name") or "Unnamed"
+    changes = []
+
+    if before["name"] != identity.name:
+        old_name = before["name"] or "Unnamed"
+        changes.append(f'renamed their "{old_name}" identity to "{identity.name}"')
+
+    if before["category"] != identity.category:
+        changes.append(
+            f'changed the category of their "{name}" identity from '
+            f"{_category_label(before['category'])} to "
+            f"{_category_label(identity.category)}"
+        )
+
+    if before["i_am_statement"] != identity.i_am_statement:
+        if identity.i_am_statement:
+            changes.append(
+                f'updated the I Am statement for their "{name}" identity to: '
+                f'"{identity.i_am_statement}"'
+            )
+        else:
+            changes.append(f'cleared the I Am statement for their "{name}" identity')
+
+    if not changes:
+        return None
+
+    note = "Outside of our conversation, the user " + "; ".join(changes) + "."
+    return create_user_note(user, note, test_scenario=identity.test_scenario)
+
+
+def record_identity_delete_note(user, identity):
+    """Create a note that the user deleted an identity (call before deletion)."""
+    name = identity.name or "Unnamed"
+    note = f'Outside of our conversation, the user deleted their "{name}" identity.'
+    return create_user_note(user, note, test_scenario=identity.test_scenario)

--- a/server/apps/identities/tests/test_identity_activity_notes.py
+++ b/server/apps/identities/tests/test_identity_activity_notes.py
@@ -1,0 +1,120 @@
+"""
+Tests that identity edits/deletes made through the app record a UserNote (so
+the coaching agent is aware of out-of-session changes), plus the admin
+delete-identity endpoint used during impersonation.
+"""
+
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from apps.identities.models import Identity
+from apps.user_notes.models import UserNote
+from apps.users.models import User
+from enums.identity_category import IdentityCategory
+
+
+def _make_identity(user, name, **kwargs):
+    return Identity.objects.create(
+        user=user, name=name, category=IdentityCategory.PASSIONS, **kwargs
+    )
+
+
+class UserIdentityActivityNoteTests(APITestCase):
+    """The user-facing edit (PATCH) and delete (DELETE) endpoints."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            email="notes@example.com", password="testpass123"
+        )
+        self.client.force_authenticate(user=self.user)
+        self.identity = _make_identity(self.user, "Acrobat")
+
+    def test_rename_records_a_note(self):
+        response = self.client.patch(
+            f"/api/v1/identities/{self.identity.id}",
+            {"name": "Fitness Enthusiast"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        notes = UserNote.objects.filter(user=self.user)
+        self.assertEqual(notes.count(), 1)
+        self.assertIn("Acrobat", notes.first().note)
+        self.assertIn("Fitness Enthusiast", notes.first().note)
+
+    def test_i_am_statement_edit_records_a_note(self):
+        response = self.client.patch(
+            f"/api/v1/identities/{self.identity.id}",
+            {"i_am_statement": "I am unstoppable."},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(UserNote.objects.filter(user=self.user).count(), 1)
+        self.assertIn("I am unstoppable.", UserNote.objects.first().note)
+
+    def test_scene_only_edit_records_no_note(self):
+        response = self.client.patch(
+            f"/api/v1/identities/{self.identity.id}",
+            {"clothing": "linen shirt", "mood": "calm"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(UserNote.objects.filter(user=self.user).count(), 0)
+
+    def test_delete_records_a_note_and_removes_identity(self):
+        response = self.client.delete(f"/api/v1/identities/{self.identity.id}")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        self.assertFalse(Identity.objects.filter(id=self.identity.id).exists())
+        notes = UserNote.objects.filter(user=self.user)
+        self.assertEqual(notes.count(), 1)
+        self.assertIn("deleted", notes.first().note.lower())
+        self.assertIn("Acrobat", notes.first().note)
+
+
+class AdminIdentityDeleteTests(APITestCase):
+    """The admin delete-identity endpoint (impersonation)."""
+
+    URL = "/api/v1/admin/identities/delete-identity"
+
+    def setUp(self):
+        self.client = APIClient()
+        self.admin = User.objects.create_user(
+            email="admin@example.com", password="testpass123", is_staff=True
+        )
+        self.target = User.objects.create_user(
+            email="target@example.com", password="testpass123"
+        )
+        self.client.force_authenticate(user=self.admin)
+        self.identity = _make_identity(self.target, "Acrobat")
+
+    def test_admin_deletes_target_identity_and_records_note(self):
+        response = self.client.delete(f"{self.URL}?identity_id={self.identity.id}")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        self.assertFalse(Identity.objects.filter(id=self.identity.id).exists())
+        # Note is recorded against the target user, not the admin.
+        self.assertEqual(UserNote.objects.filter(user=self.target).count(), 1)
+        self.assertEqual(UserNote.objects.filter(user=self.admin).count(), 0)
+
+    def test_admin_edit_records_note_for_target_user(self):
+        response = self.client.patch(
+            "/api/v1/admin/identities/update-identity",
+            {"identity_id": str(self.identity.id), "name": "Marathoner"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        notes = UserNote.objects.filter(user=self.target)
+        self.assertEqual(notes.count(), 1)
+        self.assertIn("Marathoner", notes.first().note)
+
+    def test_missing_identity_id_is_rejected(self):
+        response = self.client.delete(self.URL)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_non_admin_is_forbidden(self):
+        self.client.force_authenticate(user=self.target)
+        response = self.client.delete(f"{self.URL}?identity_id={self.identity.id}")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertTrue(Identity.objects.filter(id=self.identity.id).exists())

--- a/server/apps/identities/views/admin_identity_view_set.py
+++ b/server/apps/identities/views/admin_identity_view_set.py
@@ -15,7 +15,12 @@ from rest_framework.decorators import action
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 from rest_framework.response import Response
 
-from apps.identities.functions.public import reorder_user_identities
+from apps.identities.functions.public import (
+    capture_identity_fields,
+    record_identity_delete_note,
+    record_identity_edit_note,
+    reorder_user_identities,
+)
 from apps.identities.models import Identity
 from apps.identities.serializers import (
     IdentitySerializer,
@@ -85,12 +90,55 @@ class AdminIdentityViewSet(viewsets.GenericViewSet):
         # Remove identity_id from data before passing to serializer
         update_data = {k: v for k, v in request.data.items() if k != "identity_id"}
 
+        before = capture_identity_fields(identity)
         serializer = IdentitySerializer(identity, data=update_data, partial=True)
         serializer.is_valid(raise_exception=True)
         serializer.save()
+        # Record a UserNote against the identity's owner (the impersonated user).
+        record_identity_edit_note(identity.user, before, identity)
 
         log.info(f"Admin {request.user.id} updated identity {identity_id}")
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @action(
+        detail=False,
+        methods=["DELETE"],
+        url_path="delete-identity",
+        permission_classes=[IsAdminUser],
+    )
+    def delete_identity(self, request):
+        """
+        Delete any identity (admin only).
+        DELETE /api/v1/admin/identities/delete-identity?identity_id=<id>
+
+        Used when an admin is impersonating a test user — the regular
+        DELETE /identities/{id} endpoint is scoped to request.user.
+
+        Returns: 204 No Content.
+        """
+        identity_id = request.query_params.get("identity_id")
+        if not identity_id:
+            return Response(
+                {"success": False, "error": "identity_id is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            identity = Identity.objects.get(id=identity_id)
+        except Identity.DoesNotExist:
+            return Response(
+                {"success": False, "error": "Identity not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        # Record a UserNote against the identity's owner before deletion.
+        record_identity_delete_note(identity.user, identity)
+        if identity.image:
+            identity.image.delete()
+        identity.delete()
+
+        log.info(f"Admin {request.user.id} deleted identity {identity_id}")
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(
         detail=False,

--- a/server/apps/identities/views/identity_view_set.py
+++ b/server/apps/identities/views/identity_view_set.py
@@ -13,7 +13,12 @@ from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from apps.identities.functions.public import reorder_user_identities
+from apps.identities.functions.public import (
+    capture_identity_fields,
+    record_identity_delete_note,
+    record_identity_edit_note,
+    reorder_user_identities,
+)
 from apps.identities.models import Identity
 from apps.identities.serializers import (
     IdentitySerializer,
@@ -203,9 +208,12 @@ class IdentityViewSet(
         try:
             pk = kwargs.get("pk")
             identity = get_object_or_404(Identity, id=pk, user=request.user)
+            before = capture_identity_fields(identity)
             serializer = IdentitySerializer(identity, data=request.data, partial=True)
             serializer.is_valid(raise_exception=True)
             serializer.save()
+            # Record a UserNote so the coach knows about edits made via the app.
+            record_identity_edit_note(request.user, before, identity)
             return Response(serializer.data, status=status.HTTP_200_OK)
         except ValidationError as e:
             log.error(f"Validation error during partial update: {e.detail}")
@@ -238,6 +246,8 @@ class IdentityViewSet(
         try:
             pk = kwargs.get("pk")
             identity = get_object_or_404(Identity, id=pk, user=request.user)
+            # Record a UserNote (before deletion, while the name is available).
+            record_identity_delete_note(request.user, identity)
             # Delete the image file if it exists
             if identity.image:
                 identity.image.delete()

--- a/server/apps/user_notes/functions/__init__.py
+++ b/server/apps/user_notes/functions/__init__.py
@@ -1,0 +1,7 @@
+"""
+Functions for the user_notes app.
+"""
+
+from .public import create_user_note
+
+__all__ = ["create_user_note"]

--- a/server/apps/user_notes/functions/public/__init__.py
+++ b/server/apps/user_notes/functions/public/__init__.py
@@ -1,0 +1,7 @@
+"""
+Public functions for the user_notes app.
+"""
+
+from .create_user_note import create_user_note
+
+__all__ = ["create_user_note"]

--- a/server/apps/user_notes/functions/public/create_user_note.py
+++ b/server/apps/user_notes/functions/public/create_user_note.py
@@ -1,0 +1,36 @@
+"""
+Create a single UserNote.
+
+A small public helper so other apps (e.g. identity edit/delete endpoints) can
+record a note about something the user did, without each caller reaching into
+the ORM directly. Notes created here feed the coaching agent's prompt via
+`get_user_notes_context`.
+"""
+
+from apps.user_notes.models import UserNote
+
+
+def create_user_note(user, note, *, test_scenario=None, source_message=None):
+    """
+    Create a UserNote for ``user``.
+
+    Args:
+        user: The user the note is about.
+        note: The note text. Blank/whitespace-only notes are ignored.
+        test_scenario: Optional TestScenario for test-data isolation (e.g. when
+            an admin acts on an impersonated test user's identity).
+        source_message: Optional ChatMessage that prompted the note.
+
+    Returns:
+        The created UserNote, or None if the note text was blank.
+    """
+    text = (note or "").strip()
+    if not text:
+        return None
+
+    return UserNote.objects.create(
+        user=user,
+        note=text,
+        test_scenario=test_scenario,
+        source_message=source_message,
+    )


### PR DESCRIPTION
## Why

Closes the last of Leigh Ann's *edit identity info* checkboxes — **delete an identity** — and adds the activity-tracking idea so the coaching agent knows about changes the user makes outside the conversation.

## Delete an identity
- **Detail page** (`/identities/$identityId`): a destructive **Delete** button next to Edit opens a confirmation dialog; on confirm it deletes and navigates back to `/identities` (toast on success/failure).
- **API**: new `deleteIdentity` (user) and `adminDeleteIdentity`; the page routes to the admin endpoint when impersonating a test user.
- **Backend**: new admin endpoint `DELETE /api/v1/admin/identities/delete-identity?identity_id=<id>` (`IsAdminUser`), mirroring the edit/reorder admin variants so delete works during impersonation.

## Activity notes (agent awareness)
Edits and deletes made through the app happen *outside* the coaching chat, so the agent would otherwise never know. We now record a plain-language **UserNote** for them:
- `Outside of our conversation, the user renamed their "Acrobat" identity to "Fitness Enthusiast".`
- `Outside of our conversation, the user updated the I Am statement for their "Acrobat" identity to: "…".`
- `Outside of our conversation, the user deleted their "Acrobat" identity.`

These feed the prompt through the **existing** `get_user_notes_context` (the same `## User Notes` block the Sentinel writes to) — no prompt or LLM changes needed, so the conversation can reference them naturally.

Implementation:
- New reusable `create_user_note()` in the `user_notes` app.
- New `record_identity_edit_note` / `record_identity_delete_note` helpers, wired into the user **and** admin edit/delete endpoints.
- Only **name / category / I Am statement** changes are noted — scene/image-only edits (clothing, mood, setting) are intentionally ignored.
- Admin actions record the note against the **impersonated user**, not the admin, and notes carry the identity's `test_scenario` for test-data isolation.

## Tests
8 new backend tests: edit records a note, I-Am edit records a note, scene-only edit records nothing, delete records a note + removes the identity, admin delete (happy path, missing `identity_id` → 400, non-admin → 403), admin edit records a note for the target user. Full identities + user_notes suites pass (93).

## Notes
- `tsc` + HMR clean. Only lint finding is the pre-existing `noRedeclare` on `Identity` in `Identity.tsx` (already on `main`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)