### PR TITLE
feat(coach): add GPT-5.4 support and make it the default coach model

### DIFF
--- a/server/enums/ai.py
+++ b/server/enums/ai.py
@@ -43,6 +43,9 @@ class AIModel(models.TextChoices):
     CLAUDE_3_5_SONNET = "claude-3-5-sonnet-latest", "Claude 3.5 Sonnet"
     CLAUDE_3_5_HAIKU = "claude-3-5-haiku-latest", "Claude 3.5 Haiku"
 
+    # OpenAI GPT-5 model (reasoning-capable; structured outputs supported)
+    GPT_5_4 = "gpt-5.4", "GPT-5.4"
+
     # OpenAI GPT models
     GPT_4_1 = "gpt-4.1", "GPT-4.1"
     GPT_4_5_PREVIEW = "gpt-4.5-preview", "GPT-4.5 Preview"
@@ -69,6 +72,7 @@ class AIModel(models.TextChoices):
         ]
 
         openai_models = [
+            cls.GPT_5_4,
             cls.GPT_4_1,
             cls.GPT_4_5_PREVIEW,
             cls.O3_MINI,
@@ -100,6 +104,7 @@ class AIModel(models.TextChoices):
         except ValueError:
             # Try some common aliases
             name_map = {
+                "gpt-5.4": cls.GPT_5_4,
                 "claude-3.7-sonnet": cls.CLAUDE_3_7_SONNET,
                 "claude-3.5-sonnet": cls.CLAUDE_3_5_SONNET,
                 "claude-3.5-haiku": cls.CLAUDE_3_5_HAIKU,
@@ -173,11 +178,19 @@ class AIModel(models.TextChoices):
         """
         Get the AIModel from a string, or return the default model if not provided.
         This is useful for endpoints where the user may or may not specify a model.
-        Default is GPT_4O.
+        Default is the configured ``DEFAULT_AI_MODEL`` setting (env-driven),
+        falling back to GPT_4O when unset. This lets a single setting flip the
+        coach model per-environment without code changes.
         """
-        if not model_name:
-            return cls.GPT_4O
-        return cls.from_string(model_name)
+        if model_name:
+            return cls.from_string(model_name)
+
+        from django.conf import settings
+
+        configured = getattr(settings, "DEFAULT_AI_MODEL", None)
+        if configured:
+            return cls.from_string(configured)
+        return cls.GPT_4O
 
 
 # -----------------------------------------------------------------------------
@@ -187,6 +200,7 @@ class AIModel(models.TextChoices):
 # Set of model names that support structured outputs.
 # Used in: AIModel.supports_structured_outputs
 STRUCTURED_OUTPUT_MODELS: Set[str] = {
+    "gpt-5.4",
     "gpt-4.1",
     "gpt-4.5-preview",
     "o1",
@@ -200,6 +214,7 @@ STRUCTURED_OUTPUT_MODELS: Set[str] = {
 # Set of model names that require max_completion_tokens parameter.
 # Used in: AIModel.get_token_param_name
 COMPLETION_TOKEN_MODELS: Set[str] = {
+    "gpt-5",
     "gpt-4.1",
     "o1",
     "o1-mini",
@@ -213,6 +228,8 @@ COMPLETION_TOKEN_MODELS: Set[str] = {
 # Default token limits for each model.
 # Used in: AIModel.get_default_token_limit
 DEFAULT_TOKEN_LIMITS: Dict[str, int] = {
+    # GPT-5.4 supports up to 128k output tokens (1.05M context window).
+    "gpt-5.4": 128000,
     "gpt-4.1": 32768,
     "gpt-4.5-preview": 16384,
     "o3-mini": 100000,

--- a/server/services/ai/utils/openai/structured_completion.py
+++ b/server/services/ai/utils/openai/structured_completion.py
@@ -22,8 +22,9 @@ from enums.ai import AIModel
 
 log = logging.getLogger(__name__)
 
-# o-series model name fragments that do not accept 'temperature' or 'top_p'.
-_O_SERIES_TAGS = ("o1", "o3", "o4-mini")
+# Model name fragments for reasoning families that do not accept a custom
+# 'temperature' / 'top_p' (o-series and the GPT-5 line).
+_NO_TEMPERATURE_TAGS = ("o1", "o3", "o4-mini", "gpt-5")
 
 
 def structured_completion(
@@ -77,10 +78,15 @@ def structured_completion(
         token_param: max_tokens,
     }
 
-    # o-series models reject 'temperature'; skip it for those families.
-    is_o_series = any(tag in model_str for tag in _O_SERIES_TAGS)
-    if not is_o_series and temperature is not None:
+    # Reasoning families (o-series, GPT-5) reject 'temperature'; skip it.
+    is_reasoning = any(tag in model_str for tag in _NO_TEMPERATURE_TAGS)
+    if not is_reasoning and temperature is not None:
         params["temperature"] = temperature
+
+    # GPT-5 accepts a 'reasoning_effort' control. Default it low for
+    # latency-sensitive coach turns; a caller-supplied value wins.
+    if "gpt-5" in model_str and "reasoning_effort" not in kwargs:
+        params["reasoning_effort"] = "low"
 
     for key, value in kwargs.items():
         if key not in params:

--- a/server/settings/common.py
+++ b/server/settings/common.py
@@ -309,3 +309,13 @@ CELERY_WORKER_MAX_MEMORY_PER_CHILD = 400000  # recycle if RSS exceeds ~400 MB (K
 # COACHING_PHASE_VIDEOS_ENABLED is the feature flag — flip it to control
 # visibility without an env-var change. Flipping is a code change + deploy.
 COACHING_PHASE_VIDEOS_ENABLED = True
+
+#########################################
+# COACH AI MODEL
+#########################################
+# Default LLM used for the coach when a request doesn't specify one. Resolved
+# by AIModel.get_or_default() (request model_name wins, then this setting, then
+# a hardcoded gpt-4o fallback). Read from the environment so any environment can
+# override without a code change; the default makes gpt-5.4 the coach model
+# across all environments.
+DEFAULT_AI_MODEL = env("DEFAULT_AI_MODEL", default="gpt-5.4")


### PR DESCRIPTION
## What

Adds **GPT-5.4** support and makes it the default coach LLM in every environment. Previously the default model was only set in `settings/local.py` *and* the GPT-5 family wasn't registered at all on `main` — so this is the complete, self-contained enablement (without it, defaulting to gpt-5.4 would raise `ValueError: Unknown AI model`).

## How

- **`enums/ai.py`** — register `GPT_5_4` (`"gpt-5.4"`):
  - OpenAI provider, structured-output capable, uses `max_completion_tokens`.
  - **128k default token limit** (matches GPT-5.4's max output; 1.05M context window), up from the 32k used by older models.
  - `get_or_default()` now reads `settings.DEFAULT_AI_MODEL`, falling back to `GPT_4O` when unset.
- **`services/ai/utils/openai/structured_completion.py`** — GPT-5 API constraints:
  - Rejects `temperature`/`top_p` (like the o-series), so they're skipped.
  - Accepts `reasoning_effort`, defaulted to `low` for coach-turn latency (caller can override).
- **`settings/common.py`** — `DEFAULT_AI_MODEL = env("DEFAULT_AI_MODEL", default="gpt-5.4")`, so all environments default to gpt-5.4 and can override per-environment via env var.

Model resolution is otherwise unchanged: request `model_name` wins, then `DEFAULT_AI_MODEL`, then the `gpt-4o` fallback. The frontend doesn't send `model_name`, so the coach now runs on gpt-5.4 everywhere.

## Notes

- Only **gpt-5.4** is added (no 5.5 / mini / nano).
- No migration — `AIModel` is a `TextChoices` enum, not a DB-backed table.
- `settings/local.py` already sets `DEFAULT_AI_MODEL = "gpt-5.4"` locally; that override is now redundant with the base default but harmless.

## Testing

- Live under `settings.test`: `get_or_default() = gpt-5.4`, token limit `128000`, param `max_completion_tokens`, structured outputs `True`, provider `OPENAI`.
- `pytest services/ai apps/coach` — 142/142 passing.