### PR TITLE
feat(admin): surface email-verified status + toggle on user admin

### DIFF
--- a/server/apps/users/admin/user_admin.py
+++ b/server/apps/users/admin/user_admin.py
@@ -26,13 +26,21 @@ class UserAdmin(BaseUserAdmin):
         "email",
         "first_name",
         "last_name",
+        "is_email_verified",
         "is_staff",
         "is_active",
         "is_superuser",
         "created_at",
         "test_scenario_display",
     )
-    list_filter = ("is_staff", "is_active", "is_superuser", "test_scenario")
+    list_filter = (
+        "is_email_verified",
+        "is_staff",
+        "is_active",
+        "is_superuser",
+        "test_scenario",
+    )
+    actions = ("mark_email_verified", "mark_email_unverified")
     search_fields = ("email", "first_name", "last_name", "test_scenario__name")
     fieldsets = (
         (None, {"fields": ("email", "password")}),
@@ -52,7 +60,13 @@ class UserAdmin(BaseUserAdmin):
         ("Important dates", {"fields": ("last_login", "created_at", "updated_at")}),
         (
             "Verification",
-            {"fields": ("verification_token", "email_verification_sent_at")},
+            {
+                "fields": (
+                    "is_email_verified",
+                    "verification_token",
+                    "email_verification_sent_at",
+                )
+            },
         ),
         (
             "Appearance Preferences",
@@ -112,3 +126,15 @@ class UserAdmin(BaseUserAdmin):
 
     test_scenario_display.short_description = "Test Scenario"
     test_scenario_display.admin_order_field = "test_scenario__name"
+
+    @admin.action(description="Mark selected users as email verified")
+    def mark_email_verified(self, request, queryset):
+        """Bulk-mark the selected users' email addresses as verified."""
+        updated = queryset.update(is_email_verified=True)
+        self.message_user(request, f"Marked {updated} user(s) as email verified.")
+
+    @admin.action(description="Mark selected users as email NOT verified")
+    def mark_email_unverified(self, request, queryset):
+        """Bulk-mark the selected users' email addresses as not verified."""
+        updated = queryset.update(is_email_verified=False)
+        self.message_user(request, f"Marked {updated} user(s) as email not verified.")


### PR DESCRIPTION
## What

Makes a user's email-verification state visible and editable from the Django admin user page. The `is_email_verified` field already existed on the `User` model but was never surfaced in the admin.

- **Per-user toggle:** `is_email_verified` is now an editable checkbox in the **Verification** fieldset on the user change form — check it to mark a user verified, save.
- **At-a-glance:** added as a boolean column on the user changelist and as a list filter.
- **Bulk actions:** "Mark selected users as email verified" and the inverse "Mark selected users as email NOT verified" for the changelist.

## How

- `server/apps/users/admin/user_admin.py` only:
  - Added `is_email_verified` to `list_display`, `list_filter`, and the `Verification` fieldset.
  - Added `actions = ("mark_email_verified", "mark_email_unverified")` with two `@admin.action` methods that `queryset.update(is_email_verified=...)` and report a count via `message_user`.

## Notes

- No model change and **no migration** — the field already exists (`users.0007` / backfilled in `users.0008`).
- The editable checkbox is the toggle requested; the bulk actions are a convenience and are reversible.
- Scope is admin-only; nothing in the auth/verification runtime flow changes.

## Testing

- `python manage.py check` — "System check identified no issues" (validates the admin config: list_display/list_filter/fieldsets/actions all reference valid fields/methods).
- `pytest apps/users` — the only failures are pre-existing and unrelated (stale `INITIAL_MESSAGE` assertions from the shipped coaching-phase-videos change; confirmed identical on a clean tree by stashing this diff).
- Manual: admin user page shows the Email-verified checkbox; changelist shows the column + filter; bulk actions flip the flag with a confirmation message.