### PR TITLE
feat(coach): remove the get-to-know intro video

### DIFF
--- a/server/apps/coach_states/constants/session_videos.py
+++ b/server/apps/coach_states/constants/session_videos.py
@@ -36,11 +36,8 @@ SESSION_VIDEOS: dict[str, SessionVideo] = {
         "name": "Welcome",
         "s3_key": "media/session-videos/01-welcome-session-intro.mov",
     },
-    # get_to_know_session
-    "get_to_know_session_intro": {
-        "name": "Get to Know You Intro",
-        "s3_key": "media/session-videos/02-get-to-know-session-intro.mov",
-    },
+    # get_to_know_session — outro only (no intro; the coach introduces the
+    # phase itself, so video 02 was removed)
     "get_to_know_session_outro": {
         "name": "Get to Know You Outro",
         "s3_key": "media/session-videos/03-get-to-know-session-outro.mov",

--- a/server/apps/coach_states/tests/test_session_videos.py
+++ b/server/apps/coach_states/tests/test_session_videos.py
@@ -54,9 +54,10 @@ class TestSessionVideosCoverage:
                 expected.add(meta["outro"])
         assert set(SESSION_VIDEOS.keys()) == expected
 
-    def test_total_video_count_is_twelve(self):
-        """Sanity check on the documented 12-video set."""
-        assert len(SESSION_VIDEOS) == 12
+    def test_total_video_count_is_eleven(self):
+        """Sanity check on the video set: 12 originals minus the removed
+        get-to-know intro (the coach introduces that phase itself)."""
+        assert len(SESSION_VIDEOS) == 11
 
 
 # ---------------------------------------------------------------------------

--- a/server/enums/coaching_phase.py
+++ b/server/enums/coaching_phase.py
@@ -73,7 +73,9 @@ SESSIONS: dict[str, SessionMeta] = {
     },
     "get_to_know_session": {
         "phases": [CoachingPhase.GET_TO_KNOW_YOU, CoachingPhase.IDENTITY_WARMUP],
-        "intro": "get_to_know_session_intro",
+        # No intro video: the coach introduces this phase itself. (The
+        # Introduction-phase transition is the lead-in to get-to-know.)
+        "intro": None,
         "outro": "get_to_know_session_outro",
     },
     "brainstorming_session": {

--- a/server/services/action_handler/tests/test_transition_phase_action.py
+++ b/server/services/action_handler/tests/test_transition_phase_action.py
@@ -248,27 +248,7 @@ class TransitionPhaseSessionVideoEnrichmentTests(TestCase):
             actions[1].params, {"session_key": "get_to_know_session"}
         )
 
-    # --- Intro emission --------------------------------------------------
-
-    @override_settings(COACHING_PHASE_VIDEOS_ENABLED=True)
-    def test_attaches_intro_when_leaving_session_has_no_outro_and_entering_has_intro(
-        self,
-    ):
-        """INTRODUCTION → GET_TO_KNOW_YOU: welcome has no outro; emit get_to_know intro."""
-        self._set_phase(CoachingPhase.INTRODUCTION)
-        params = TransitionPhaseParams(to_phase=CoachingPhase.GET_TO_KNOW_YOU)
-
-        result = transition_phase(self.coach_state, params, self.coach_message)
-
-        self.assertIsInstance(result, ComponentConfig)
-        self.assertEqual(result.component_type, ComponentType.SESSION_VIDEO.value)
-        self.assertEqual(result.video_key, "get_to_know_session_intro")
-
-        self.coach_message.refresh_from_db()
-        self.assertEqual(
-            self.coach_message.component_config["video_key"],
-            "get_to_know_session_intro",
-        )
+    # --- Outro emission --------------------------------------------------
 
     @override_settings(
         COACHING_PHASE_VIDEOS_ENABLED=True,
@@ -301,24 +281,6 @@ class TransitionPhaseSessionVideoEnrichmentTests(TestCase):
             "media/session-videos/03-get-to-know-session-outro.mov",
         )
 
-    @override_settings(COACHING_PHASE_VIDEOS_ENABLED=True)
-    def test_intro_button_carries_only_ack_with_intro_key(self):
-        """Intro's Continue button is [ACK(intro_key)] — no START_BREAK."""
-        self._set_phase(CoachingPhase.INTRODUCTION)
-        params = TransitionPhaseParams(to_phase=CoachingPhase.GET_TO_KNOW_YOU)
-
-        result = transition_phase(self.coach_state, params, self.coach_message)
-
-        self.assertIsNotNone(result)
-        actions = result.buttons[0].actions
-        self.assertEqual(len(actions), 1)
-        self.assertEqual(
-            actions[0].action, ActionType.ACKNOWLEDGE_SESSION_VIDEO.value
-        )
-        self.assertEqual(
-            actions[0].params, {"video_key": "get_to_know_session_intro"}
-        )
-
     # --- No-emit cases ---------------------------------------------------
 
     @override_settings(COACHING_PHASE_VIDEOS_ENABLED=True)
@@ -334,13 +296,13 @@ class TransitionPhaseSessionVideoEnrichmentTests(TestCase):
         self.assertIsNone(self.coach_message.component_config)
 
     @override_settings(COACHING_PHASE_VIDEOS_ENABLED=True)
-    def test_no_intro_when_entering_session_intro_already_in_shown_videos(self):
-        """If the entering session's intro is already acked, don't re-emit."""
-        self.coach_state.shown_videos = ["get_to_know_session_intro"]
+    def test_no_video_for_introduction_to_get_to_know(self):
+        """INTRODUCTION → GET_TO_KNOW_YOU: welcome has no outro and
+        get_to_know has no intro video, so nothing is attached. (The coach
+        introduces the get-to-know phase itself.)"""
         self._set_phase(CoachingPhase.INTRODUCTION)
-        self.coach_state.save()
-
         params = TransitionPhaseParams(to_phase=CoachingPhase.GET_TO_KNOW_YOU)
+
         result = transition_phase(self.coach_state, params, self.coach_message)
 
         self.assertIsNone(result)
@@ -413,12 +375,12 @@ class TransitionPhaseSessionVideoEnrichmentTests(TestCase):
         coach_message row carries the same component_config in DB so the
         history serializer (PR 11) renders it on subsequent turns.
         """
-        self._set_phase(CoachingPhase.INTRODUCTION)
+        self._set_phase(CoachingPhase.IDENTITY_WARMUP)
         coach_response = CoachChatResponse(
-            message="Let's move on to getting to know you.",
+            message="Beautiful work — let's bring these to life.",
             transition_phase=TransitionPhaseAction(
                 params=TransitionPhaseParams(
-                    to_phase=CoachingPhase.GET_TO_KNOW_YOU
+                    to_phase=CoachingPhase.IDENTITY_BRAINSTORMING
                 )
             ),
         )
@@ -428,20 +390,20 @@ class TransitionPhaseSessionVideoEnrichmentTests(TestCase):
         )
 
         self.assertEqual(
-            updated_state.current_phase, CoachingPhase.GET_TO_KNOW_YOU
+            updated_state.current_phase, CoachingPhase.IDENTITY_BRAINSTORMING
         )
         self.assertIsInstance(component_config, ComponentConfig)
         self.assertEqual(
             component_config.component_type, ComponentType.SESSION_VIDEO.value
         )
         self.assertEqual(
-            component_config.video_key, "get_to_know_session_intro"
+            component_config.video_key, "get_to_know_session_outro"
         )
 
         self.coach_message.refresh_from_db()
         self.assertEqual(
             self.coach_message.component_config["video_key"],
-            "get_to_know_session_intro",
+            "get_to_know_session_outro",
         )
         self.assertEqual(
             self.coach_message.component_config["component_type"],


### PR DESCRIPTION
## What

Removes the **Get-To-Know intro video** (02) from the coaching flow. The coach now introduces that phase itself (its own opener / the Introduction-phase transition), so a separate Leigh-Ann intro video there is redundant. The get-to-know **outro** (03) and the break are unchanged.

## How

- `enums/coaching_phase.py`: `get_to_know_session` `intro` → `None` in the `SESSIONS` map.
- `apps/coach_states/constants/session_videos.py`: drop the `get_to_know_session_intro` registry entry.
- No helper changes needed: `should_emit_intro` already returns `False` (before any registry lookup) when a session's intro is `None`, so `introduction → get_to_know_you` now attaches no video.

## Notes

- This was the only boundary where the leaving session had no outro **and** the entering session had an intro, so the intro-via-`transition_phase` path is no longer exercised by a real boundary (intro emission still happens after breaks via the `END_BREAK` handler, which is covered by its own tests).
- The `02-get-to-know-session-intro.mov` file is gitignored (source videos aren't committed); nothing to remove from the repo.
- Pairs with the coach-prompt updates that restore each phase's coach-side intro (separate, prompt-only, synced via the prompt-copy commands).

## Testing

- `pytest services/action_handler apps/coach apps/coach_states apps/test_scenario/tests enums` — 454 passed.
- Updated tests: the three `test_transition_phase_action` cases that assumed the get-to-know intro emitted (repointed the end-to-end propagation test to the warm-up→brainstorming **outro** boundary; converted the emission/idempotency cases to a "no video for introduction → get-to-know" assertion), and the registry count sanity test (12 → 11). The dynamic SESSIONS-vs-registry coverage tests pass unchanged.
- Pre-existing unrelated failure `test_adds_initial_message` (stale `INITIAL_MESSAGE` assertion) is present on a clean tree too — not from this change.