### PR TITLE
feat(auth): working forgot/reset password + email verification

### DIFF
--- a/client/src/api/auth.ts
+++ b/client/src/api/auth.ts
@@ -4,6 +4,8 @@ import {
   LOGIN,
   FORGOT_PASSWORD,
   RESET_PASSWORD,
+  VERIFY_EMAIL,
+  RESEND_VERIFICATION,
 } from "@/constants/api";
 import {
   type RegisterCredentials,
@@ -137,6 +139,34 @@ export async function resetPassword(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(creds),
+  });
+  return response.json();
+}
+
+/**
+ * Confirm an email address with a verification token.
+ */
+export async function verifyEmail(token: string): Promise<AuthResponse> {
+  const verifyEmailUrl = `${COACH_BASE_URL}${VERIFY_EMAIL}`;
+  const response = await fetch(verifyEmailUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token }),
+  });
+  return response.json();
+}
+
+/**
+ * Re-send the verification email for an unverified account.
+ */
+export async function resendVerification(
+  email: string
+): Promise<AuthResponse> {
+  const resendUrl = `${COACH_BASE_URL}${RESEND_VERIFICATION}`;
+  const response = await fetch(resendUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email }),
   });
   return response.json();
 }

--- a/client/src/hooks/__tests__/useAuth.test.ts
+++ b/client/src/hooks/__tests__/useAuth.test.ts
@@ -9,6 +9,8 @@ vi.mock("@/api/auth", () => ({
   register: vi.fn(),
   forgotPassword: vi.fn(),
   resetPassword: vi.fn(),
+  verifyEmail: vi.fn(),
+  resendVerification: vi.fn(),
   logout: vi.fn(),
 }));
 

--- a/client/src/hooks/use-auth.ts
+++ b/client/src/hooks/use-auth.ts
@@ -4,6 +4,8 @@ import {
   register as registerApi,
   forgotPassword as forgotPasswordApi,
   resetPassword as resetPasswordApi,
+  verifyEmail as verifyEmailApi,
+  resendVerification as resendVerificationApi,
   logout as logoutApi,
 } from "@/api/auth";
 import {
@@ -89,6 +91,16 @@ export function useAuth() {
     mutationFn: resetPasswordApi,
   });
 
+  // Verify email mutation
+  const verifyEmailMutation = useMutation<AuthResponse, unknown, string>({
+    mutationFn: verifyEmailApi,
+  });
+
+  // Resend verification mutation
+  const resendVerificationMutation = useMutation<AuthResponse, unknown, string>({
+    mutationFn: resendVerificationApi,
+  });
+
   // Logout mutation
   const logoutMutation = useMutation<void, unknown, void>({
     mutationFn: logoutApi,
@@ -107,6 +119,10 @@ export function useAuth() {
     forgotPasswordStatus: forgotPasswordMutation.status,
     resetPassword: resetPasswordMutation.mutateAsync,
     resetPasswordStatus: resetPasswordMutation.status,
+    verifyEmail: verifyEmailMutation.mutateAsync,
+    verifyEmailStatus: verifyEmailMutation.status,
+    resendVerification: resendVerificationMutation.mutateAsync,
+    resendVerificationStatus: resendVerificationMutation.status,
     logout: logoutMutation.mutateAsync,
     logoutStatus: logoutMutation.status,
   };

--- a/client/src/pages/forgot-password/ForgotPassword.tsx
+++ b/client/src/pages/forgot-password/ForgotPassword.tsx
@@ -1,0 +1,160 @@
+import { useForm } from "@tanstack/react-form";
+import { Link } from "@tanstack/react-router";
+import { motion } from "framer-motion";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useAuth } from "@/hooks/use-auth";
+
+const nvLogoSmall = "/neovita_logo_small.png";
+
+/**
+ * Forgot Password Route (/forgot-password)
+ *
+ * Collects an email and asks the backend to send a password-reset link.
+ * Always shows the same generic confirmation (the backend does not reveal
+ * whether an account exists).
+ */
+export default function ForgotPasswordPage() {
+  const { forgotPassword } = useAuth();
+  const [submitted, setSubmitted] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const form = useForm({
+    defaultValues: { email: "" },
+    onSubmit: async ({ value }) => {
+      setErrorMessage(null);
+      try {
+        await forgotPassword(value.email);
+        // Backend is intentionally non-committal about account existence.
+        setSubmitted(true);
+      } catch {
+        setErrorMessage("Something went wrong. Please try again.");
+      }
+    },
+  });
+
+  return (
+    <div className="min-h-screen w-screen flex items-center justify-center bg-[var(--nv-lilac-white)] px-6">
+      <div className="w-full max-w-[460px]">
+        <div className="mb-8 flex flex-col items-center gap-4">
+          <img
+            src={nvLogoSmall}
+            alt="Neovita mark"
+            className="h-[80px] w-auto select-none"
+            draggable={false}
+          />
+        </div>
+
+        {submitted ? (
+          <motion.div
+            className="rounded-2xl bg-white p-8 text-center shadow-sm"
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.4 }}
+          >
+            <h1 className="text-[28px] font-medium text-black">Check your email</h1>
+            <p className="mt-3 text-[16px] text-black/70">
+              If an account exists for that address, we&apos;ve sent a link to
+              reset your password.
+            </p>
+            <Link
+              to="/login"
+              className="mt-6 inline-block text-[color:var(--nv-violet-blue)] underline"
+            >
+              Back to login
+            </Link>
+          </motion.div>
+        ) : (
+          <motion.div
+            className="rounded-2xl bg-white p-8 shadow-sm"
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.4 }}
+          >
+            <h1 className="text-[28px] font-medium text-black text-center">
+              Forgot password?
+            </h1>
+            <p className="mt-2 mb-6 text-center text-[16px] text-black/70">
+              Enter your email and we&apos;ll send you a reset link.
+            </p>
+
+            <form
+              className="space-y-6"
+              onSubmit={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                form.handleSubmit();
+              }}
+            >
+              <form.Field
+                name="email"
+                validators={{
+                  onChange: ({ value }) =>
+                    !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
+                      ? "Enter a valid email"
+                      : undefined,
+                }}
+              >
+                {(field) => (
+                  <div className="space-y-2">
+                    <Label htmlFor={field.name} className="text-base">
+                      Your email
+                    </Label>
+                    <Input
+                      id={field.name}
+                      type="email"
+                      placeholder="Enter your email address"
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      className="h-12 rounded-full px-6 border border-black/50"
+                      aria-invalid={
+                        field.state.meta.errors.length ? true : undefined
+                      }
+                    />
+                    {field.state.meta.isTouched &&
+                    field.state.meta.errors.length ? (
+                      <p className="mt-1 text-sm text-destructive">
+                        {field.state.meta.errors[0] as string}
+                      </p>
+                    ) : null}
+                  </div>
+                )}
+              </form.Field>
+
+              {errorMessage && (
+                <p className="text-sm text-destructive text-center">
+                  {errorMessage}
+                </p>
+              )}
+
+              <form.Subscribe selector={(s) => s.isSubmitting}>
+                {(isSubmitting) => (
+                  <Button
+                    type="submit"
+                    disabled={isSubmitting}
+                    className="nv-gradient-button w-full rounded-full h-[52px] px-8 text-[20px] font-semibold"
+                  >
+                    {isSubmitting ? "Sending…" : "Send reset link"}
+                  </Button>
+                )}
+              </form.Subscribe>
+            </form>
+
+            <p className="mt-8 text-center text-sm text-foreground">
+              Remembered it?{" "}
+              <Link
+                to="/login"
+                className="text-[color:var(--nv-violet-blue)] underline"
+              >
+                Back to login
+              </Link>
+            </p>
+          </motion.div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/login/Login.tsx
+++ b/client/src/pages/login/Login.tsx
@@ -178,7 +178,7 @@ export default function LoginPage() {
                       <button
                         type="button"
                         className="text-sm text-muted-foreground hover:underline"
-                        onClick={() => console.log("Forgot password")}
+                        onClick={() => navigate({ to: "/forgot-password" })}
                       >
                         Forgot password?
                       </button>

--- a/client/src/pages/reset-password/ResetPassword.tsx
+++ b/client/src/pages/reset-password/ResetPassword.tsx
@@ -1,0 +1,200 @@
+import { useForm } from "@tanstack/react-form";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { motion } from "framer-motion";
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useAuth } from "@/hooks/use-auth";
+
+const nvLogoSmall = "/neovita_logo_small.png";
+
+/**
+ * Reset Password Route (/reset-password?token=...)
+ *
+ * Reads the reset token from the query string (the link emailed by the
+ * backend), collects a new password, and submits it. On success the user is
+ * sent back to the login page.
+ */
+export default function ResetPasswordPage() {
+  const { resetPassword } = useAuth();
+  const navigate = useNavigate();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  const token = useMemo(
+    () => new URLSearchParams(window.location.search).get("token") ?? "",
+    []
+  );
+
+  const form = useForm({
+    defaultValues: { password: "", confirm: "" },
+    onSubmit: async ({ value }) => {
+      setErrorMessage(null);
+      if (value.password !== value.confirm) {
+        setErrorMessage("Passwords don't match.");
+        return;
+      }
+      try {
+        const response = await resetPassword({
+          token,
+          password: value.password,
+        });
+        if (response.success) {
+          setDone(true);
+          setTimeout(() => navigate({ to: "/login" }), 2000);
+        } else {
+          setErrorMessage(
+            response.error || "This reset link is invalid or has expired."
+          );
+        }
+      } catch {
+        setErrorMessage("Something went wrong. Please try again.");
+      }
+    },
+  });
+
+  return (
+    <div className="min-h-screen w-screen flex items-center justify-center bg-[var(--nv-lilac-white)] px-6">
+      <div className="w-full max-w-[460px]">
+        <div className="mb-8 flex flex-col items-center gap-4">
+          <img
+            src={nvLogoSmall}
+            alt="Neovita mark"
+            className="h-[80px] w-auto select-none"
+            draggable={false}
+          />
+        </div>
+
+        <motion.div
+          className="rounded-2xl bg-white p-8 shadow-sm"
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4 }}
+        >
+          {done ? (
+            <div className="text-center">
+              <h1 className="text-[28px] font-medium text-black">
+                Password updated
+              </h1>
+              <p className="mt-3 text-[16px] text-black/70">
+                You can now log in with your new password. Redirecting…
+              </p>
+              <Link
+                to="/login"
+                className="mt-6 inline-block text-[color:var(--nv-violet-blue)] underline"
+              >
+                Go to login
+              </Link>
+            </div>
+          ) : !token ? (
+            <div className="text-center">
+              <h1 className="text-[28px] font-medium text-black">
+                Invalid reset link
+              </h1>
+              <p className="mt-3 text-[16px] text-black/70">
+                This link is missing its token. Request a new one from the
+                forgot-password page.
+              </p>
+              <Link
+                to="/forgot-password"
+                className="mt-6 inline-block text-[color:var(--nv-violet-blue)] underline"
+              >
+                Request a new link
+              </Link>
+            </div>
+          ) : (
+            <>
+              <h1 className="text-[28px] font-medium text-black text-center">
+                Choose a new password
+              </h1>
+              <p className="mt-2 mb-6 text-center text-[16px] text-black/70">
+                Enter and confirm your new password.
+              </p>
+
+              <form
+                className="space-y-6"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  form.handleSubmit();
+                }}
+              >
+                <form.Field
+                  name="password"
+                  validators={{
+                    onChange: ({ value }) =>
+                      value.length < 8
+                        ? "Password must be at least 8 characters"
+                        : undefined,
+                  }}
+                >
+                  {(field) => (
+                    <div className="space-y-2">
+                      <Label htmlFor={field.name} className="text-base">
+                        New password
+                      </Label>
+                      <Input
+                        id={field.name}
+                        type="password"
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        className="h-12 rounded-full px-6 border border-black/50"
+                        aria-invalid={
+                          field.state.meta.errors.length ? true : undefined
+                        }
+                      />
+                      {field.state.meta.isTouched &&
+                      field.state.meta.errors.length ? (
+                        <p className="mt-1 text-sm text-destructive">
+                          {field.state.meta.errors[0] as string}
+                        </p>
+                      ) : null}
+                    </div>
+                  )}
+                </form.Field>
+
+                <form.Field name="confirm">
+                  {(field) => (
+                    <div className="space-y-2">
+                      <Label htmlFor={field.name} className="text-base">
+                        Confirm password
+                      </Label>
+                      <Input
+                        id={field.name}
+                        type="password"
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        className="h-12 rounded-full px-6 border border-black/50"
+                      />
+                    </div>
+                  )}
+                </form.Field>
+
+                {errorMessage && (
+                  <p className="text-sm text-destructive text-center">
+                    {errorMessage}
+                  </p>
+                )}
+
+                <form.Subscribe selector={(s) => s.isSubmitting}>
+                  {(isSubmitting) => (
+                    <Button
+                      type="submit"
+                      disabled={isSubmitting}
+                      className="nv-gradient-button w-full rounded-full h-[52px] px-8 text-[20px] font-semibold"
+                    >
+                      {isSubmitting ? "Updating…" : "Update password"}
+                    </Button>
+                  )}
+                </form.Subscribe>
+              </form>
+            </>
+          )}
+        </motion.div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/verify-email/VerifyEmail.tsx
+++ b/client/src/pages/verify-email/VerifyEmail.tsx
@@ -1,0 +1,138 @@
+import { Link } from "@tanstack/react-router";
+import { motion } from "framer-motion";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useAuth } from "@/hooks/use-auth";
+
+const nvLogoSmall = "/neovita_logo_small.png";
+
+type Status = "verifying" | "success" | "error" | "no-token";
+
+/**
+ * Verify Email Route (/verify-email?token=...)
+ *
+ * Reads the token from the verification link and confirms it on mount. On
+ * failure, offers to re-send a fresh verification email.
+ */
+export default function VerifyEmailPage() {
+  const { verifyEmail, resendVerification } = useAuth();
+  const token = useMemo(
+    () => new URLSearchParams(window.location.search).get("token") ?? "",
+    []
+  );
+  const [status, setStatus] = useState<Status>(token ? "verifying" : "no-token");
+  const [resendEmail, setResendEmail] = useState("");
+  const [resent, setResent] = useState(false);
+  const ranRef = useRef(false);
+
+  useEffect(() => {
+    if (!token || ranRef.current) return;
+    ranRef.current = true; // guard against StrictMode double-invoke
+    verifyEmail(token)
+      .then((response) => setStatus(response.success ? "success" : "error"))
+      .catch(() => setStatus("error"));
+  }, [token, verifyEmail]);
+
+  async function handleResend() {
+    if (!resendEmail) return;
+    try {
+      await resendVerification(resendEmail);
+    } finally {
+      // Generic confirmation regardless of outcome (no account-existence leak).
+      setResent(true);
+    }
+  }
+
+  return (
+    <div className="min-h-screen w-screen flex items-center justify-center bg-[var(--nv-lilac-white)] px-6">
+      <div className="w-full max-w-[460px]">
+        <div className="mb-8 flex flex-col items-center gap-4">
+          <img
+            src={nvLogoSmall}
+            alt="Neovita mark"
+            className="h-[80px] w-auto select-none"
+            draggable={false}
+          />
+        </div>
+
+        <motion.div
+          className="rounded-2xl bg-white p-8 text-center shadow-sm"
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4 }}
+        >
+          {status === "verifying" && (
+            <>
+              <h1 className="text-[28px] font-medium text-black">
+                Verifying your email…
+              </h1>
+              <p className="mt-3 text-[16px] text-black/70">One moment.</p>
+            </>
+          )}
+
+          {status === "success" && (
+            <>
+              <h1 className="text-[28px] font-medium text-black">
+                Email verified
+              </h1>
+              <p className="mt-3 text-[16px] text-black/70">
+                Thanks for confirming your email address.
+              </p>
+              <Link
+                to="/login"
+                className="mt-6 inline-block text-[color:var(--nv-violet-blue)] underline"
+              >
+                Continue to login
+              </Link>
+            </>
+          )}
+
+          {(status === "error" || status === "no-token") && (
+            <>
+              <h1 className="text-[28px] font-medium text-black">
+                {status === "no-token"
+                  ? "Invalid verification link"
+                  : "Link expired or invalid"}
+              </h1>
+              {resent ? (
+                <p className="mt-3 text-[16px] text-black/70">
+                  If an unverified account exists for that address, a new
+                  verification email is on its way.
+                </p>
+              ) : (
+                <>
+                  <p className="mt-3 mb-5 text-[16px] text-black/70">
+                    Enter your email to get a fresh verification link.
+                  </p>
+                  <div className="space-y-4">
+                    <Input
+                      type="email"
+                      placeholder="Enter your email address"
+                      value={resendEmail}
+                      onChange={(e) => setResendEmail(e.target.value)}
+                      className="h-12 rounded-full px-6 border border-black/50"
+                    />
+                    <Button
+                      type="button"
+                      onClick={handleResend}
+                      className="nv-gradient-button w-full rounded-full h-[52px] px-8 text-[18px] font-semibold"
+                    >
+                      Resend verification email
+                    </Button>
+                  </div>
+                </>
+              )}
+              <Link
+                to="/login"
+                className="mt-6 inline-block text-[color:var(--nv-violet-blue)] underline"
+              >
+                Back to login
+              </Link>
+            </>
+          )}
+        </motion.div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/routeTree.gen.ts
+++ b/client/src/routeTree.gen.ts
@@ -12,8 +12,11 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as PublicRouteRouteImport } from './routes/_public/route'
 import { Route as AuthenticatedRouteRouteImport } from './routes/_authenticated/route'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as VerifyEmailIndexRouteImport } from './routes/verify-email/index'
 import { Route as SignupIndexRouteImport } from './routes/signup/index'
+import { Route as ResetPasswordIndexRouteImport } from './routes/reset-password/index'
 import { Route as LoginIndexRouteImport } from './routes/login/index'
+import { Route as ForgotPasswordIndexRouteImport } from './routes/forgot-password/index'
 import { Route as AuthenticatedAdminRouteRouteImport } from './routes/_authenticated/admin/route'
 import { Route as AuthenticatedSettingsIndexRouteImport } from './routes/_authenticated/settings/index'
 import { Route as AuthenticatedNotificationsIndexRouteImport } from './routes/_authenticated/notifications/index'
@@ -42,14 +45,29 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const VerifyEmailIndexRoute = VerifyEmailIndexRouteImport.update({
+  id: '/verify-email/',
+  path: '/verify-email/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SignupIndexRoute = SignupIndexRouteImport.update({
   id: '/signup/',
   path: '/signup/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ResetPasswordIndexRoute = ResetPasswordIndexRouteImport.update({
+  id: '/reset-password/',
+  path: '/reset-password/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LoginIndexRoute = LoginIndexRouteImport.update({
   id: '/login/',
   path: '/login/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ForgotPasswordIndexRoute = ForgotPasswordIndexRouteImport.update({
+  id: '/forgot-password/',
+  path: '/forgot-password/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthenticatedAdminRouteRoute = AuthenticatedAdminRouteRouteImport.update({
@@ -134,8 +152,11 @@ const AuthenticatedAdminPromptsRoute =
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/admin': typeof AuthenticatedAdminRouteRouteWithChildren
+  '/forgot-password': typeof ForgotPasswordIndexRoute
   '/login': typeof LoginIndexRoute
+  '/reset-password': typeof ResetPasswordIndexRoute
   '/signup': typeof SignupIndexRoute
+  '/verify-email': typeof VerifyEmailIndexRoute
   '/admin/prompts': typeof AuthenticatedAdminPromptsRoute
   '/admin/test': typeof AuthenticatedAdminTestRoute
   '/admin/users': typeof AuthenticatedAdminUsersRoute
@@ -153,8 +174,11 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/admin': typeof AuthenticatedAdminRouteRouteWithChildren
+  '/forgot-password': typeof ForgotPasswordIndexRoute
   '/login': typeof LoginIndexRoute
+  '/reset-password': typeof ResetPasswordIndexRoute
   '/signup': typeof SignupIndexRoute
+  '/verify-email': typeof VerifyEmailIndexRoute
   '/admin/prompts': typeof AuthenticatedAdminPromptsRoute
   '/admin/test': typeof AuthenticatedAdminTestRoute
   '/admin/users': typeof AuthenticatedAdminUsersRoute
@@ -175,8 +199,11 @@ export interface FileRoutesById {
   '/_authenticated': typeof AuthenticatedRouteRouteWithChildren
   '/_public': typeof PublicRouteRoute
   '/_authenticated/admin': typeof AuthenticatedAdminRouteRouteWithChildren
+  '/forgot-password/': typeof ForgotPasswordIndexRoute
   '/login/': typeof LoginIndexRoute
+  '/reset-password/': typeof ResetPasswordIndexRoute
   '/signup/': typeof SignupIndexRoute
+  '/verify-email/': typeof VerifyEmailIndexRoute
   '/_authenticated/admin/prompts': typeof AuthenticatedAdminPromptsRoute
   '/_authenticated/admin/test': typeof AuthenticatedAdminTestRoute
   '/_authenticated/admin/users': typeof AuthenticatedAdminUsersRoute
@@ -196,8 +223,11 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/admin'
+    | '/forgot-password'
     | '/login'
+    | '/reset-password'
     | '/signup'
+    | '/verify-email'
     | '/admin/prompts'
     | '/admin/test'
     | '/admin/users'
@@ -215,8 +245,11 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/admin'
+    | '/forgot-password'
     | '/login'
+    | '/reset-password'
     | '/signup'
+    | '/verify-email'
     | '/admin/prompts'
     | '/admin/test'
     | '/admin/users'
@@ -236,8 +269,11 @@ export interface FileRouteTypes {
     | '/_authenticated'
     | '/_public'
     | '/_authenticated/admin'
+    | '/forgot-password/'
     | '/login/'
+    | '/reset-password/'
     | '/signup/'
+    | '/verify-email/'
     | '/_authenticated/admin/prompts'
     | '/_authenticated/admin/test'
     | '/_authenticated/admin/users'
@@ -257,8 +293,11 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AuthenticatedRouteRoute: typeof AuthenticatedRouteRouteWithChildren
   PublicRouteRoute: typeof PublicRouteRoute
+  ForgotPasswordIndexRoute: typeof ForgotPasswordIndexRoute
   LoginIndexRoute: typeof LoginIndexRoute
+  ResetPasswordIndexRoute: typeof ResetPasswordIndexRoute
   SignupIndexRoute: typeof SignupIndexRoute
+  VerifyEmailIndexRoute: typeof VerifyEmailIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -284,6 +323,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/verify-email/': {
+      id: '/verify-email/'
+      path: '/verify-email'
+      fullPath: '/verify-email'
+      preLoaderRoute: typeof VerifyEmailIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/signup/': {
       id: '/signup/'
       path: '/signup'
@@ -291,11 +337,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SignupIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/reset-password/': {
+      id: '/reset-password/'
+      path: '/reset-password'
+      fullPath: '/reset-password'
+      preLoaderRoute: typeof ResetPasswordIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/login/': {
       id: '/login/'
       path: '/login'
       fullPath: '/login'
       preLoaderRoute: typeof LoginIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/forgot-password/': {
+      id: '/forgot-password/'
+      path: '/forgot-password'
+      fullPath: '/forgot-password'
+      preLoaderRoute: typeof ForgotPasswordIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_authenticated/admin': {
@@ -453,8 +513,11 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthenticatedRouteRoute: AuthenticatedRouteRouteWithChildren,
   PublicRouteRoute: PublicRouteRoute,
+  ForgotPasswordIndexRoute: ForgotPasswordIndexRoute,
   LoginIndexRoute: LoginIndexRoute,
+  ResetPasswordIndexRoute: ResetPasswordIndexRoute,
   SignupIndexRoute: SignupIndexRoute,
+  VerifyEmailIndexRoute: VerifyEmailIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/client/src/routes/forgot-password/index.tsx
+++ b/client/src/routes/forgot-password/index.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from "@tanstack/react-router";
+import ForgotPassword from "@/pages/forgot-password/ForgotPassword.tsx";
+
+/**
+ * /forgot-password — request a password-reset email.
+ */
+export const Route = createFileRoute("/forgot-password/")({
+  component: ForgotPassword,
+});

--- a/client/src/routes/reset-password/index.tsx
+++ b/client/src/routes/reset-password/index.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from "@tanstack/react-router";
+import ResetPassword from "@/pages/reset-password/ResetPassword.tsx";
+
+/**
+ * /reset-password?token=... — set a new password from an emailed link.
+ */
+export const Route = createFileRoute("/reset-password/")({
+  component: ResetPassword,
+});

--- a/client/src/routes/verify-email/index.tsx
+++ b/client/src/routes/verify-email/index.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from "@tanstack/react-router";
+import VerifyEmail from "@/pages/verify-email/VerifyEmail.tsx";
+
+/**
+ * /verify-email?token=... — confirm an email address from an emailed link.
+ */
+export const Route = createFileRoute("/verify-email/")({
+  component: VerifyEmail,
+});

--- a/server/.env.sample
+++ b/server/.env.sample
@@ -44,7 +44,7 @@ AWS_REGION="us-east-1"
 # AWS SES Configuration
 AWS_SES_REGION_NAME=us-east-1
 AWS_SES_REGION_ENDPOINT=email.us-east-1.amazonaws.com
-AWS_SES_SOURCE_EMAIL=noreply@discovita.com
+AWS_SES_SOURCE_EMAIL=noreply@neovita.ai
 
 DEBUG="True"
 

--- a/server/.flake8
+++ b/server/.flake8
@@ -26,7 +26,7 @@ extend-ignore =
 # dynamic dispatch — these are intentional patterns, not accidental star imports.
 per-file-ignores =
     */ai_service_factory.py: E402
-    */settings/*.py: F401, F403, F405
+    */settings/*.py: E402, F401, F403, F405
     */action_handler/*.py: F403, F405
     */prompt_manager/utils/__init__.py: F403, F405
     */prompt_manager/utils/context/__init__.py: F403, F405

--- a/server/apps/authentication/functions/public/__init__.py
+++ b/server/apps/authentication/functions/public/__init__.py
@@ -7,11 +7,17 @@ Business logic for public (unauthenticated) authentication endpoints.
 from apps.authentication.functions.public.forgot_password import forgot_password
 from apps.authentication.functions.public.login_user import login_user
 from apps.authentication.functions.public.register_user import register_user
+from apps.authentication.functions.public.resend_verification import (
+    resend_verification,
+)
 from apps.authentication.functions.public.reset_password import reset_password
+from apps.authentication.functions.public.verify_email import verify_email
 
 __all__ = [
     "forgot_password",
     "login_user",
     "register_user",
+    "resend_verification",
     "reset_password",
+    "verify_email",
 ]

--- a/server/apps/authentication/functions/public/forgot_password.py
+++ b/server/apps/authentication/functions/public/forgot_password.py
@@ -6,7 +6,6 @@ Initiate the password-reset flow by generating a token and sending an email.
 
 from apps.authentication.utils import (
     AuthErrorMessages,
-    generate_verification_token,
     send_password_reset_email,
 )
 from apps.users.models import User
@@ -40,7 +39,7 @@ def forgot_password(email: str) -> dict:
         log.info("Forgot-password for non-existent email %s", email)
         return {"message": _GENERIC_MESSAGE, "email_sent": False}
 
-    generate_verification_token(user)
+    # send_password_reset_email generates and persists the token itself.
     email_sent = send_password_reset_email(user)
 
     if not email_sent:

--- a/server/apps/authentication/functions/public/register_user.py
+++ b/server/apps/authentication/functions/public/register_user.py
@@ -10,6 +10,7 @@ from rest_framework_simplejwt.tokens import RefreshToken
 
 from django.db import transaction
 
+from apps.authentication.utils import send_verification_email
 from apps.users.models import User
 from services.logger import configure_logging
 
@@ -19,7 +20,11 @@ log = configure_logging(__name__, log_level="INFO")
 @transaction.atomic
 def register_user(email: str, password: str) -> dict[str, Any]:
     """
-    Create a new user and issue JWT tokens.
+    Create a new user, send a verification email, and issue JWT tokens.
+
+    Email verification is best-effort and does NOT gate access: the account is
+    active and logged in immediately. A failed verification send is logged but
+    does not fail registration.
 
     Args:
         email: Validated email address (unique check done by serializer).
@@ -35,6 +40,10 @@ def register_user(email: str, password: str) -> dict[str, Any]:
     refresh = RefreshToken.for_user(user)
 
     log.info("Registered new user %s", email)
+
+    # Best-effort verification email — never block registration on delivery.
+    if not send_verification_email(user):
+        log.warning("Verification email could not be sent for new user %s", email)
 
     return {
         "user_id": user.id,

--- a/server/apps/authentication/functions/public/resend_verification.py
+++ b/server/apps/authentication/functions/public/resend_verification.py
@@ -1,0 +1,45 @@
+"""
+resend_verification
+
+Re-send the email-verification message for an unverified account.
+"""
+
+from apps.authentication.utils import send_verification_email
+from apps.users.models import User
+from services.logger import configure_logging
+
+log = configure_logging(__name__, log_level="INFO")
+
+_GENERIC_MESSAGE = (
+    "If an account exists and is unverified, a verification email will be sent"
+)
+
+
+def resend_verification(email: str) -> dict:
+    """
+    Look up the user and re-send a verification email if they are unverified.
+
+    Returns a generic success message regardless of whether the email exists
+    or is already verified, to avoid leaking account existence.
+
+    Args:
+        email: Email address from the request.
+
+    Returns:
+        Dict with ``message`` and ``email_sent`` keys.
+    """
+    try:
+        user = User.objects.get(email=email)
+    except User.DoesNotExist:
+        log.info("Resend-verification for non-existent email %s", email)
+        return {"message": _GENERIC_MESSAGE, "email_sent": False}
+
+    if user.is_email_verified:
+        log.info("Resend-verification for already-verified email %s", email)
+        return {"message": _GENERIC_MESSAGE, "email_sent": False}
+
+    email_sent = send_verification_email(user)
+    if email_sent:
+        log.info("Verification email re-sent to %s", email)
+
+    return {"message": _GENERIC_MESSAGE, "email_sent": email_sent}

--- a/server/apps/authentication/functions/public/reset_password.py
+++ b/server/apps/authentication/functions/public/reset_password.py
@@ -44,7 +44,10 @@ def reset_password(token: str, new_password: str) -> dict:
         log.warning("Reset attempt with expired token for user %s", user.email)
         raise TokenExpiredError(AuthErrorMessages.VERIFICATION_EXPIRED)
 
+    # Completing a reset proves the user controls the email, so treat it as
+    # verified too (clearing the single-use token either way).
     user.set_password(new_password)
+    user.is_email_verified = True
     user.verification_token = ""
     user.email_verification_sent_at = None
     user.save()

--- a/server/apps/authentication/functions/public/verify_email.py
+++ b/server/apps/authentication/functions/public/verify_email.py
@@ -1,0 +1,52 @@
+"""
+verify_email
+
+Validate an email-verification token and mark the user's email verified.
+"""
+
+from apps.authentication.utils import AuthErrorMessages, is_token_expired
+from apps.users.models import User
+from services.logger import configure_logging
+
+log = configure_logging(__name__, log_level="INFO")
+
+
+class VerificationInvalidError(Exception):
+    """Raised when the verification token does not match any user."""
+
+
+class VerificationExpiredError(Exception):
+    """Raised when the verification token has expired."""
+
+
+def verify_email(token: str) -> dict:
+    """
+    Validate a verification token, mark the email verified, and clear the token.
+
+    Args:
+        token: Verification token from the verify-email URL.
+
+    Returns:
+        Dict with a ``message`` key on success.
+
+    Raises:
+        VerificationInvalidError: If no user matches the token.
+        VerificationExpiredError: If the token has expired.
+    """
+    try:
+        user = User.objects.get(verification_token=token)
+    except User.DoesNotExist:
+        log.warning("Email verification attempt with invalid token")
+        raise VerificationInvalidError(AuthErrorMessages.VERIFICATION_INVALID)
+
+    if is_token_expired(user):
+        log.warning("Email verification attempt with expired token for %s", user.email)
+        raise VerificationExpiredError(AuthErrorMessages.VERIFICATION_EXPIRED)
+
+    user.is_email_verified = True
+    user.verification_token = ""
+    user.email_verification_sent_at = None
+    user.save()
+
+    log.info("Email verified for user %s", user.email)
+    return {"message": "Email verified successfully"}

--- a/server/apps/authentication/tests/test_forgot_password.py
+++ b/server/apps/authentication/tests/test_forgot_password.py
@@ -29,15 +29,9 @@ class ForgotPasswordTests(TestCase):
         ".send_password_reset_email",
         return_value=True,
     )
-    @patch(
-        "apps.authentication.functions.public.forgot_password"
-        ".generate_verification_token",
-        return_value="abc123",
-    )
-    def test_existing_email_sends_reset(self, mock_gen, mock_send):
-        """Should generate a token and send the email for known users."""
+    def test_existing_email_sends_reset(self, mock_send):
+        """Should send the reset email for known users (token gen lives in the send)."""
         result = forgot_password("forgot@example.com")
-        mock_gen.assert_called_once_with(self.user)
         mock_send.assert_called_once_with(self.user)
         self.assertEqual(result["message"], "Password reset email sent")
         self.assertTrue(result["email_sent"])
@@ -47,12 +41,7 @@ class ForgotPasswordTests(TestCase):
         ".send_password_reset_email",
         return_value=False,
     )
-    @patch(
-        "apps.authentication.functions.public.forgot_password"
-        ".generate_verification_token",
-        return_value="abc123",
-    )
-    def test_email_failure_raises_runtime_error(self, mock_gen, mock_send):
+    def test_email_failure_raises_runtime_error(self, mock_send):
         """Should raise RuntimeError when SES send fails."""
         with self.assertRaises(RuntimeError) as ctx:
             forgot_password("forgot@example.com")

--- a/server/apps/authentication/tests/test_password_reset_endpoints.py
+++ b/server/apps/authentication/tests/test_password_reset_endpoints.py
@@ -31,12 +31,7 @@ class ForgotPasswordEndpointTests(APITestCase):
         ".send_password_reset_email",
         return_value=True,
     )
-    @patch(
-        "apps.authentication.functions.public.forgot_password"
-        ".generate_verification_token",
-        return_value="tok",
-    )
-    def test_existing_email_returns_success(self, _mock_gen, _mock_send):
+    def test_existing_email_returns_success(self, _mock_send):
         """Known email should return 200 with success message."""
         response = self.client.post(
             self.url, {"email": "forgot@example.com"}, format="json"
@@ -57,12 +52,7 @@ class ForgotPasswordEndpointTests(APITestCase):
         ".send_password_reset_email",
         return_value=False,
     )
-    @patch(
-        "apps.authentication.functions.public.forgot_password"
-        ".generate_verification_token",
-        return_value="tok",
-    )
-    def test_email_send_failure_returns_400(self, _mock_gen, _mock_send):
+    def test_email_send_failure_returns_400(self, _mock_send):
         """SES failure should return 400."""
         response = self.client.post(
             self.url, {"email": "forgot@example.com"}, format="json"
@@ -93,6 +83,8 @@ class ResetPasswordEndpointTests(APITestCase):
         self.assertTrue(response.data["success"])
         self.user.refresh_from_db()
         self.assertTrue(self.user.check_password("NewPass1!"))
+        # Completing a reset proves email ownership.
+        self.assertTrue(self.user.is_email_verified)
 
     def test_missing_token_returns_400(self):
         """Request without token should return 400."""

--- a/server/apps/authentication/tests/test_register_user.py
+++ b/server/apps/authentication/tests/test_register_user.py
@@ -2,6 +2,8 @@
 Integration tests for register_user function.
 """
 
+from unittest.mock import patch
+
 from django.test import TestCase
 
 from apps.authentication.functions.public import register_user
@@ -10,6 +12,29 @@ from apps.users.models import User
 
 class RegisterUserTests(TestCase):
     """Tests for the register_user function."""
+
+    def setUp(self):
+        # register_user sends a verification email via SES; mock the seam so
+        # tests never touch the network.
+        patcher = patch(
+            "apps.authentication.functions.public.register_user"
+            ".send_verification_email",
+            return_value=True,
+        )
+        self.mock_send_verification = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_sends_verification_email(self):
+        """Registration should trigger a verification email (best-effort)."""
+        register_user(email="verify@example.com", password="TestPass1!")
+        user = User.objects.get(email="verify@example.com")
+        self.mock_send_verification.assert_called_once_with(user)
+
+    def test_new_user_is_unverified(self):
+        """A freshly registered user starts unverified."""
+        register_user(email="unverified@example.com", password="TestPass1!")
+        user = User.objects.get(email="unverified@example.com")
+        self.assertFalse(user.is_email_verified)
 
     def test_creates_user_in_database(self):
         """Should create a User row with the given email."""

--- a/server/apps/authentication/tests/test_registration.py
+++ b/server/apps/authentication/tests/test_registration.py
@@ -2,6 +2,8 @@
 Endpoint tests for POST /api/v1/auth/register/.
 """
 
+from unittest.mock import patch
+
 from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -75,6 +77,14 @@ class RegisterEndpointTests(APITestCase):
             "email": "new@example.com",
             "password": "TestPass1!",
         }
+        # Registration sends a verification email via SES; mock the seam.
+        patcher = patch(
+            "apps.authentication.functions.public.register_user"
+            ".send_verification_email",
+            return_value=True,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_successful_registration(self):
         """Valid payload creates user and returns tokens."""

--- a/server/apps/authentication/tests/test_resend_verification.py
+++ b/server/apps/authentication/tests/test_resend_verification.py
@@ -1,0 +1,83 @@
+"""
+Tests for the resend-verification flow (function + endpoint).
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.authentication.functions.public import resend_verification
+from apps.users.models import User
+
+SEND_SEAM = (
+    "apps.authentication.functions.public.resend_verification"
+    ".send_verification_email"
+)
+
+
+class ResendVerificationFunctionTests(TestCase):
+    """Tests for the resend_verification business function."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="resend@example.com", password="TestPass1!"
+        )
+
+    @patch(SEND_SEAM, return_value=True)
+    def test_unverified_user_gets_email(self, mock_send):
+        result = resend_verification("resend@example.com")
+        mock_send.assert_called_once_with(self.user)
+        self.assertTrue(result["email_sent"])
+
+    @patch(SEND_SEAM, return_value=True)
+    def test_already_verified_user_is_skipped(self, mock_send):
+        self.user.is_email_verified = True
+        self.user.save()
+        result = resend_verification("resend@example.com")
+        mock_send.assert_not_called()
+        self.assertFalse(result["email_sent"])
+
+    @patch(SEND_SEAM, return_value=True)
+    def test_unknown_email_is_noop(self, mock_send):
+        result = resend_verification("nobody@example.com")
+        mock_send.assert_not_called()
+        self.assertFalse(result["email_sent"])
+
+    @patch(SEND_SEAM, return_value=True)
+    def test_does_not_leak_user_existence(self, _mock_send):
+        """Known and unknown emails return the same generic message."""
+        known = resend_verification("resend@example.com")
+        unknown = resend_verification("nobody@example.com")
+        self.assertEqual(known["message"], unknown["message"])
+
+
+class ResendVerificationEndpointTests(APITestCase):
+    """Tests for POST /api/v1/auth/resend-verification/."""
+
+    def setUp(self):
+        self.url = "/api/v1/auth/resend-verification"
+        self.user = User.objects.create_user(
+            email="resend@example.com", password="TestPass1!"
+        )
+
+    def test_missing_email_returns_400(self):
+        response = self.client.post(self.url, {}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch(SEND_SEAM, return_value=True)
+    def test_valid_email_returns_success(self, _mock_send):
+        response = self.client.post(
+            self.url, {"email": "resend@example.com"}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data["success"])
+
+    def test_unknown_email_returns_success(self):
+        """Unknown email still returns 200 (no information leak)."""
+        response = self.client.post(
+            self.url, {"email": "nobody@example.com"}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data["success"])

--- a/server/apps/authentication/tests/test_verify_email.py
+++ b/server/apps/authentication/tests/test_verify_email.py
@@ -1,0 +1,91 @@
+"""
+Tests for the email-verification flow (function + endpoint).
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.authentication.functions.public.verify_email import (
+    VerificationExpiredError,
+    VerificationInvalidError,
+    verify_email,
+)
+from apps.authentication.utils.verification_token import TOKEN_EXPIRY_HOURS
+from apps.users.models import User
+
+
+class VerifyEmailFunctionTests(TestCase):
+    """Tests for the verify_email business function."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="verify@example.com", password="TestPass1!"
+        )
+        self.user.verification_token = "valid-verify-token"
+        self.user.email_verification_sent_at = datetime.now(tz=timezone.utc)
+        self.user.save()
+
+    def test_valid_token_marks_verified_and_clears_token(self):
+        result = verify_email("valid-verify-token")
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.is_email_verified)
+        self.assertEqual(self.user.verification_token, "")
+        self.assertIsNone(self.user.email_verification_sent_at)
+        self.assertIn("verified", result["message"].lower())
+
+    def test_invalid_token_raises(self):
+        with self.assertRaises(VerificationInvalidError):
+            verify_email("does-not-exist")
+
+    def test_expired_token_raises_and_stays_unverified(self):
+        self.user.email_verification_sent_at = datetime.now(
+            tz=timezone.utc
+        ) - timedelta(hours=TOKEN_EXPIRY_HOURS + 1)
+        self.user.save()
+        with self.assertRaises(VerificationExpiredError):
+            verify_email("valid-verify-token")
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.is_email_verified)
+
+
+class VerifyEmailEndpointTests(APITestCase):
+    """Tests for POST /api/v1/auth/verify-email/."""
+
+    def setUp(self):
+        self.url = "/api/v1/auth/verify-email"
+        self.user = User.objects.create_user(
+            email="verify@example.com", password="TestPass1!"
+        )
+        self.user.verification_token = "valid-verify-token"
+        self.user.email_verification_sent_at = datetime.now(tz=timezone.utc)
+        self.user.save()
+
+    def test_valid_token_returns_success(self):
+        response = self.client.post(
+            self.url, {"token": "valid-verify-token"}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data["success"])
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.is_email_verified)
+
+    def test_missing_token_returns_400(self):
+        response = self.client.post(self.url, {}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_invalid_token_returns_400(self):
+        response = self.client.post(self.url, {"token": "bogus"}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_expired_token_returns_400(self):
+        self.user.email_verification_sent_at = datetime.now(
+            tz=timezone.utc
+        ) - timedelta(hours=TOKEN_EXPIRY_HOURS + 1)
+        self.user.save()
+        response = self.client.post(
+            self.url, {"token": "valid-verify-token"}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/server/apps/authentication/utils/__init__.py
+++ b/server/apps/authentication/utils/__init__.py
@@ -14,6 +14,9 @@ from apps.authentication.utils.response_helpers import (
 from apps.authentication.utils.send_password_reset_email import (
     send_password_reset_email,
 )
+from apps.authentication.utils.send_verification_email import (
+    send_verification_email,
+)
 from apps.authentication.utils.verification_token import (
     generate_verification_token,
     is_token_expired,
@@ -27,5 +30,6 @@ __all__ = [
     "generate_verification_token",
     "is_token_expired",
     "send_password_reset_email",
+    "send_verification_email",
     "success_response",
 ]

--- a/server/apps/authentication/utils/send_verification_email.py
+++ b/server/apps/authentication/utils/send_verification_email.py
@@ -1,0 +1,73 @@
+"""
+Send email-verification emails via AWS SES.
+"""
+
+import boto3
+from botocore.exceptions import ClientError
+
+from django.conf import settings
+from django.template.loader import render_to_string
+
+from apps.authentication.utils.verification_token import (
+    TOKEN_EXPIRY_HOURS,
+    generate_verification_token,
+)
+from apps.users.models import User
+from services.logger import configure_logging
+
+log = configure_logging(__name__, log_level="INFO")
+
+
+def send_verification_email(user: User) -> bool:
+    """
+    Generate a verification token and send a verify-email message via AWS SES.
+
+    Args:
+        user: User whose email address needs verifying.
+
+    Returns:
+        True if the email was sent successfully, False on any SES or
+        unexpected error.
+    """
+    try:
+        ses = boto3.client(
+            "ses",
+            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+            region_name=settings.AWS_REGION,
+        )
+
+        token = generate_verification_token(user)
+        verify_url = f"{settings.FRONTEND_URL}/verify-email?token={token}"
+
+        html_content = render_to_string(
+            "verification_email.html",
+            {"verify_url": verify_url, "expiry_hours": TOKEN_EXPIRY_HOURS},
+        )
+        text_content = render_to_string(
+            "verification_email.txt",
+            {"verify_url": verify_url, "expiry_hours": TOKEN_EXPIRY_HOURS},
+        )
+
+        ses.send_email(
+            Source=settings.AWS_SES_SOURCE_EMAIL,
+            Destination={"ToAddresses": [user.email]},
+            Message={
+                "Subject": {"Data": "Verify Your Email - Discovita"},
+                "Body": {
+                    "Text": {"Data": text_content},
+                    "Html": {"Data": html_content},
+                },
+            },
+        )
+        log.info("Sent verification email to %s", user.email)
+        return True
+
+    except ClientError as e:
+        log.error("AWS SES error sending verification to %s: %s", user.email, e)
+        return False
+    except Exception as e:
+        log.error(
+            "Unexpected error sending verification email to %s: %s", user.email, e
+        )
+        return False

--- a/server/apps/authentication/views/auth_view_set.py
+++ b/server/apps/authentication/views/auth_view_set.py
@@ -13,11 +13,17 @@ from apps.authentication.functions.public import (
     forgot_password,
     login_user,
     register_user,
+    resend_verification,
     reset_password,
+    verify_email,
 )
 from apps.authentication.functions.public.reset_password import (
     TokenExpiredError,
     TokenInvalidError,
+)
+from apps.authentication.functions.public.verify_email import (
+    VerificationExpiredError,
+    VerificationInvalidError,
 )
 from apps.authentication.serializers import LoginSerializer, RegisterSerializer
 from apps.authentication.utils import (
@@ -39,6 +45,8 @@ class AuthViewSet(viewsets.GenericViewSet):
     - POST /api/v1/auth/login/
     - POST /api/v1/auth/forgot-password/
     - POST /api/v1/auth/reset-password/
+    - POST /api/v1/auth/verify-email/
+    - POST /api/v1/auth/resend-verification/
     """
 
     # ------------------------------------------------------------------
@@ -148,4 +156,54 @@ class AuthViewSet(viewsets.GenericViewSet):
             return error_response(str(e))
         except Exception:
             log.exception("Unexpected error in reset-password")
+            return error_response(AuthErrorMessages.UNEXPECTED_ERROR)
+
+    # ------------------------------------------------------------------
+    # POST /api/v1/auth/verify-email/
+    # ------------------------------------------------------------------
+    @decorators.action(
+        detail=False,
+        methods=["post"],
+        permission_classes=[AllowAny],
+        url_path="verify-email",
+    )
+    def verify_email(self, request: Request) -> Response:
+        """POST /api/v1/auth/verify-email/  — Confirm an email address."""
+        token = request.data.get("token")
+        if not token:
+            return error_response(AuthErrorMessages.VERIFICATION_INVALID)
+
+        try:
+            result = verify_email(token)
+            return success_response(result)
+        except VerificationInvalidError as e:
+            return error_response(str(e))
+        except VerificationExpiredError as e:
+            return error_response(str(e))
+        except Exception:
+            log.exception("Unexpected error in verify-email")
+            return error_response(AuthErrorMessages.UNEXPECTED_ERROR)
+
+    # ------------------------------------------------------------------
+    # POST /api/v1/auth/resend-verification/
+    # ------------------------------------------------------------------
+    @decorators.action(
+        detail=False,
+        methods=["post"],
+        permission_classes=[AllowAny],
+        url_path="resend-verification",
+    )
+    def resend_verification(self, request: Request) -> Response:
+        """POST /api/v1/auth/resend-verification/  — Re-send a verify email."""
+        email = request.data.get("email")
+        if not email:
+            return error_response(AuthErrorMessages.INVALID_EMAIL_FORMAT)
+
+        try:
+            result = resend_verification(email)
+            return success_response(
+                {"message": result["message"], "email_sent": result["email_sent"]}
+            )
+        except Exception:
+            log.exception("Unexpected error in resend-verification for %s", email)
             return error_response(AuthErrorMessages.UNEXPECTED_ERROR)

--- a/server/apps/users/migrations/0007_user_is_email_verified.py
+++ b/server/apps/users/migrations/0007_user_is_email_verified.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0006_alter_user_build"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="user",
+            name="is_email_verified",
+            field=models.BooleanField(
+                default=False,
+                help_text="Whether the user has confirmed ownership of their email address.",
+            ),
+        ),
+    ]

--- a/server/apps/users/models/user.py
+++ b/server/apps/users/models/user.py
@@ -108,6 +108,10 @@ class User(AbstractUser):
     )
 
     # Email verification fields
+    is_email_verified = models.BooleanField(
+        default=False,
+        help_text="Whether the user has confirmed ownership of their email address.",
+    )
     verification_token = models.CharField(
         max_length=100, blank=True, help_text="Token for email verification"
     )

--- a/server/settings/test.py
+++ b/server/settings/test.py
@@ -6,7 +6,23 @@ Extends common settings with test-specific configurations.
 
 import os
 
+# common.py reads the AWS_SES_* settings from the environment with no defaults,
+# so it raises ImproperlyConfigured at import time when no .env is present (e.g.
+# running the suite outside the Docker container). Provide harmless dummy values
+# BEFORE importing common so auth tests run anywhere. Real email sends are mocked
+# at the service seam (send_password_reset_email / send_verification_email).
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "test-access-key-id")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test-secret-access-key")
+os.environ.setdefault("AWS_REGION", "us-east-1")
+os.environ.setdefault("AWS_SES_REGION_NAME", "us-east-1")
+os.environ.setdefault("AWS_SES_REGION_ENDPOINT", "email.us-east-1.amazonaws.com")
+os.environ.setdefault("AWS_SES_SOURCE_EMAIL", "noreply@neovita.ai")
+os.environ.setdefault("FRONTEND_URL", "http://localhost:5173")
+
 from settings.common import *
+
+# Never hit a real mail provider in tests; collect messages in memory instead.
+EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 
 # Use a separate test database
 DATABASES = {


### PR DESCRIPTION
## What & why

Now that SES is live (verified sender `neovita.ai`, out of sandbox), this makes the account auth flow actually work end-to-end for the alpha. Backend reset *logic* already existed but had no UI and no email verification; this fills those gaps.

## Frontend
- New pages + routes: `/forgot-password`, `/reset-password`, `/verify-email`. Reset & verify read the token from the `?token=` query param (matching the emailed link).
- Wired the login **"Forgot password?"** button (was `onClick={() => console.log(...)}`) to navigate to `/forgot-password`.
- Added `verifyEmail` / `resendVerification` to the auth API + `useAuth` hook.

## Email verification (new)
- Added `User.is_email_verified` (+ migration `0007`).
- New endpoints `POST /api/v1/auth/verify-email` and `POST /api/v1/auth/resend-verification` (enumeration-safe).
- Registration now sends a verification email (best-effort via the existing, previously-orphaned templates).
- **Login is intentionally NOT gated on verification** — keeps existing alpha users (e.g. Eric) from being locked out; no backfill needed. Easy to flip on later.
- Completing a password reset also marks the email verified (clicking the link proves ownership).

## Cleanup
- Removed the duplicate `generate_verification_token` call in `forgot_password` (the send already generates it).
- `settings/test.py` now `setdefault`s the `AWS_SES_*` vars before importing `common` and uses the locmem email backend, so the auth suite runs outside the Docker container. (`.flake8` gains `E402` in the settings per-file-ignore, consistent with the existing `ai_service_factory.py` entry.)
- `.env.sample` sender → `noreply@neovita.ai`.

## Testing
- `apps/authentication`: **78 passing** (incl. new `test_verify_email` + `test_resend_verification`, and updated register/forgot/reset coverage). Verified against a fresh test DB so migration `0007` applies cleanly.
- Frontend: `tsc` clean, **vitest 275 passing**.
- Backend lint clean (black/isort/flake8). Biome is not enforced in this repo (baseline is space-indented); new files match the surrounding 2-space style.

> Note: 5 pre-existing failures in `apps/users` initial-message tests are unrelated to this PR (they fail on `main` too) and are left untouched.

## Follow-ups (out of scope)
- Set the SES env vars in Render (staging/prod) + `FRONTEND_URL=https://neovita.ai`.
- Optional: gate login on verification (+ backfill), server-side logout, authenticated change-password. Email templates still say "Discovita" — rebrand to NeoVita separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)