### PR TITLE
refactor(account): split account page into tabs

### DIFF
--- a/client/src/pages/account/Account.tsx
+++ b/client/src/pages/account/Account.tsx
@@ -5,6 +5,7 @@ import { useImpersonation } from "@/context/ImpersonationContext";
 import { useQuery } from "@tanstack/react-query";
 import { fetchTestScenarioUserProfile } from "@/api/testScenarioUser";
 import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { AccountInformation } from "./components/AccountInformation";
 import { ReferenceImageManager } from "./components/ReferenceImageManager";
 import { AppearanceSelector } from "./components/appearance";
@@ -69,37 +70,49 @@ export default function Account() {
     <div className="max-w-4xl mx-auto p-6">
       <h1 className="text-3xl font-semibold mb-6">Account</h1>
 
-      <div className="space-y-6">
-        {/* Account Information */}
-        <AccountInformation profile={viewedProfile ?? null} />
+      <Tabs defaultValue="account">
+        <TabsList>
+          <TabsTrigger value="account">Account</TabsTrigger>
+          <TabsTrigger value="reference-photos">Reference Photos</TabsTrigger>
+          <TabsTrigger value="appearance">Appearance Preferences</TabsTrigger>
+        </TabsList>
 
-        {/* Reference Photos Section */}
-        <ReferenceImageManager userId={isImpersonating ? viewedUserId ?? undefined : undefined} />
+        {/* Account tab — account info + sign out */}
+        <TabsContent value="account" className="space-y-6">
+          <AccountInformation profile={viewedProfile ?? null} />
 
-        {/* Appearance Preferences Section */}
-        <AppearanceSelector
-          appearance={appearance}
-          onSave={handleAppearanceSave}
-          isSaving={isUpdating}
-        />
+          {/* Logout Section — hidden when impersonating */}
+          {!isImpersonating && (
+            <div className="bg-card rounded-lg border p-6">
+              <h2 className="text-xl font-medium mb-4">Sign Out</h2>
+              <p className="text-sm text-muted-foreground mb-4">
+                Sign out of your account. You'll need to log in again to access your account.
+              </p>
+              <Button
+                onClick={handleLogout}
+                disabled={logoutStatus === "pending"}
+                className="nv-gradient-button w-full sm:w-auto text-white"
+              >
+                {logoutStatus === "pending" ? "Signing out..." : "Sign Out"}
+              </Button>
+            </div>
+          )}
+        </TabsContent>
 
-        {/* Logout Section — hidden when impersonating */}
-        {!isImpersonating && (
-          <div className="bg-card rounded-lg border p-6">
-            <h2 className="text-xl font-medium mb-4">Sign Out</h2>
-            <p className="text-sm text-muted-foreground mb-4">
-              Sign out of your account. You'll need to log in again to access your account.
-            </p>
-            <Button
-              onClick={handleLogout}
-              disabled={logoutStatus === "pending"}
-              className="nv-gradient-button w-full sm:w-auto text-white"
-            >
-              {logoutStatus === "pending" ? "Signing out..." : "Sign Out"}
-            </Button>
-          </div>
-        )}
-      </div>
+        {/* Reference Photos tab */}
+        <TabsContent value="reference-photos">
+          <ReferenceImageManager userId={isImpersonating ? viewedUserId ?? undefined : undefined} />
+        </TabsContent>
+
+        {/* Appearance Preferences tab */}
+        <TabsContent value="appearance">
+          <AppearanceSelector
+            appearance={appearance}
+            onSave={handleAppearanceSave}
+            isSaving={isUpdating}
+          />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }


### PR DESCRIPTION
## What

Refactors the Account page from inline-stacked sections into a tabbed layout using the existing `ui/tabs` primitive. Three tabs:

- **Account** — Account Information + the Sign Out section
- **Reference Photos** — `ReferenceImageManager`
- **Appearance Preferences** — `AppearanceSelector`

## Why

The inline stacked view crowds three distinct concerns onto one long page. Tabs separate them cleanly and mirror the same grouping used in the upcoming onboarding flow.

## Notes

- Pure layout change — no logic, data, or API changes. The three sections keep their existing props and impersonation wiring.
- Sign Out remains hidden while impersonating, unchanged.
- Reuses the existing `client/src/components/ui/tabs.tsx` primitive; no new dependencies.

## Testing

- `npx tsc --noEmit` — clean for `Account.tsx` (unrelated pre-existing `@dnd-kit`/`IAms.tsx` errors remain).
- Manual: each tab renders its section; default tab is Account.