### PR TITLE
feat(coach): seed evals from a frozen scenario + salvage the duplicated-JSON glitch

### DIFF
--- a/docs/docs/testing/eval-harness/overview.md
+++ b/docs/docs/testing/eval-harness/overview.md
@@ -194,10 +194,10 @@ scenarios.
 
 - **Built:** the full loop (seed → drive → judge → report); persona files +
   loading; component-aware driving; phase-scoped prompt-version pinning; the
-  `build_eval_scenario` chain builder (dry-run by default, opt-in freeze).
-- **Planned:** seeding the eval directly from a frozen scenario (`--from-scenario`),
-  baseline-vs-candidate diffing with replay, rubrics derived from `Prompt.body` +
-  targeted checks, and a `run_coach_eval` MCP tool. See the
+  `build_eval_scenario` chain builder (dry-run by default, opt-in freeze); seeding
+  the eval directly from a frozen scenario (`--from-scenario`).
+- **Planned:** baseline-vs-candidate diffing with replay, rubrics derived from
+  `Prompt.body` + targeted checks, and a `run_coach_eval` MCP tool. See the
   [Roadmap](/docs/testing/eval-harness/roadmap).
 
 ## Related Documentation

--- a/docs/docs/testing/eval-harness/roadmap.md
+++ b/docs/docs/testing/eval-harness/roadmap.md
@@ -32,12 +32,14 @@ The core loop and the scenario-building tooling are in place.
 - **Observability** — per-turn coach-state snapshots (mirroring the admin Coach
   State viewer) and the coach's action log, surfaced inline and in the report.
   Quality and progression are reported as separate outcomes (not AND-ed).
+- **Seed evals from a frozen scenario** — `--from-scenario "<name>"` hydrates a
+  built starting state (real prior history) and picks the eval up from that
+  scenario's phase instead of fresh-seeding. Prior history feeds the user-bot for
+  continuity and the judge as context (not scored); only new actions are reported.
+  See [Running Evals → Seeding from a frozen scenario](/docs/testing/eval-harness/running-evals#seeding-from-a-frozen-scenario).
 
 ## Planned
 
-- **Seed evals from a frozen scenario** — `--from-scenario "<name>"` on the eval so
-  it picks a phase up from a built starting state (real prior history) instead of
-  fresh-seeding. This is the next step.
 - **Rubric derived from `Prompt.body`** ("did the Coach do what this prompt
   instructs?") plus a per-run list of **targeted checks** — the
   "phase X does Y and I hate it" cases.

--- a/docs/docs/testing/eval-harness/running-evals.md
+++ b/docs/docs/testing/eval-harness/running-evals.md
@@ -73,12 +73,42 @@ cd server \
 | `--max-turns N` | `20` | Cap on steps before the run stops. The run also stops early when the phase transitions. |
 | `--coach-model NAME` | configured `DEFAULT_AI_MODEL` (e.g. `gpt-5.4`) | Override the **coach** model under test. Any id from `server/enums/ai.py`. |
 | `--prompt-version N` | latest active | Pin the phase-under-test prompt to a specific version. This is how you run before/after — see [Prompt Version Pinning](/docs/testing/eval-harness/prompt-versioning). |
+| `--from-scenario NAME` | off (cold-seed) | Hydrate a frozen [TestScenario](/docs/testing/eval-harness/scenario-chain) by exact name (real prior history) and pick the eval up from that scenario's phase, instead of cold-seeding a fresh user at `get_to_know_you`. |
 | `--keep` | off | Keep the throwaway test user instead of deleting it. |
 
-> The spike currently fresh-seeds `get_to_know_you`. Seeding an eval directly from
-> a frozen scenario (`--from-scenario`) is planned — see the
-> [Roadmap](/docs/testing/eval-harness/roadmap). To create those frozen scenarios
-> today, use the [scenario builder](/docs/testing/eval-harness/scenario-chain).
+## Seeding from a frozen scenario
+
+By default the spike cold-seeds a fresh user at `get_to_know_you` with no history.
+`--from-scenario` instead instantiates a named [TestScenario](/docs/testing/eval-harness/scenario-chain)
+— full hydration (chat history, identities, coach state, notes, actions, breaks)
+— so the eval resumes from **real prior history**, exactly like opening that
+scenario in the admin Test Scenario tools.
+
+```bash
+docker exec dev-coach-local-backend-1 \
+  python manage.py run_coach_eval_spike \
+    --from-scenario "[Auto] Casey @ get_to_know_you"
+```
+
+What changes when you seed from a scenario:
+
+- **Start phase is the scenario's phase** — read from the hydrated coach state,
+  not hard-coded. The version pin (`--prompt-version`) applies to that phase.
+- **Prior history feeds the user-bot** so it continues the conversation naturally,
+  and is given to the judge as **context only** — prior coach turns are *not*
+  scored (they predate the phase under test).
+- **Only new actions are reported** — actions baked into the scenario are excluded
+  from the action log so you see just what the Coach did during this run.
+- The throwaway user (a fresh copy of the scenario's user) is still deleted on
+  exit unless `--keep` is passed; your saved scenario is never mutated.
+
+Build these scenarios with the [scenario builder](/docs/testing/eval-harness/scenario-chain).
+If the name doesn't exist, the command prints the available scenario names.
+
+> **Rubric caveat:** the spike's rubric is `get_to_know_you`-specific. Seeding from
+> a different-phase scenario still runs (and progression is meaningful), but the
+> quality score won't be phase-matched yet — the command prints a warning. Phase-derived
+> rubrics are the [next roadmap item](/docs/testing/eval-harness/roadmap).
 
 ## Before / after comparison
 

--- a/server/apps/coach/eval/harness.py
+++ b/server/apps/coach/eval/harness.py
@@ -187,6 +187,26 @@ def coach_state_snapshot(coach_state) -> dict:
     return snap
 
 
+def chat_history_transcript(user) -> Transcript:
+    """Build a (role, text) transcript from a user's stored chat history.
+
+    Maps coach/user ChatMessage rows in chronological order; skips blank-text
+    cards (e.g. the welcome video card, whose text is ""). Used to give the
+    user-bot conversational continuity — and the judge prior context — when an
+    eval is seeded from a frozen scenario's real history rather than a cold start.
+    """
+    rows = ChatMessage.objects.filter(
+        user=user, role__in=(MessageRole.USER, MessageRole.COACH)
+    ).order_by("timestamp")
+    out: Transcript = []
+    for m in rows:
+        text = (m.content or "").strip()
+        if not text:
+            continue
+        out.append(("coach" if m.role == MessageRole.COACH else "user", text))
+    return out
+
+
 def collect_new_actions(user, seen_ids: set) -> list:
     """Return the Action rows for this user not already in seen_ids (i.e. the
     actions the coach took on the latest turn), recording their ids into seen_ids.

--- a/server/apps/coach/management/commands/diagnose_coach_json.py
+++ b/server/apps/coach/management/commands/diagnose_coach_json.py
@@ -18,9 +18,15 @@ This command replicates the exact coach generation call:
 Run it many times to catch the intermittent failure and see precisely what the
 model appended.
 
+The minimal default seed (a 2-message history) has historically failed to
+reproduce the glitch. Pass --from-scenario "<name>" to instead build the prompt
+from a frozen TestScenario's REAL history (the condition under which the glitch
+has actually been observed); the --message is appended as the latest user turn.
+
 Usage:
     python manage.py diagnose_coach_json --iterations 30
     python manage.py diagnose_coach_json --phase get_to_know_you --message "yeah, sounds good — i'm Casey."
+    python manage.py diagnose_coach_json --from-scenario "[Auto] Casey @ get_to_know_you" --iterations 30
 """
 
 import json
@@ -33,6 +39,10 @@ from pydantic import ValidationError
 from apps.chat_messages.utils import add_chat_message
 from apps.coach.utils import build_coach_prompt
 from apps.coach_states.models import CoachState
+from apps.test_scenario.functions.admin.instantiate_test_scenario import (
+    instantiate_test_scenario,
+)
+from apps.test_scenario.models import TestScenario
 from enums.ai import AIModel
 from enums.message_role import MessageRole
 from services.ai.ai_service_factory import AIServiceFactory
@@ -54,6 +64,18 @@ class Command(BaseCommand):
             type=str,
             default="Sounds good! I'm Casey — go ahead and ask me whatever you'd like.",
             help="The latest user message to seed into the prompt's recent history.",
+        )
+        parser.add_argument(
+            "--from-scenario",
+            type=str,
+            default=None,
+            metavar="NAME",
+            help=(
+                "Build the prompt from a frozen TestScenario's real history "
+                "(by exact name) instead of the minimal default seed. The "
+                "--message is appended as the latest user turn. This is the "
+                "condition under which the glitch has actually reproduced."
+            ),
         )
         parser.add_argument(
             "--dump-all",
@@ -81,10 +103,46 @@ class Command(BaseCommand):
         add_chat_message(user, message, MessageRole.USER)
         return user
 
+    def _seed_from_scenario(self, name: str, message: str) -> tuple:
+        """Hydrate a frozen TestScenario and append `message` as the latest user
+        turn, so build_coach_prompt produces the same prompt the eval hit when the
+        glitch fired. Returns (user, cleanup_email)."""
+        scenario = TestScenario.objects.get(name=name)
+        result = instantiate_test_scenario(
+            scenario,
+            create_user=True,
+            create_chat_messages=True,
+            create_identities=True,
+            create_coach_state=True,
+            create_user_notes=True,
+            create_actions=True,
+            create_breaks=True,
+        )
+        user = result["user"]
+        add_chat_message(user, message, MessageRole.USER)
+        return user, result["email"]
+
     def handle(self, *args, **options):
         iterations = options["iterations"]
         model = AIModel.get_or_default(options["coach_model"])
-        user = self._seed(options["phase"], options["message"])
+        scenario_name = options["from_scenario"]
+        if scenario_name:
+            try:
+                user, cleanup_email = self._seed_from_scenario(
+                    scenario_name, options["message"]
+                )
+            except TestScenario.DoesNotExist:
+                names = list(
+                    TestScenario.objects.order_by("name").values_list("name", flat=True)
+                )
+                self.stderr.write(self.style.ERROR(
+                    f"No TestScenario named '{scenario_name}'. Available:\n  "
+                    + "\n  ".join(names or ["(none)"])
+                ))
+                return
+        else:
+            user = self._seed(options["phase"], options["message"])
+            cleanup_email = DIAG_EMAIL
 
         coach_prompt, response_format = build_coach_prompt(user, model)
         rf_param = type_to_response_format_param(response_format)
@@ -101,8 +159,9 @@ class Command(BaseCommand):
         if "gpt-5" in model.value:
             params["reasoning_effort"] = "low"
 
+        seed_label = f"scenario '{scenario_name}'" if scenario_name else f"phase {options['phase']}"
         self.stdout.write(self.style.HTTP_INFO(
-            f"Model: {model.value} | phase: {options['phase']} | "
+            f"Model: {model.value} | seed: {seed_label} | "
             f"iterations: {iterations} | response_format: {response_format.__name__}"
         ))
 
@@ -149,4 +208,4 @@ class Command(BaseCommand):
                 f"malformed: {malformed}/{iterations}  |  finish_reasons: {finish_reasons}"
             )
         finally:
-            User.objects.filter(email=DIAG_EMAIL).delete()
+            User.objects.filter(email=cleanup_email).delete()

--- a/server/apps/coach/management/commands/run_coach_eval_spike.py
+++ b/server/apps/coach/management/commands/run_coach_eval_spike.py
@@ -16,25 +16,33 @@ the loop is component-aware — it clicks through any video/break gates by
 replaying their button actions. Shared pieces live in apps/coach/eval/harness.py.
 
 Runs against the LIVE local database so it exercises whatever prompts are
-currently active (i.e. the ones you just edited). It creates a throwaway
-`@testscenario.com` user and deletes it on exit unless --keep is passed.
+currently active (i.e. the ones you just edited).
+
+By default it creates a throwaway `@testscenario.com` user seeded cold at the
+get_to_know_you phase. Pass --from-scenario "<name>" to instead hydrate a frozen
+TestScenario (real prior history, built via build_eval_scenario) and pick the
+eval up from that scenario's phase. Either way the throwaway user is deleted on
+exit unless --keep is passed.
 
 Usage:
     python manage.py run_coach_eval_spike
     python manage.py run_coach_eval_spike --persona casey --max-turns 10 --keep
     python manage.py run_coach_eval_spike --coach-model gpt-4o --prompt-version 10
+    python manage.py run_coach_eval_spike --from-scenario "[Auto] Casey @ start of get_to_know_you"
 """
 
 import json
-from typing import List
+from typing import List, Optional, Tuple
 
 from django.core.management.base import BaseCommand
 from pydantic import BaseModel, Field
 
+from apps.actions.models import Action
 from apps.coach.eval.harness import (
     DEFAULT_JUDGE_MODEL,
     DEFAULT_USER_BOT_MODEL,
     Transcript,
+    chat_history_transcript,
     coach_state_snapshot,
     collect_new_actions,
     load_persona,
@@ -45,6 +53,10 @@ from apps.coach.eval.harness import (
 )
 from apps.coach.functions.public.process_message import process_message
 from apps.coach_states.models import CoachState
+from apps.test_scenario.functions.admin.instantiate_test_scenario import (
+    instantiate_test_scenario,
+)
+from apps.test_scenario.models import TestScenario
 from django.contrib.auth import get_user_model
 from enums.ai import AIModel
 from enums.coaching_phase import CoachingPhase
@@ -124,6 +136,18 @@ class Command(BaseCommand):
             ),
         )
         parser.add_argument(
+            "--from-scenario",
+            type=str,
+            default=None,
+            metavar="NAME",
+            help=(
+                "Seed from a frozen TestScenario (by exact name) — real prior "
+                "history — and pick the eval up from that scenario's phase, "
+                "instead of cold-seeding a fresh user at get_to_know_you. Build "
+                "scenarios with build_eval_scenario."
+            ),
+        )
+        parser.add_argument(
             "--keep",
             action="store_true",
             help="Keep the throwaway test user instead of deleting it on exit.",
@@ -138,11 +162,48 @@ class Command(BaseCommand):
         coach_state.save(update_fields=["current_phase"])
         return user
 
+    def _seed_from_scenario(self, name: str) -> Tuple[User, str, str]:
+        """Hydrate a frozen TestScenario and return (user, email, start_phase).
+
+        Full hydration (chat history, identities, coach state, notes, actions,
+        breaks) so the eval resumes from real prior history. The start phase is
+        whatever the scenario's coach state was frozen at. Raises
+        TestScenario.DoesNotExist if no scenario has that exact name.
+        """
+        scenario = TestScenario.objects.get(name=name)
+        result = instantiate_test_scenario(
+            scenario,
+            create_user=True,
+            create_chat_messages=True,
+            create_identities=True,
+            create_coach_state=True,
+            create_user_notes=True,
+            create_actions=True,
+            create_breaks=True,
+        )
+        user = result["user"]
+        start_phase = CoachState.objects.get(user=user).current_phase
+        return user, result["email"], start_phase
+
     # --- judge ----------------------------------------------------------------
-    def _judge(self, client, transcript: Transcript) -> JudgeVerdict:
+    def _judge(
+        self,
+        client,
+        transcript: Transcript,
+        context: Optional[Transcript] = None,
+    ) -> JudgeVerdict:
         convo = render_transcript(transcript, you_label="CLIENT")
+        context_block = ""
+        if context:
+            ctx = render_transcript(context, you_label="CLIENT")
+            context_block = (
+                "PRIOR CONVERSATION (context only — do NOT score these messages; "
+                "they predate the phase under evaluation. Use them only to know "
+                f"what the client already shared):\n\n{ctx}\n\n"
+            )
         system = (
-            f"{RUBRIC}\n\nHere is the full transcript:\n\n{convo}\n\n"
+            f"{RUBRIC}\n\n{context_block}"
+            f"Transcript to evaluate:\n\n{convo}\n\n"
             "Return your structured verdict."
         )
         completion = structured_completion(
@@ -160,23 +221,63 @@ class Command(BaseCommand):
         coach_model = AIModel.get_or_default(options["coach_model"])
         persona = load_persona(options["persona"])
         harness_client = AIServiceFactory.create(DEFAULT_USER_BOT_MODEL).client
+        scenario_name = options["from_scenario"]
 
-        # Phase-scoped version pin: only applies while the user is in START_PHASE.
+        # Seed cold (fresh user at get_to_know_you) or from a frozen scenario
+        # (real prior history; phase = whatever it was frozen at). `prior` is the
+        # scenario's chat history — given to the user-bot for continuity and to
+        # the judge as context, but NOT itself scored.
+        prior: Transcript = []
+        if scenario_name:
+            try:
+                user, cleanup_email, start_phase = self._seed_from_scenario(scenario_name)
+            except TestScenario.DoesNotExist:
+                names = list(
+                    TestScenario.objects.order_by("name").values_list("name", flat=True)
+                )
+                self.stderr.write(self.style.ERROR(
+                    f"No TestScenario named '{scenario_name}'. Available:\n  "
+                    + "\n  ".join(names or ["(none)"])
+                ))
+                return
+            prior = chat_history_transcript(user)
+            scenario_label = scenario_name
+        else:
+            user = self._seed_user()
+            cleanup_email = SPIKE_EMAIL
+            start_phase = START_PHASE.value
+            scenario_label = "get_to_know_you_spike"
+
+        # The rubric is hard-coded for get_to_know_you. Seeding from a different
+        # phase still runs, but warn that quality scores aren't phase-matched yet
+        # (phase-derived rubrics are the next roadmap item).
+        if start_phase != START_PHASE.value:
+            self.stdout.write(self.style.WARNING(
+                f"NOTE: rubric is get_to_know_you-specific, but this scenario "
+                f"starts at '{start_phase}'. Quality scores may not be meaningful; "
+                f"progression still is."
+            ))
+
+        # Phase-scoped version pin: only applies while the user is in start_phase.
         prompt_version = options["prompt_version"]
         prompt_versions = (
-            {START_PHASE.value: prompt_version} if prompt_version is not None else None
+            {start_phase: prompt_version} if prompt_version is not None else None
         )
         version_label = prompt_version if prompt_version is not None else "latest"
 
         self.stdout.write(self.style.HTTP_INFO(
             f"Persona: {persona.name} | coach: {coach_model.value} "
-            f"| {START_PHASE.value} prompt: v{version_label} "
+            f"| start: {start_phase} (v{version_label}) "
+            f"| seed: {scenario_label} "
             f"| user-bot: {DEFAULT_USER_BOT_MODEL.value} | judge: {DEFAULT_JUDGE_MODEL.value}"
         ))
 
-        user = self._seed_user()
         transcript: Transcript = []
-        seen_action_ids: set = set()
+        # Prior-history actions exist on the hydrated user; record their ids so
+        # collect_new_actions only reports what the coach does DURING this eval.
+        seen_action_ids: set = set(
+            Action.objects.filter(user=user).values_list("id", flat=True)
+        )
         all_actions: list = []
         transition_reached = False
         run_error = None
@@ -196,7 +297,7 @@ class Command(BaseCommand):
                     )
                 else:
                     user_msg = user_bot_reply(
-                        harness_client, DEFAULT_USER_BOT_MODEL, persona, transcript
+                        harness_client, DEFAULT_USER_BOT_MODEL, persona, prior + transcript
                     )
                     transcript.append(("user", user_msg))
                     self.stdout.write(self.style.WARNING(f"\nCLIENT: {user_msg}"))
@@ -223,7 +324,7 @@ class Command(BaseCommand):
                         "  ↳ actions: " + ", ".join(a["action"] for a in acts)
                     ))
 
-                if coach_state.current_phase != START_PHASE.value:
+                if coach_state.current_phase != start_phase:
                     transition_reached = coach_state.current_phase in GOAL_PHASES
                     self.stdout.write(self.style.HTTP_INFO(
                         f"\n[phase transitioned to: {coach_state.current_phase}]"
@@ -234,7 +335,7 @@ class Command(BaseCommand):
             final_phase = final_coach_state["current_phase"]
 
             base_report = {
-                "scenario": "get_to_know_you_spike",
+                "scenario": scenario_label,
                 "persona": persona.persona_id,
                 "coach_model": coach_model.value,
                 "prompt_version": version_label,
@@ -263,7 +364,7 @@ class Command(BaseCommand):
                 ))
                 return
 
-            verdict = self._judge(harness_client, transcript)
+            verdict = self._judge(harness_client, transcript, context=prior)
 
             # Quality (LLM rubric) and progression (phase movement) are reported
             # SEPARATELY and never AND-ed together. A high-quality conversation
@@ -279,9 +380,9 @@ class Command(BaseCommand):
                     "reasoning": verdict.reasoning,
                 },
                 "progression": {
-                    "start_phase": START_PHASE.value,
+                    "start_phase": start_phase,
                     "final_phase": final_phase,
-                    "transitioned": final_phase != START_PHASE.value,
+                    "transitioned": final_phase != start_phase,
                     "reached_goal_phase": transition_reached,
                 },
                 "actions": all_actions,
@@ -295,14 +396,14 @@ class Command(BaseCommand):
                 f"QUALITY:     {'PASS' if verdict.passed else 'FAIL'}  "
                 f"(judge score {verdict.score}/5)"
             ))
-            if final_phase != START_PHASE.value:
-                prog = f"{START_PHASE.value} -> {final_phase}"
+            if final_phase != start_phase:
+                prog = f"{start_phase} -> {final_phase}"
             else:
                 prog = f"did not transition (still {final_phase})"
             self.stdout.write(self.style.HTTP_INFO(f"PROGRESSION: {prog}"))
         finally:
             if not options["keep"]:
-                User.objects.filter(email=SPIKE_EMAIL).delete()
+                User.objects.filter(email=cleanup_email).delete()
                 self.stdout.write("\n(cleaned up throwaway user)")
             else:
-                self.stdout.write(f"\n(kept throwaway user: {SPIKE_EMAIL})")
+                self.stdout.write(f"\n(kept throwaway user: {cleanup_email})")

--- a/server/services/ai/tests/utils/openai/test_structured_completion.py
+++ b/server/services/ai/tests/utils/openai/test_structured_completion.py
@@ -2,10 +2,11 @@
 Tests for services/ai/utils/openai/structured_completion.py
 """
 
+import json
 from unittest.mock import MagicMock
 
 from django.test import SimpleTestCase
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from enums.ai import AIModel
 from services.ai.utils.openai.structured_completion import structured_completion
@@ -16,6 +17,22 @@ def _mock_completion(parsed_obj=None):
     completion = MagicMock()
     completion.choices[0].message.parsed = parsed_obj or MagicMock()
     return completion
+
+
+class _Probe(BaseModel):
+    """Tiny schema standing in for a structured response_format."""
+
+    message: str
+
+
+def _validation_error_from_json(raw: str) -> ValidationError:
+    """Produce the SAME ValidationError that .parse() raises on bad JSON, so its
+    errors()[*]['input'] carries the full raw string the salvage path recovers."""
+    try:
+        _Probe.model_validate_json(raw)
+    except ValidationError as e:
+        return e
+    raise AssertionError("expected the JSON to fail validation")
 
 
 class TestStructuredCompletion(SimpleTestCase):
@@ -176,3 +193,50 @@ class TestStructuredCompletion(SimpleTestCase):
         )
         call_kwargs = client.beta.chat.completions.parse.call_args[1]
         self.assertEqual(call_kwargs["seed"], 42)
+
+    def test_salvages_duplicated_json_object(self):
+        """The duplicated-JSON glitch (a valid object emitted twice) is salvaged:
+        the first object is decoded and re-validated, no retry, no raise."""
+        obj = {"message": "Where did you grow up?"}
+        duplicated = json.dumps(obj) + "\n" + json.dumps(obj)
+        client = MagicMock()
+        client.beta.chat.completions.parse.side_effect = _validation_error_from_json(
+            duplicated
+        )
+        result = structured_completion(
+            client=client,
+            messages=[],
+            model=AIModel.GPT_4O,
+            response_format=_Probe,
+        )
+        self.assertEqual(client.beta.chat.completions.parse.call_count, 1)
+        self.assertEqual(result.choices[0].message.parsed, _Probe(**obj))
+
+    def test_salvages_single_object_with_trailing_garbage(self):
+        """A valid first object followed by non-JSON trailing text is salvaged."""
+        client = MagicMock()
+        client.beta.chat.completions.parse.side_effect = _validation_error_from_json(
+            '{"message":"hi"}\nthanks!'
+        )
+        result = structured_completion(
+            client=client,
+            messages=[],
+            model=AIModel.GPT_4O,
+            response_format=_Probe,
+        )
+        self.assertEqual(result.choices[0].message.parsed.message, "hi")
+
+    def test_reraises_when_first_object_not_schema_valid(self):
+        """If the first JSON object doesn't satisfy the schema, it's genuinely
+        malformed — re-raise rather than salvage."""
+        client = MagicMock()
+        client.beta.chat.completions.parse.side_effect = _validation_error_from_json(
+            '{"wrong_field":1}\n{"wrong_field":1}'
+        )
+        with self.assertRaises(ValidationError):
+            structured_completion(
+                client=client,
+                messages=[],
+                model=AIModel.GPT_4O,
+                response_format=_Probe,
+            )

--- a/server/services/ai/utils/openai/structured_completion.py
+++ b/server/services/ai/utils/openai/structured_completion.py
@@ -12,7 +12,9 @@ Retry behaviour:
     family misclassification.
 """
 
+import json
 import logging
+from types import SimpleNamespace
 from typing import List, Optional, Type
 
 from openai.types.chat import ChatCompletionMessageParam, ParsedChatCompletion
@@ -27,30 +29,93 @@ log = logging.getLogger(__name__)
 _NO_TEMPERATURE_TAGS = ("o1", "o3", "o4-mini", "gpt-5")
 
 
-def _log_malformed_structured_output(exc: Exception, model_str: str) -> None:
-    """Capture the FULL raw LLM output when structured-output parsing fails.
+def _recover_raw_content(exc: ValidationError) -> Optional[str]:
+    """Pull the FULL raw model output out of a parse ValidationError.
 
-    The model very occasionally returns content that fails schema validation
-    (e.g. the intermittent 'trailing characters' malformed-JSON glitch). When
-    that happens `.parse()` raises a pydantic ``ValidationError`` and the raw
-    model output is otherwise lost — the exception's string repr truncates it.
-
-    The complete content is still available in ``ValidationError.errors()[*]
-    ['input']`` (the repr truncates; the structured errors retain the whole
-    string), so we recover and log it at ERROR with a stable, greppable marker
-    (``MALFORMED_STRUCTURED_OUTPUT``). This is intentionally capture-only — it
-    does not retry or recover — so the next occurrence is fully diagnosable.
+    `.parse()` raises before returning, so the raw content is otherwise lost —
+    but the structured errors retain the whole string (the exception's repr
+    truncates it) under ``errors()[*]['input']``. Returns it, or None.
     """
-    if not isinstance(exc, ValidationError):
-        return
-
-    raw = None
     try:
         for err in exc.errors():
             candidate = err.get("input")
             if isinstance(candidate, str):
-                raw = candidate
-                break
+                return candidate
+    except Exception:  # never let recovery mask the real error
+        return None
+    return None
+
+
+def _salvage_structured_output(
+    exc: Exception, response_format: Type[BaseModel], model_str: str
+):
+    """Recover from the duplicated-JSON glitch, returning a completion-shaped
+    object or None if unrecoverable.
+
+    Some models (observed intermittently on gpt-5.4, ~13% of action-bearing
+    turns) emit the SAME valid JSON object TWICE, newline-separated:
+
+        {"message":"...","update_asked_questions":{...}}
+        {"message":"...","update_asked_questions":{...}}
+
+    `.parse()` then fails with "trailing characters at line 2 column 1" and
+    discards the result, even though the FIRST object is a complete, schema-valid
+    answer (``finish_reason=stop`` — not a truncation). This is a model output
+    quirk, not a real failure, so we decode just the first JSON value and
+    re-validate it against the response_format. The returned shim only needs to
+    satisfy ``completion.choices[0].message.parsed`` — the single field every
+    caller reads.
+    """
+    if not isinstance(exc, ValidationError):
+        return None
+    raw = _recover_raw_content(exc)
+    if not raw:
+        return None
+    try:
+        obj, end = json.JSONDecoder().raw_decode(raw.strip())
+    except (json.JSONDecodeError, ValueError):
+        return None
+    try:
+        parsed = response_format.model_validate(obj)
+    except ValidationError:
+        return None  # first object isn't schema-valid — genuinely malformed
+
+    trailing = raw.strip()[end:].strip()
+    is_duplicate = False
+    if trailing:
+        try:
+            dup, _ = json.JSONDecoder().raw_decode(trailing)
+            is_duplicate = dup == obj
+        except (json.JSONDecodeError, ValueError):
+            is_duplicate = False
+
+    log.warning(
+        "RECOVERED_STRUCTURED_OUTPUT model=%s salvaged the first JSON object "
+        "from a malformed structured response (duplicate=%s, trailing_len=%s). "
+        "Output quirk, not a coaching failure.",
+        model_str,
+        is_duplicate,
+        len(trailing),
+    )
+    message = SimpleNamespace(parsed=parsed, content=raw, refusal=None)
+    choice = SimpleNamespace(message=message, finish_reason="stop", index=0)
+    return SimpleNamespace(choices=[choice])
+
+
+def _log_malformed_structured_output(exc: Exception, model_str: str) -> None:
+    """Capture the FULL raw LLM output when structured-output parsing fails AND
+    could not be salvaged.
+
+    The complete content is recovered from the ValidationError (see
+    ``_recover_raw_content``) and logged at ERROR with a stable, greppable marker
+    (``MALFORMED_STRUCTURED_OUTPUT``) so a genuinely unrecoverable occurrence is
+    fully diagnosable.
+    """
+    if not isinstance(exc, ValidationError):
+        return
+
+    raw = _recover_raw_content(exc)
+    try:
         first_msg = exc.errors()[0].get("msg") if exc.errors() else str(exc)
     except Exception:  # never let diagnostic logging mask the real error
         first_msg = str(exc)
@@ -144,10 +209,20 @@ def structured_completion(
             try:
                 return client.beta.chat.completions.parse(**params)
             except Exception as retry_exc:
+                salvaged = _salvage_structured_output(
+                    retry_exc, response_format, model_str
+                )
+                if salvaged is not None:
+                    return salvaged
                 _log_malformed_structured_output(retry_exc, model_str)
                 raise
-        # Capture the full raw LLM output on schema-validation failures (the
-        # intermittent malformed-JSON glitch) before re-raising, so we can
-        # diagnose it the next time it happens.
+        # The duplicated-JSON glitch: the model emitted a valid object twice, so
+        # .parse() raised on the trailing copy. Salvage the first (correct) one
+        # rather than failing the turn.
+        salvaged = _salvage_structured_output(e, response_format, model_str)
+        if salvaged is not None:
+            return salvaged
+        # Otherwise capture the full raw output before re-raising so a genuinely
+        # malformed response is diagnosable next time.
         _log_malformed_structured_output(e, model_str)
         raise


### PR DESCRIPTION
Builds on the eval-harness spike (#129). Two related changes:

## 1. `--from-scenario` for the coach eval (roadmap item #1)

`run_coach_eval_spike --from-scenario "<name>"` hydrates a frozen `TestScenario` (full: chat history, identities, coach state, notes, actions, breaks) and picks the eval up from that scenario's phase, instead of cold-seeding a fresh user at `get_to_know_you` — so evals run from **real prior history**.

- Start phase is derived from the hydrated coach state and threaded through version-pinning, transition detection, and the report.
- Prior history feeds the user-bot (continuity) and the judge as **context only** — prior coach turns aren't scored.
- Only actions taken **during** the eval are reported (pre-seed the seen-id set from the hydrated user).
- Unknown name lists available scenarios; the throwaway copy is deleted on exit; the saved scenario is never mutated.
- New shared `harness.chat_history_transcript` helper; docs moved from Planned → Built.

## 2. Salvage the duplicated-JSON structured-output glitch

Using #1 surfaced the intermittent malformed-JSON failure reliably and let us root-cause it: **gpt-5.4 occasionally emits the same valid JSON object twice**, newline-separated, so `.parse()` raises `trailing characters` and discards an otherwise correct, schema-valid response (`finish_reason=stop`, ~13% of action-bearing turns, both copies identical). It's a model output quirk, not a coaching/schema failure.

`structured_completion` now **salvages the first JSON object** (decode + re-validate against the response_format, return transparently). Safeguards:
- Salvage only succeeds when the first object is schema-valid; genuinely malformed output still logs `MALFORMED_STRUCTURED_OUTPUT` and re-raises.
- Recoveries log a distinct `RECOVERED_STRUCTURED_OUTPUT` marker so frequency stays visible.
- Existing raw-output capture logging is preserved (refactored, not removed).

Also adds `--from-scenario` to `diagnose_coach_json` to reproduce the glitch against a frozen scenario's real prompt (the minimal default seed never triggered it).

## Testing

- New unit tests for all three salvage paths (recover-duplicate, recover-trailing-garbage, re-raise-genuine).
- `services.ai` structured_completion + openai_service tests pass (38); `apps.coach` + `apps.test_scenario` pass (249).
- End-to-end: eval from `[Auto] Casey @ get_to_know_you` with the real gpt-5.4 coach hit the glitch live, salvaged it transparently, finished **QUALITY PASS 5/5**, **PROGRESSION get_to_know_you → identity_warm_up**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)