### PR TITLE
feat(auth): gate registration on email verification + branded emails

### DIFF
--- a/client/src/api/auth.ts
+++ b/client/src/api/auth.ts
@@ -145,6 +145,7 @@ export async function resetPassword(
 
 /**
  * Confirm an email address with a verification token.
+ * On success the backend returns tokens, so we log the user straight in.
  */
 export async function verifyEmail(token: string): Promise<AuthResponse> {
   const verifyEmailUrl = `${COACH_BASE_URL}${VERIFY_EMAIL}`;
@@ -153,7 +154,14 @@ export async function verifyEmail(token: string): Promise<AuthResponse> {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ token }),
   });
-  return response.json();
+  const data: AuthResponse = await response.json();
+  if (data.tokens) {
+    setCookie("neovita-access-token", data.tokens.access, 60 * 60 * 24);
+    setCookie("neovita-refresh-token", data.tokens.refresh, 60 * 60 * 24 * 30);
+    const user = await fetchUserComplete();
+    return { ...data, user };
+  }
+  return data;
 }
 
 /**

--- a/client/src/hooks/use-auth.ts
+++ b/client/src/hooks/use-auth.ts
@@ -91,9 +91,14 @@ export function useAuth() {
     mutationFn: resetPasswordApi,
   });
 
-  // Verify email mutation
+  // Verify email mutation — verifying logs the user in, so cache the user.
   const verifyEmailMutation = useMutation<AuthResponse, unknown, string>({
     mutationFn: verifyEmailApi,
+    onSuccess: (data) => {
+      if (data && data.user) {
+        setUserDataInCache(data.user);
+      }
+    },
   });
 
   // Resend verification mutation

--- a/client/src/pages/check-email/CheckEmail.tsx
+++ b/client/src/pages/check-email/CheckEmail.tsx
@@ -1,0 +1,100 @@
+import { Link } from "@tanstack/react-router";
+import { motion } from "framer-motion";
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/use-auth";
+
+const nvLogoSmall = "/neovita_logo_small.png";
+
+/**
+ * Check Email Route (/check-email?email=...)
+ *
+ * The post-registration pause page. The user has been sent a verification
+ * link and cannot continue until they confirm their email. Offers a resend.
+ */
+export default function CheckEmailPage() {
+  const { resendVerification } = useAuth();
+  const email = useMemo(
+    () => new URLSearchParams(window.location.search).get("email") ?? "",
+    []
+  );
+  const [resent, setResent] = useState(false);
+  const [sending, setSending] = useState(false);
+
+  async function handleResend() {
+    if (!email || sending) return;
+    setSending(true);
+    try {
+      await resendVerification(email);
+    } finally {
+      setResent(true);
+      setSending(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen w-screen flex items-center justify-center bg-[var(--nv-lilac-white)] px-6">
+      <div className="w-full max-w-[460px]">
+        <div className="mb-8 flex flex-col items-center gap-4">
+          <img
+            src={nvLogoSmall}
+            alt="Neovita mark"
+            className="h-[80px] w-auto select-none"
+            draggable={false}
+          />
+        </div>
+
+        <motion.div
+          className="rounded-2xl bg-white p-8 text-center shadow-sm"
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4 }}
+        >
+          <h1 className="text-[28px] font-medium text-black">
+            Verify your email to continue
+          </h1>
+          <p className="mt-3 text-[16px] text-black/70">
+            We sent a verification link to
+            {email ? (
+              <>
+                {" "}
+                <span className="font-medium text-black">{email}</span>.
+              </>
+            ) : (
+              " your email."
+            )}{" "}
+            Click it to activate your account, then you&rsquo;ll be brought
+            right back.
+          </p>
+
+          <div className="mt-6">
+            {resent ? (
+              <p className="text-[15px] text-[color:var(--nv-violet-blue)]">
+                Sent! Check your inbox (and spam folder).
+              </p>
+            ) : (
+              <Button
+                type="button"
+                onClick={handleResend}
+                disabled={sending || !email}
+                className="nv-gradient-button w-full rounded-full h-[52px] px-8 text-[18px] font-semibold"
+              >
+                {sending ? "Sending…" : "Resend verification email"}
+              </Button>
+            )}
+          </div>
+
+          <p className="mt-8 text-center text-sm text-foreground">
+            Already verified?{" "}
+            <Link
+              to="/login"
+              className="text-[color:var(--nv-violet-blue)] underline"
+            >
+              Log in
+            </Link>
+          </p>
+        </motion.div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/login/Login.tsx
+++ b/client/src/pages/login/Login.tsx
@@ -35,11 +35,13 @@ export default function LoginPage() {
   const { profile } = useProfile();
   const navigate = useNavigate();
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [unverifiedEmail, setUnverifiedEmail] = useState<string | null>(null);
 
   const form = useForm({
     defaultValues: { email: "", password: "" },
     onSubmit: async ({ value }) => {
       setErrorMessage(null);
+      setUnverifiedEmail(null);
       try {
         const response = await login({
           email: value.email,
@@ -57,6 +59,9 @@ export default function LoginPage() {
                   `${field}: ${Array.isArray(msgs) ? msgs.join(", ") : msgs}`
               )
               .join("; ");
+          }
+          if (typeof errorMsg === "string" && /verify your email/i.test(errorMsg)) {
+            setUnverifiedEmail(value.email);
           }
           setErrorMessage(errorMsg || "Login failed. Please try again.");
         }
@@ -209,6 +214,22 @@ export default function LoginPage() {
                   <p className="text-sm text-destructive text-center">
                     {errorMessage}
                   </p>
+                  {unverifiedEmail && (
+                    <p className="mt-1 text-sm text-center">
+                      <button
+                        type="button"
+                        className="text-[color:var(--nv-violet-blue)] underline"
+                        onClick={() =>
+                          navigate({
+                            to: "/check-email",
+                            search: { email: unverifiedEmail },
+                          })
+                        }
+                      >
+                        Resend verification email
+                      </button>
+                    </p>
+                  )}
                 </div>
               )}
 

--- a/client/src/pages/signup/Signup.tsx
+++ b/client/src/pages/signup/Signup.tsx
@@ -4,9 +4,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { motion } from "framer-motion";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useAuth } from "@/hooks/use-auth";
-import { useProfile } from "@/hooks/use-profile";
 
 /**
  * Signup Route (/signup)
@@ -29,7 +28,6 @@ const nvLogoLarge = "/neovita_logo_large.png";
 
 export default function Signup() {
   const { register } = useAuth();
-  const { profile } = useProfile();
   const navigate = useNavigate();
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -43,7 +41,8 @@ export default function Signup() {
           password: value.password,
         });
         if (response.success) {
-          // Redirect handled by the useEffect below when profile cache updates
+          // Registration no longer logs you in — verify your email first.
+          navigate({ to: "/check-email", search: { email: value.email } });
         } else {
           let errorMsg = response.error;
           if (typeof errorMsg === "object" && errorMsg !== null) {
@@ -63,13 +62,6 @@ export default function Signup() {
       }
     },
   });
-
-  // Redirect after successful registration when profile is available
-  useEffect(() => {
-    if (!profile) return;
-
-    navigate({ to: "/chat" });
-  }, [profile, navigate]);
 
   return (
     <div className="h-screen w-screen bg-[var(--nv-lilac-white)]">

--- a/client/src/pages/verify-email/VerifyEmail.tsx
+++ b/client/src/pages/verify-email/VerifyEmail.tsx
@@ -1,4 +1,4 @@
-import { Link } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import { motion } from "framer-motion";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -17,6 +17,7 @@ type Status = "verifying" | "success" | "error" | "no-token";
  */
 export default function VerifyEmailPage() {
   const { verifyEmail, resendVerification } = useAuth();
+  const navigate = useNavigate();
   const token = useMemo(
     () => new URLSearchParams(window.location.search).get("token") ?? "",
     []
@@ -30,9 +31,17 @@ export default function VerifyEmailPage() {
     if (!token || ranRef.current) return;
     ranRef.current = true; // guard against StrictMode double-invoke
     verifyEmail(token)
-      .then((response) => setStatus(response.success ? "success" : "error"))
+      .then((response) => {
+        if (response.success) {
+          setStatus("success");
+          // Verification logs the user in — drop them straight into the app.
+          setTimeout(() => navigate({ to: "/chat" }), 1500);
+        } else {
+          setStatus("error");
+        }
+      })
       .catch(() => setStatus("error"));
-  }, [token, verifyEmail]);
+  }, [token, verifyEmail, navigate]);
 
   async function handleResend() {
     if (!resendEmail) return;
@@ -77,13 +86,13 @@ export default function VerifyEmailPage() {
                 Email verified
               </h1>
               <p className="mt-3 text-[16px] text-black/70">
-                Thanks for confirming your email address.
+                You&rsquo;re all set — taking you in…
               </p>
               <Link
-                to="/login"
+                to="/chat"
                 className="mt-6 inline-block text-[color:var(--nv-violet-blue)] underline"
               >
-                Continue to login
+                Continue
               </Link>
             </>
           )}

--- a/client/src/routeTree.gen.ts
+++ b/client/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as SignupIndexRouteImport } from './routes/signup/index'
 import { Route as ResetPasswordIndexRouteImport } from './routes/reset-password/index'
 import { Route as LoginIndexRouteImport } from './routes/login/index'
 import { Route as ForgotPasswordIndexRouteImport } from './routes/forgot-password/index'
+import { Route as CheckEmailIndexRouteImport } from './routes/check-email/index'
 import { Route as AuthenticatedAdminRouteRouteImport } from './routes/_authenticated/admin/route'
 import { Route as AuthenticatedSettingsIndexRouteImport } from './routes/_authenticated/settings/index'
 import { Route as AuthenticatedNotificationsIndexRouteImport } from './routes/_authenticated/notifications/index'
@@ -68,6 +69,11 @@ const LoginIndexRoute = LoginIndexRouteImport.update({
 const ForgotPasswordIndexRoute = ForgotPasswordIndexRouteImport.update({
   id: '/forgot-password/',
   path: '/forgot-password/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CheckEmailIndexRoute = CheckEmailIndexRouteImport.update({
+  id: '/check-email/',
+  path: '/check-email/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthenticatedAdminRouteRoute = AuthenticatedAdminRouteRouteImport.update({
@@ -152,6 +158,7 @@ const AuthenticatedAdminPromptsRoute =
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/admin': typeof AuthenticatedAdminRouteRouteWithChildren
+  '/check-email': typeof CheckEmailIndexRoute
   '/forgot-password': typeof ForgotPasswordIndexRoute
   '/login': typeof LoginIndexRoute
   '/reset-password': typeof ResetPasswordIndexRoute
@@ -174,6 +181,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/admin': typeof AuthenticatedAdminRouteRouteWithChildren
+  '/check-email': typeof CheckEmailIndexRoute
   '/forgot-password': typeof ForgotPasswordIndexRoute
   '/login': typeof LoginIndexRoute
   '/reset-password': typeof ResetPasswordIndexRoute
@@ -199,6 +207,7 @@ export interface FileRoutesById {
   '/_authenticated': typeof AuthenticatedRouteRouteWithChildren
   '/_public': typeof PublicRouteRoute
   '/_authenticated/admin': typeof AuthenticatedAdminRouteRouteWithChildren
+  '/check-email/': typeof CheckEmailIndexRoute
   '/forgot-password/': typeof ForgotPasswordIndexRoute
   '/login/': typeof LoginIndexRoute
   '/reset-password/': typeof ResetPasswordIndexRoute
@@ -223,6 +232,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/admin'
+    | '/check-email'
     | '/forgot-password'
     | '/login'
     | '/reset-password'
@@ -245,6 +255,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/admin'
+    | '/check-email'
     | '/forgot-password'
     | '/login'
     | '/reset-password'
@@ -269,6 +280,7 @@ export interface FileRouteTypes {
     | '/_authenticated'
     | '/_public'
     | '/_authenticated/admin'
+    | '/check-email/'
     | '/forgot-password/'
     | '/login/'
     | '/reset-password/'
@@ -293,6 +305,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AuthenticatedRouteRoute: typeof AuthenticatedRouteRouteWithChildren
   PublicRouteRoute: typeof PublicRouteRoute
+  CheckEmailIndexRoute: typeof CheckEmailIndexRoute
   ForgotPasswordIndexRoute: typeof ForgotPasswordIndexRoute
   LoginIndexRoute: typeof LoginIndexRoute
   ResetPasswordIndexRoute: typeof ResetPasswordIndexRoute
@@ -356,6 +369,13 @@ declare module '@tanstack/react-router' {
       path: '/forgot-password'
       fullPath: '/forgot-password'
       preLoaderRoute: typeof ForgotPasswordIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/check-email/': {
+      id: '/check-email/'
+      path: '/check-email'
+      fullPath: '/check-email'
+      preLoaderRoute: typeof CheckEmailIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_authenticated/admin': {
@@ -513,6 +533,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthenticatedRouteRoute: AuthenticatedRouteRouteWithChildren,
   PublicRouteRoute: PublicRouteRoute,
+  CheckEmailIndexRoute: CheckEmailIndexRoute,
   ForgotPasswordIndexRoute: ForgotPasswordIndexRoute,
   LoginIndexRoute: LoginIndexRoute,
   ResetPasswordIndexRoute: ResetPasswordIndexRoute,

--- a/client/src/routes/check-email/index.tsx
+++ b/client/src/routes/check-email/index.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router";
+import CheckEmail from "@/pages/check-email/CheckEmail.tsx";
+
+/**
+ * /check-email?email=... — post-registration "verify your email" pause page.
+ */
+export const Route = createFileRoute("/check-email/")({
+  validateSearch: (search: Record<string, unknown>): { email?: string } => ({
+    email: typeof search.email === "string" ? search.email : undefined,
+  }),
+  component: CheckEmail,
+});

--- a/server/apps/authentication/functions/public/register_user.py
+++ b/server/apps/authentication/functions/public/register_user.py
@@ -6,8 +6,6 @@ Create a new user account and return JWT tokens.
 
 from typing import Any
 
-from rest_framework_simplejwt.tokens import RefreshToken
-
 from django.db import transaction
 
 from apps.authentication.utils import send_verification_email
@@ -20,35 +18,33 @@ log = configure_logging(__name__, log_level="INFO")
 @transaction.atomic
 def register_user(email: str, password: str) -> dict[str, Any]:
     """
-    Create a new user, send a verification email, and issue JWT tokens.
+    Create a new (unverified) user and send a verification email.
 
-    Email verification is best-effort and does NOT gate access: the account is
-    active and logged in immediately. A failed verification send is logged but
-    does not fail registration.
+    Registration does NOT log the user in: no JWT tokens are issued. The user
+    must verify their email before they can log in (see LoginSerializer). The
+    verification send is best-effort — a delivery failure is reported via
+    ``email_sent`` so the UI can offer a resend, but it does not fail
+    registration or roll back the account.
 
     Args:
         email: Validated email address (unique check done by serializer).
         password: Validated password (strength check done by serializer).
 
     Returns:
-        Dict with ``user_id``, ``tokens.refresh``, and ``tokens.access``.
+        Dict with ``user_id`` and ``email_sent``.
 
     Raises:
-        Exception: If user creation or token generation fails.
+        Exception: If user creation fails.
     """
     user = User.objects.create_user(email=email, password=password)
-    refresh = RefreshToken.for_user(user)
 
     log.info("Registered new user %s", email)
 
-    # Best-effort verification email — never block registration on delivery.
-    if not send_verification_email(user):
+    email_sent = send_verification_email(user)
+    if not email_sent:
         log.warning("Verification email could not be sent for new user %s", email)
 
     return {
         "user_id": user.id,
-        "tokens": {
-            "refresh": str(refresh),
-            "access": str(refresh.access_token),
-        },
+        "email_sent": email_sent,
     }

--- a/server/apps/authentication/functions/public/verify_email.py
+++ b/server/apps/authentication/functions/public/verify_email.py
@@ -4,6 +4,8 @@ verify_email
 Validate an email-verification token and mark the user's email verified.
 """
 
+from rest_framework_simplejwt.tokens import RefreshToken
+
 from apps.authentication.utils import AuthErrorMessages, is_token_expired
 from apps.users.models import User
 from services.logger import configure_logging
@@ -27,7 +29,8 @@ def verify_email(token: str) -> dict:
         token: Verification token from the verify-email URL.
 
     Returns:
-        Dict with a ``message`` key on success.
+        Dict with ``message``, ``user_id``, and ``tokens`` (refresh/access) so
+        the caller is logged in immediately on successful verification.
 
     Raises:
         VerificationInvalidError: If no user matches the token.
@@ -48,5 +51,14 @@ def verify_email(token: str) -> dict:
     user.email_verification_sent_at = None
     user.save()
 
+    refresh = RefreshToken.for_user(user)
+
     log.info("Email verified for user %s", user.email)
-    return {"message": "Email verified successfully"}
+    return {
+        "message": "Email verified successfully",
+        "user_id": user.id,
+        "tokens": {
+            "refresh": str(refresh),
+            "access": str(refresh.access_token),
+        },
+    }

--- a/server/apps/authentication/serializers/login_serializer.py
+++ b/server/apps/authentication/serializers/login_serializer.py
@@ -20,9 +20,11 @@ class LoginSerializer(serializers.Serializer):
     password = serializers.CharField(help_text="User's password.")
 
     def validate(self, data: dict) -> dict:
-        """Authenticate credentials. Raises ValidationError on failure."""
+        """Authenticate credentials and require a verified email."""
         user = authenticate(email=data["email"], password=data["password"])
         if not user:
             raise serializers.ValidationError(AuthErrorMessages.INVALID_CREDENTIALS)
+        if not user.is_email_verified:
+            raise serializers.ValidationError(AuthErrorMessages.EMAIL_NOT_VERIFIED)
         data["user"] = user
         return data

--- a/server/apps/authentication/templates/password_reset_email.html
+++ b/server/apps/authentication/templates/password_reset_email.html
@@ -1,56 +1,116 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <style>
-      body {
-        font-family: Arial, sans-serif;
-        line-height: 1.6;
-        color: #333;
-      }
-
-      .container {
-        max-width: 600px;
-        margin: 0 auto;
-        padding: 20px;
-      }
-
-      .button {
-        display: inline-block;
-        padding: 12px 24px;
-        font-weight: bold;
-        text-decoration: none;
-        border-radius: 6px;
-        margin: 20px 0;
-      }
-
-      .footer {
-        margin-top: 30px;
-        font-size: 0.9em;
-        color: #666;
-      }
-    </style>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light only" />
+    <title>Reset your NeoVita password</title>
   </head>
+  <body
+    style="margin: 0; padding: 0; background-color: #f7f5ff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; -webkit-font-smoothing: antialiased;"
+  >
+    <table
+      role="presentation"
+      width="100%"
+      cellpadding="0"
+      cellspacing="0"
+      style="background-color: #f7f5ff;"
+    >
+      <tr>
+        <td align="center" style="padding: 40px 16px;">
+          <table
+            role="presentation"
+            width="100%"
+            cellpadding="0"
+            cellspacing="0"
+            style="max-width: 480px; background-color: #ffffff; border-radius: 16px; box-shadow: 0 6px 24px rgba(11, 28, 74, 0.06); overflow: hidden;"
+          >
+            <!-- Logo header -->
+            <tr>
+              <td align="center" style="padding: 36px 40px 8px 40px;">
+                <img
+                  src="{{ logo_url }}"
+                  width="56"
+                  alt="NeoVita"
+                  style="display: block; height: auto; border: 0; margin-bottom: 12px;"
+                />
+                <div
+                  style="font-size: 22px; font-weight: 600; letter-spacing: -0.5px; color: #0b1c4a;"
+                >
+                  neovita
+                </div>
+              </td>
+            </tr>
 
-  <body>
-    <div class="container">
-      <h2>Reset Your Password</h2>
-      <p
-        >We received a request to reset your password. Click the button below to
-        choose a new password:
-      </p>
+            <!-- Body -->
+            <tr>
+              <td style="padding: 16px 40px 8px 40px;">
+                <h1
+                  style="margin: 0 0 12px 0; font-size: 24px; font-weight: 600; color: #0b1c4a; text-align: center;"
+                >
+                  Reset your password
+                </h1>
+                <p
+                  style="margin: 0 0 24px 0; font-size: 16px; line-height: 1.6; color: #4a4a5a; text-align: center;"
+                >
+                  We received a request to reset your NeoVita password. Click
+                  below to choose a new one.
+                </p>
+              </td>
+            </tr>
 
-      <a href="{{ reset_url }}" class="button">Reset Password</a>
+            <!-- Button -->
+            <tr>
+              <td align="center" style="padding: 0 40px 8px 40px;">
+                <table role="presentation" cellpadding="0" cellspacing="0">
+                  <tr>
+                    <td
+                      align="center"
+                      bgcolor="#531e96"
+                      style="border-radius: 999px; background-color: #531e96; background-image: linear-gradient(135deg, #531e96 0%, #6a5ffb 100%);"
+                    >
+                      <a
+                        href="{{ reset_url }}"
+                        target="_blank"
+                        style="display: inline-block; padding: 15px 40px; font-size: 16px; font-weight: 600; color: #ffffff; text-decoration: none; border-radius: 999px;"
+                      >
+                        Reset password
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
 
-      <p>This link will expire in {{ expiry_hours }} hours.</p>
+            <!-- Fallback link -->
+            <tr>
+              <td style="padding: 20px 40px 8px 40px;">
+                <p
+                  style="margin: 0; font-size: 13px; line-height: 1.6; color: #8a8a9a; text-align: center;"
+                >
+                  Or paste this link into your browser:<br />
+                  <a href="{{ reset_url }}" style="color: #6a5ffb; word-break: break-all;">{{ reset_url }}</a>
+                </p>
+              </td>
+            </tr>
 
-      <p
-        >If you didn't request a password reset, you can safely ignore this
-        email.</p
-      >
+            <!-- Footer -->
+            <tr>
+              <td style="padding: 16px 40px 36px 40px;">
+                <hr style="border: none; border-top: 1px solid #ecebf5; margin: 8px 0 16px 0;" />
+                <p style="margin: 0; font-size: 13px; line-height: 1.6; color: #9a9aa8; text-align: center;">
+                  This link expires in {{ expiry_hours }} hours. If you didn&rsquo;t
+                  request a password reset, you can safely ignore this email.
+                </p>
+              </td>
+            </tr>
+          </table>
 
-      <div class="footer">
-        <p>Best regards,<br />The Discovita Team</p>
-      </div>
-    </div>
+          <p style="margin: 20px 0 0 0; font-size: 12px; color: #b0b0bd;">
+            &copy; NeoVita
+          </p>
+        </td>
+      </tr>
+    </table>
   </body>
 </html>

--- a/server/apps/authentication/templates/password_reset_email.txt
+++ b/server/apps/authentication/templates/password_reset_email.txt
@@ -1,12 +1,12 @@
-Reset Your Password
+Reset your password — NeoVita
 
-We received a request to reset your password. Click the link below to choose a new password:
+We received a request to reset your NeoVita password. Use the link below to
+choose a new one.
 
+Reset your password:
 {{ reset_url }}
 
-This link will expire in {{ expiry_hours }} hours.
+This link expires in {{ expiry_hours }} hours. If you didn't request a password
+reset, you can safely ignore this email.
 
-If you didn't request a password reset, you can safely ignore this email.
-
-Best regards,
-The Discovita Team 
+— NeoVita

--- a/server/apps/authentication/templates/verification_email.html
+++ b/server/apps/authentication/templates/verification_email.html
@@ -1,58 +1,116 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <style>
-      body {
-        font-family: Arial, sans-serif;
-        line-height: 1.6;
-        color: #333;
-      }
-
-      .container {
-        max-width: 600px;
-        margin: 0 auto;
-        padding: 20px;
-      }
-
-      .button {
-        display: inline-block;
-        padding: 12px 24px;
-        background-color: #000000;
-        color: #ffffff;
-        font-weight: bold;
-        text-decoration: none;
-        border-radius: 6px;
-        margin: 20px 0;
-      }
-
-      .footer {
-        margin-top: 30px;
-        font-size: 0.9em;
-        color: #666;
-      }
-    </style>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light only" />
+    <title>Verify your NeoVita email</title>
   </head>
+  <body
+    style="margin: 0; padding: 0; background-color: #f7f5ff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; -webkit-font-smoothing: antialiased;"
+  >
+    <table
+      role="presentation"
+      width="100%"
+      cellpadding="0"
+      cellspacing="0"
+      style="background-color: #f7f5ff;"
+    >
+      <tr>
+        <td align="center" style="padding: 40px 16px;">
+          <table
+            role="presentation"
+            width="100%"
+            cellpadding="0"
+            cellspacing="0"
+            style="max-width: 480px; background-color: #ffffff; border-radius: 16px; box-shadow: 0 6px 24px rgba(11, 28, 74, 0.06); overflow: hidden;"
+          >
+            <!-- Logo header -->
+            <tr>
+              <td align="center" style="padding: 36px 40px 8px 40px;">
+                <img
+                  src="{{ logo_url }}"
+                  width="56"
+                  alt="NeoVita"
+                  style="display: block; height: auto; border: 0; margin-bottom: 12px;"
+                />
+                <div
+                  style="font-size: 22px; font-weight: 600; letter-spacing: -0.5px; color: #0b1c4a;"
+                >
+                  neovita
+                </div>
+              </td>
+            </tr>
 
-  <body>
-    <div class="container">
-      <h2>Welcome to Discovita!</h2>
-      <p
-        >Thanks for signing up. Please verify your email address by clicking the
-        button below:
-      </p>
+            <!-- Body -->
+            <tr>
+              <td style="padding: 16px 40px 8px 40px;">
+                <h1
+                  style="margin: 0 0 12px 0; font-size: 24px; font-weight: 600; color: #0b1c4a; text-align: center;"
+                >
+                  Confirm your email
+                </h1>
+                <p
+                  style="margin: 0 0 24px 0; font-size: 16px; line-height: 1.6; color: #4a4a5a; text-align: center;"
+                >
+                  Welcome to NeoVita! Confirm your email address to activate your
+                  account and start your journey.
+                </p>
+              </td>
+            </tr>
 
-      <a href="{{ verify_url }}" class="button">Verify Email Address</a>
+            <!-- Button -->
+            <tr>
+              <td align="center" style="padding: 0 40px 8px 40px;">
+                <table role="presentation" cellpadding="0" cellspacing="0">
+                  <tr>
+                    <td
+                      align="center"
+                      bgcolor="#531e96"
+                      style="border-radius: 999px; background-color: #531e96; background-image: linear-gradient(135deg, #531e96 0%, #6a5ffb 100%);"
+                    >
+                      <a
+                        href="{{ verify_url }}"
+                        target="_blank"
+                        style="display: inline-block; padding: 15px 40px; font-size: 16px; font-weight: 600; color: #ffffff; text-decoration: none; border-radius: 999px;"
+                      >
+                        Verify email address
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
 
-      <p>This link will expire in {{ expiry_hours }} hours.</p>
+            <!-- Fallback link -->
+            <tr>
+              <td style="padding: 20px 40px 8px 40px;">
+                <p
+                  style="margin: 0; font-size: 13px; line-height: 1.6; color: #8a8a9a; text-align: center;"
+                >
+                  Or paste this link into your browser:<br />
+                  <a href="{{ verify_url }}" style="color: #6a5ffb; word-break: break-all;">{{ verify_url }}</a>
+                </p>
+              </td>
+            </tr>
 
-      <p
-        >If you didn't create an account with Discovita, you can safely ignore
-        this email.
-      </p>
+            <!-- Footer -->
+            <tr>
+              <td style="padding: 16px 40px 36px 40px;">
+                <hr style="border: none; border-top: 1px solid #ecebf5; margin: 8px 0 16px 0;" />
+                <p style="margin: 0; font-size: 13px; line-height: 1.6; color: #9a9aa8; text-align: center;">
+                  This link expires in {{ expiry_hours }} hours. If you didn&rsquo;t
+                  create a NeoVita account, you can safely ignore this email.
+                </p>
+              </td>
+            </tr>
+          </table>
 
-      <div class="footer">
-        <p>Best regards,<br />The Discovita Team</p>
-      </div>
-    </div>
+          <p style="margin: 20px 0 0 0; font-size: 12px; color: #b0b0bd;">
+            &copy; NeoVita
+          </p>
+        </td>
+      </tr>
+    </table>
   </body>
 </html>

--- a/server/apps/authentication/templates/verification_email.txt
+++ b/server/apps/authentication/templates/verification_email.txt
@@ -1,13 +1,12 @@
-Welcome to Discovita!
+Confirm your email — NeoVita
 
+Welcome to NeoVita! Confirm your email address to activate your account and
+start your journey.
 
-Thanks for signing up. Please verify your email address by clicking the link below:
-
+Verify your email address:
 {{ verify_url }}
 
-This link will expire in {{ expiry_hours }} hours.
+This link expires in {{ expiry_hours }} hours. If you didn't create a NeoVita
+account, you can safely ignore this email.
 
-If you didn't create an account with Discovita, you can safely ignore this email.
-
-Best regards,
-The Discovita Team 
+— NeoVita

--- a/server/apps/authentication/tests/test_login_endpoint.py
+++ b/server/apps/authentication/tests/test_login_endpoint.py
@@ -17,6 +17,8 @@ class LoginSerializerTests(TestCase):
         self.user = User.objects.create_user(
             email="login@example.com", password="TestPass1!"
         )
+        self.user.is_email_verified = True
+        self.user.save()
 
     def test_valid_credentials_pass(self):
         """Correct email/password should validate and attach user."""
@@ -25,6 +27,15 @@ class LoginSerializerTests(TestCase):
         )
         self.assertTrue(serializer.is_valid(), serializer.errors)
         self.assertEqual(serializer.validated_data["user"], self.user)
+
+    def test_unverified_email_rejected(self):
+        """A correct password but unverified email should fail validation."""
+        self.user.is_email_verified = False
+        self.user.save()
+        serializer = LoginSerializer(
+            data={"email": "login@example.com", "password": "TestPass1!"}
+        )
+        self.assertFalse(serializer.is_valid())
 
     def test_wrong_password_rejected(self):
         """Wrong password should fail validation."""
@@ -59,6 +70,8 @@ class LoginEndpointTests(APITestCase):
         self.user = User.objects.create_user(
             email="login@example.com", password="TestPass1!"
         )
+        self.user.is_email_verified = True
+        self.user.save()
 
     def test_successful_login(self):
         """Valid credentials return tokens."""
@@ -71,6 +84,18 @@ class LoginEndpointTests(APITestCase):
         self.assertTrue(response.data["success"])
         self.assertIn("tokens", response.data)
         self.assertEqual(response.data["user_id"], self.user.id)
+
+    def test_unverified_email_returns_400(self):
+        """An unverified account cannot log in."""
+        self.user.is_email_verified = False
+        self.user.save()
+        response = self.client.post(
+            self.url,
+            {"email": "login@example.com", "password": "TestPass1!"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(response.data["success"])
 
     def test_wrong_password_returns_400(self):
         """Invalid password returns 400."""

--- a/server/apps/authentication/tests/test_register_user.py
+++ b/server/apps/authentication/tests/test_register_user.py
@@ -47,14 +47,11 @@ class RegisterUserTests(TestCase):
         user = User.objects.get(email="new@example.com")
         self.assertEqual(result["user_id"], user.id)
 
-    def test_returns_jwt_tokens(self):
-        """Result should contain refresh and access tokens."""
+    def test_does_not_return_tokens(self):
+        """Registration must NOT log the user in — no tokens until verified."""
         result = register_user(email="new@example.com", password="TestPass1!")
-        self.assertIn("tokens", result)
-        self.assertIn("refresh", result["tokens"])
-        self.assertIn("access", result["tokens"])
-        self.assertTrue(len(result["tokens"]["refresh"]) > 0)
-        self.assertTrue(len(result["tokens"]["access"]) > 0)
+        self.assertNotIn("tokens", result)
+        self.assertTrue(result["email_sent"])
 
     def test_password_is_hashed(self):
         """Stored password should be hashed, not plaintext."""

--- a/server/apps/authentication/tests/test_registration.py
+++ b/server/apps/authentication/tests/test_registration.py
@@ -87,14 +87,15 @@ class RegisterEndpointTests(APITestCase):
         self.addCleanup(patcher.stop)
 
     def test_successful_registration(self):
-        """Valid payload creates user and returns tokens."""
+        """Valid payload creates an unverified user and does NOT log them in."""
         response = self.client.post(self.url, self.valid_payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.data["success"])
-        self.assertIn("tokens", response.data)
+        self.assertNotIn("tokens", response.data)
         self.assertIn("user_id", response.data)
-        self.assertTrue(User.objects.filter(email="new@example.com").exists())
+        user = User.objects.get(email="new@example.com")
+        self.assertFalse(user.is_email_verified)
 
     def test_duplicate_email_returns_400(self):
         """Existing email should return 400."""

--- a/server/apps/authentication/tests/test_verify_email.py
+++ b/server/apps/authentication/tests/test_verify_email.py
@@ -35,6 +35,9 @@ class VerifyEmailFunctionTests(TestCase):
         self.assertEqual(self.user.verification_token, "")
         self.assertIsNone(self.user.email_verification_sent_at)
         self.assertIn("verified", result["message"].lower())
+        # Verifying logs the user in.
+        self.assertIn("tokens", result)
+        self.assertIn("access", result["tokens"])
 
     def test_invalid_token_raises(self):
         with self.assertRaises(VerificationInvalidError):
@@ -69,6 +72,7 @@ class VerifyEmailEndpointTests(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.data["success"])
+        self.assertIn("tokens", response.data)
         self.user.refresh_from_db()
         self.assertTrue(self.user.is_email_verified)
 

--- a/server/apps/authentication/utils/send_password_reset_email.py
+++ b/server/apps/authentication/utils/send_password_reset_email.py
@@ -39,21 +39,20 @@ def send_password_reset_email(user: User) -> bool:
 
         token = generate_verification_token(user)
         reset_url = f"{settings.FRONTEND_URL}/reset-password?token={token}"
+        context = {
+            "reset_url": reset_url,
+            "expiry_hours": TOKEN_EXPIRY_HOURS,
+            "logo_url": f"{settings.FRONTEND_URL}/neovita_logo_small.png",
+        }
 
-        html_content = render_to_string(
-            "password_reset_email.html",
-            {"reset_url": reset_url, "expiry_hours": TOKEN_EXPIRY_HOURS},
-        )
-        text_content = render_to_string(
-            "password_reset_email.txt",
-            {"reset_url": reset_url, "expiry_hours": TOKEN_EXPIRY_HOURS},
-        )
+        html_content = render_to_string("password_reset_email.html", context)
+        text_content = render_to_string("password_reset_email.txt", context)
 
         ses.send_email(
             Source=settings.AWS_SES_SOURCE_EMAIL,
             Destination={"ToAddresses": [user.email]},
             Message={
-                "Subject": {"Data": "Reset Your Password - Discovita"},
+                "Subject": {"Data": "Reset your NeoVita password"},
                 "Body": {
                     "Text": {"Data": text_content},
                     "Html": {"Data": html_content},

--- a/server/apps/authentication/utils/send_verification_email.py
+++ b/server/apps/authentication/utils/send_verification_email.py
@@ -39,21 +39,20 @@ def send_verification_email(user: User) -> bool:
 
         token = generate_verification_token(user)
         verify_url = f"{settings.FRONTEND_URL}/verify-email?token={token}"
+        context = {
+            "verify_url": verify_url,
+            "expiry_hours": TOKEN_EXPIRY_HOURS,
+            "logo_url": f"{settings.FRONTEND_URL}/neovita_logo_small.png",
+        }
 
-        html_content = render_to_string(
-            "verification_email.html",
-            {"verify_url": verify_url, "expiry_hours": TOKEN_EXPIRY_HOURS},
-        )
-        text_content = render_to_string(
-            "verification_email.txt",
-            {"verify_url": verify_url, "expiry_hours": TOKEN_EXPIRY_HOURS},
-        )
+        html_content = render_to_string("verification_email.html", context)
+        text_content = render_to_string("verification_email.txt", context)
 
         ses.send_email(
             Source=settings.AWS_SES_SOURCE_EMAIL,
             Destination={"ToAddresses": [user.email]},
             Message={
-                "Subject": {"Data": "Verify Your Email - Discovita"},
+                "Subject": {"Data": "Verify your NeoVita email"},
                 "Body": {
                     "Text": {"Data": text_content},
                     "Html": {"Data": html_content},

--- a/server/apps/users/migrations/0008_backfill_email_verified.py
+++ b/server/apps/users/migrations/0008_backfill_email_verified.py
@@ -1,0 +1,28 @@
+from django.db import migrations
+
+
+def mark_existing_verified(apps, schema_editor):
+    """
+    Grandfather every pre-existing account as email-verified.
+
+    Login is now gated on ``is_email_verified``. Accounts created before that
+    gate existed were never asked to verify, so mark them verified to avoid
+    locking them out. Only brand-new sign-ups (created after this migration)
+    start unverified and must confirm their email.
+    """
+    User = apps.get_model("users", "User")
+    User.objects.filter(is_email_verified=False).update(is_email_verified=True)
+
+
+def noop_reverse(apps, schema_editor):
+    """No-op: we cannot know which users were backfilled vs. genuinely verified."""
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0007_user_is_email_verified"),
+    ]
+
+    operations = [
+        migrations.RunPython(mark_existing_verified, noop_reverse),
+    ]


### PR DESCRIPTION
## What & why

Two fixes on top of #121:
1. **Registration no longer auto-logs-in.** You now have to verify your email before you can get in — the behaviour you described.
2. **The emails look professional** — NeoVita-branded instead of plain text with a black button.

## New flow
`Register` → **"Verify your email to continue"** pause page → click the link in the email → **auto-logged-in and dropped into `/chat`**.

## Backend
- `register_user` no longer issues JWTs — returns `{user_id, email_sent}`. The account is created but not logged in.
- `LoginSerializer` rejects unverified accounts with `EMAIL_NOT_VERIFIED`.
- `verify_email` now issues JWTs on success, so clicking the link logs you in.
- **Data migration `0008`** backfills every existing user to `is_email_verified=True`, so the new login gate can't lock anyone out — only brand-new signups must verify. (No backfill = locked-out alpha users; this avoids that.)

## Frontend
- New **`/check-email`** pause page with a resend button; signup navigates here on success.
- `/verify-email` auto-logs-in (api `verifyEmail` sets cookies) and redirects to `/chat`.
- Login shows a **"Resend verification email"** link when the account is unverified.

## Emails (verification + password reset)
- Rebuilt both HTML templates: logo, NeoVita wordmark, brand palette (`#0b1c4a` headings, `#f7f5ff` background), and a **rounded gradient button** (`#531e96`→`#6a5ffb`) with a **solid-purple fallback for Outlook** — replacing the old black button with dark-blue text.
- Subjects + body copy now say **NeoVita**. Logo URL derives from `FRONTEND_URL` (so it resolves to `https://neovita.ai/neovita_logo_small.png` in prod).
- Plain-text parts updated to match.

## Testing
- `apps/authentication`: **80 passing** (fresh DB, so migration `0008` is exercised). Added login email-verification-gate tests; updated register (no tokens), verify (returns tokens), and login (verified-user) expectations.
- Frontend: `tsc` clean, **vitest 275 passing**.
- Backend lint clean (black/isort/flake8). All 4 email templates render without errors.

## Decisions (flagged in chat, override if you disagree)
- **Login is gated on verification** (with the existing-user backfill above).
- **Verifying logs you straight in** rather than bouncing to the login page.

## Follow-ups (unchanged from #121)
- Set SES env vars + `FRONTEND_URL=https://neovita.ai` in Render.
- Email logo requires the frontend to be serving `neovita_logo_small.png` at the `FRONTEND_URL` root (it already does in `client/public/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)