### PR TITLE
fix(prompts): use first name only for user_name context key

### DIFF
--- a/server/services/prompt_manager/utils/context/func/get_user_name_context.py
+++ b/server/services/prompt_manager/utils/context/func/get_user_name_context.py
@@ -4,6 +4,9 @@ from apps.coach_states.models import CoachState
 def get_user_name_context(coach_state: CoachState) -> str:
     """
     Get the user's name context.
+
+    The coach addresses the user by first name only, so this returns the
+    user's first name (falling back to their email when no first name is set).
     """
     user = coach_state.user
-    return user.get_full_name() or user.email
+    return user.first_name or user.email


### PR DESCRIPTION
## What

The `user_name` context key injected into coach prompts now resolves to the user's **first name** instead of their full name. The coach already addresses the user by first name throughout the prompts (e.g. "I'm so glad you're here, {user_name}"), so the full name read awkwardly.

## How

- `server/services/prompt_manager/utils/context/func/get_user_name_context.py`: return `user.first_name or user.email` instead of `user.get_full_name() or user.email`. Email remains the fallback when no first name is set.

## Notes

- Single-line behavior change; no model/migration/API changes.
- Edge case: a user with only a last name set (no first name) falls back to email rather than the last name — acceptable, and not a real path in the signup flow.

## Testing

- `pytest services/prompt_manager` — 6/6 passing.