### PR TITLE
feat(coach): derive eval rubric from the phase prompt + targeted checks

### DIFF
--- a/docs/docs/testing/eval-harness/overview.md
+++ b/docs/docs/testing/eval-harness/overview.md
@@ -104,13 +104,19 @@ them.
    and immune to LLM flakiness. Examples: did `current_phase` advance to an
    expected phase? Was a disallowed action emitted? These catch most regressions.
 2. **LLM-as-judge rubric** — for qualitative behavior the deterministic layer
-   cannot see: warmth, asking one thing at a time, building on what the client
-   said, not hallucinating facts, moving the conversation forward.
+   cannot see. The rubric is **derived live from the phase's own coach
+   `Prompt.body`** (the same version the coach ran): the judge is asked "did the
+   coach follow these instructions?" and derives the criteria from the body
+   itself, so it tracks the prompt automatically and needs no maintenance. On top
+   of that, hand-authored **targeted checks** (per-phase files + `--check` flags)
+   assert specific "must do X / must never do Y" behaviors. See
+   [Running Evals → Rubric & targeted checks](/docs/testing/eval-harness/running-evals#rubric--targeted-checks).
 
-These two are reported as **separate, independent outcomes** — `quality` (the
-judge's verdict) and `progression` (phase movement) — never AND-ed into a single
-pass/fail. A 5/5 conversation that simply didn't transition within the turn budget
-is a *non-transition*, not a failure; conflating the two hides the real signal.
+These are reported as **separate, independent outcomes** — `quality` (the judge's
+verdict against the derived rubric), `targeted_checks` (explicit assertions), and
+`progression` (phase movement) — never AND-ed into a single pass/fail. A 5/5
+conversation that simply didn't transition within the turn budget is a
+*non-transition*, not a failure; conflating them hides the real signal.
 
 Because LLM output is non-deterministic, a single run is one sample. Rigorous
 suites run each scenario several times and report a pass *rate*.
@@ -195,10 +201,10 @@ scenarios.
 - **Built:** the full loop (seed → drive → judge → report); persona files +
   loading; component-aware driving; phase-scoped prompt-version pinning; the
   `build_eval_scenario` chain builder (dry-run by default, opt-in freeze); seeding
-  the eval directly from a frozen scenario (`--from-scenario`).
-- **Planned:** baseline-vs-candidate diffing with replay, rubrics derived from
-  `Prompt.body` + targeted checks, and a `run_coach_eval` MCP tool. See the
-  [Roadmap](/docs/testing/eval-harness/roadmap).
+  the eval directly from a frozen scenario (`--from-scenario`); rubrics derived
+  live from the phase `Prompt.body` + per-phase targeted checks.
+- **Planned:** baseline-vs-candidate diffing with replay and a `run_coach_eval`
+  MCP tool. See the [Roadmap](/docs/testing/eval-harness/roadmap).
 
 ## Related Documentation
 

--- a/docs/docs/testing/eval-harness/roadmap.md
+++ b/docs/docs/testing/eval-harness/roadmap.md
@@ -37,12 +37,16 @@ The core loop and the scenario-building tooling are in place.
   scenario's phase instead of fresh-seeding. Prior history feeds the user-bot for
   continuity and the judge as context (not scored); only new actions are reported.
   See [Running Evals → Seeding from a frozen scenario](/docs/testing/eval-harness/running-evals#seeding-from-a-frozen-scenario).
+- **Rubric derived from `Prompt.body`** — the rubric IS the phase's own coach
+  prompt body (the same version the coach runs); the judge is asked "did the coach
+  follow these instructions?", so it tracks the prompt automatically and works for
+  any phase with nothing to hand-maintain. Plus per-phase **targeted checks**
+  (explicit pass/fail assertions in `apps/coach/eval/checks/<phase>.md`, plus
+  `--check` flags) reported as their own outcome. See
+  [Running Evals → Rubric & targeted checks](/docs/testing/eval-harness/running-evals#rubric--targeted-checks).
 
 ## Planned
 
-- **Rubric derived from `Prompt.body`** ("did the Coach do what this prompt
-  instructs?") plus a per-run list of **targeted checks** — the
-  "phase X does Y and I hate it" cases.
 - **Baseline ↔ candidate diff** — run two prompt versions and report the delta
   (deterministic outcome + per-criterion rubric scores).
 - **Replay mode** — reuse a baseline run's exact user turns against the candidate

--- a/docs/docs/testing/eval-harness/running-evals.md
+++ b/docs/docs/testing/eval-harness/running-evals.md
@@ -72,8 +72,9 @@ cd server \
 | `--persona NAME` | `casey` | Persona file to drive the user-bot (filename stem in `apps/coach/eval/personas/`). See [Personas](/docs/testing/eval-harness/personas). |
 | `--max-turns N` | `20` | Cap on steps before the run stops. The run also stops early when the phase transitions. |
 | `--coach-model NAME` | configured `DEFAULT_AI_MODEL` (e.g. `gpt-5.4`) | Override the **coach** model under test. Any id from `server/enums/ai.py`. |
-| `--prompt-version N` | latest active | Pin the phase-under-test prompt to a specific version. This is how you run before/after — see [Prompt Version Pinning](/docs/testing/eval-harness/prompt-versioning). |
+| `--prompt-version N` | latest active | Pin the phase-under-test prompt to a specific version. This is how you run before/after — see [Prompt Version Pinning](/docs/testing/eval-harness/prompt-versioning). The derived rubric uses this same version's body. |
 | `--from-scenario NAME` | off (cold-seed) | Hydrate a frozen [TestScenario](/docs/testing/eval-harness/scenario-chain) by exact name (real prior history) and pick the eval up from that scenario's phase, instead of cold-seeding a fresh user at `get_to_know_you`. |
+| `--check ASSERTION` | none | Add a one-off [targeted check](#rubric--targeted-checks) (repeatable), evaluated on top of the per-phase checks file. |
 | `--keep` | off | Keep the throwaway test user instead of deleting it. |
 
 ## Seeding from a frozen scenario
@@ -105,10 +106,40 @@ What changes when you seed from a scenario:
 Build these scenarios with the [scenario builder](/docs/testing/eval-harness/scenario-chain).
 If the name doesn't exist, the command prints the available scenario names.
 
-> **Rubric caveat:** the spike's rubric is `get_to_know_you`-specific. Seeding from
-> a different-phase scenario still runs (and progression is meaningful), but the
-> quality score won't be phase-matched yet — the command prints a warning. Phase-derived
-> rubrics are the [next roadmap item](/docs/testing/eval-harness/roadmap).
+## Rubric & targeted checks
+
+The judge scores the coach against **two** standards, reported separately.
+
+**1. The derived rubric (quality).** There is no hand-written rubric. The judge is
+handed the phase's own coach `Prompt.body` — the *same version the coach ran* (so
+`--prompt-version` pins both) — and asked *"did the coach follow these
+instructions?"* It derives the salient behavioral criteria from the body itself
+and scores each. This means:
+
+- The rubric **tracks the prompt automatically** — edit the prompt (or pin a
+  different version) and the standard moves with it. Nothing to maintain in
+  lockstep, and it works for **any phase**.
+- Only the phase **`Prompt.body`** is used — the appended action/JSON mechanics,
+  global system context, and chat history are deliberately excluded, so the judge
+  evaluates coaching behavior, not output plumbing.
+
+**2. Targeted checks.** Explicit, hand-authored pass/fail assertions — the "this
+phase must do X / must never do Y" cases you care about, including things the
+prompt may not spell out. They come from two places, merged:
+
+- A per-phase file at `apps/coach/eval/checks/<phase>.md` — one check per line;
+  blank lines and `#` comments ignored, a leading `-`/`*` bullet stripped.
+- Any `--check "…"` flags (repeatable) for one-off cases.
+
+```bash
+docker exec dev-coach-local-backend-1 \
+  python manage.py run_coach_eval_spike \
+    --check "The coach addresses the client by name at least once"
+```
+
+Each check gets its own `passed` + `note`. Checks are reported as their **own
+outcome** (`CHECKS: n/m passed`) — never folded into the quality score — so a
+failed assertion is visible even when overall quality passes.
 
 ## Before / after comparison
 
@@ -135,12 +166,13 @@ The version pin is **phase-scoped** (details:
   "scenario": "get_to_know_you_spike",
   "persona": "casey",
   "coach_model": "gpt-5.4",
-  "prompt_version": "latest",
+  "prompt_version": 6,
   "turns": 10,
   "quality": {
     "passed": true,
     "score": 5,
-    "criteria": [ { "name": "Warmth & rapport", "passed": true, "note": "..." } ],
+    "rubric_source": { "phase": "get_to_know_you", "prompt_version": 6, "pinned": false },
+    "criteria": [ { "name": "Single Question Per Response", "passed": true, "note": "..." } ],
     "reasoning": "..."
   },
   "progression": {
@@ -149,6 +181,10 @@ The version pin is **phase-scoped** (details:
     "transitioned": false,
     "reached_goal_phase": false
   },
+  "targeted_checks": [
+    { "check": "The coach never asks more than one question in a single message.", "passed": true, "note": "..." },
+    { "check": "The coach addresses the client by name at least once", "passed": false, "note": "..." }
+  ],
   "actions": [
     {
       "action": "update_asked_questions",
@@ -166,15 +202,20 @@ The version pin is **phase-scoped** (details:
 }
 ```
 
-The report keeps **quality** and **progression** as separate, independent
-outcomes — they are never combined into one verdict:
+The report keeps **quality**, **targeted checks**, and **progression** as
+separate, independent outcomes — they are never combined into one verdict:
 
-- `quality` — the LLM-judge verdict (overall pass, 1–5 score, per-criterion
-  results, reasoning). This is the coaching-quality call.
+- `quality` — the LLM-judge verdict against the [derived rubric](#rubric--targeted-checks)
+  (overall pass, 1–5 score, per-criterion results, reasoning). `rubric_source`
+  records which phase + prompt version the standard came from, and whether it was
+  pinned. This is the coaching-quality call.
 - `progression` — phase movement: whether the coach transitioned and whether it
   reached a goal phase. **Reported independently of quality** — a 5/5 conversation
   that didn't transition within the turn budget is a *non-transition*, not a
   failure. (Some phases legitimately run long; raise `--max-turns` if needed.)
+- `targeted_checks` — one `passed` + `note` per [targeted check](#rubric--targeted-checks)
+  (omitted entirely when none are defined). A failed check stands on its own and
+  is **not** folded into the quality score.
 - `actions` — every action the coach took that run, from the
   [Action table](/docs/database/models/action): e.g. which get-to-know-you
   questions it recorded (`update_asked_questions`), identity creates, phase
@@ -182,8 +223,9 @@ outcomes — they are never combined into one verdict:
 - `final_coach_state` — a snapshot mirroring the admin Coach State viewer (phase,
   identity focus, who-you-are, asked questions, shown videos, current identity).
 
-The run also prints two terminal lines — `QUALITY: PASS (5/5)` and
-`PROGRESSION: get_to_know_you -> …` — so the two outcomes are never conflated.
+The run also prints terminal summary lines — `QUALITY: PASS (5/5, …)`,
+`CHECKS: n/m passed` (when checks are defined), and `PROGRESSION:
+get_to_know_you -> …` — so the outcomes are never conflated.
 
 Per-turn, the live output also shows a `↳ actions: …` line whenever the coach
 takes actions, so you can watch the coach state evolve as the conversation runs.

--- a/server/apps/coach/eval/checks/get_to_know_you.md
+++ b/server/apps/coach/eval/checks/get_to_know_you.md
@@ -1,0 +1,14 @@
+# Targeted checks for the get_to_know_you phase.
+#
+# Explicit, hand-authored pass/fail assertions the judge evaluates IN ADDITION
+# to the prompt-derived rubric — the "this phase must do X / must never do Y"
+# cases you care about, including things the prompt may not spell out.
+#
+# One check per line. Blank lines and lines starting with '#' are ignored; a
+# single leading '-' bullet is stripped. Keep each check a single, unambiguous,
+# yes/no statement about the COACH's behavior.
+
+- The coach never asks more than one question in a single message.
+- The coach never invents or assumes facts about the client that the client did not actually say.
+- The coach builds on what the client just shared rather than asking generic, disconnected questions.
+- The coach does not begin Identity work (brainstorming or naming identities) during this phase.

--- a/server/apps/coach/eval/harness.py
+++ b/server/apps/coach/eval/harness.py
@@ -17,9 +17,11 @@ from pydantic import BaseModel, Field
 from apps.actions.models import Action
 from apps.chat_messages.models import ChatMessage
 from apps.coach_states.serializers.coach_state_serializer import CoachStateSerializer
+from apps.prompts.models import Prompt
 from enums.ai import AIModel
 from enums.component_type import ComponentType
 from enums.message_role import MessageRole
+from enums.prompt_type import PromptType
 from services.ai.utils.openai import structured_completion
 
 # Component types that genuinely GATE the conversation — the client must click a
@@ -33,6 +35,9 @@ GATE_COMPONENT_TYPES = {
 
 # Persona markdown files live alongside this module.
 PERSONA_DIR = Path(__file__).resolve().parent / "personas"
+
+# Per-phase targeted-check files (one assertion per line) live here.
+CHECKS_DIR = Path(__file__).resolve().parent / "checks"
 
 # Models for the harness itself (NOT the coach under test). The user-bot is
 # cheap; the judge is the stronger model. The coach uses its configured default.
@@ -205,6 +210,58 @@ def chat_history_transcript(user) -> Transcript:
             continue
         out.append(("coach" if m.role == MessageRole.COACH else "user", text))
     return out
+
+
+def load_phase_prompt_body(
+    phase: str, version: Optional[int] = None
+) -> Tuple[str, Optional[int]]:
+    """Return (body, version) of the coach Prompt for `phase` — the SAME row the
+    coach pipeline uses (see PromptManager.create_chat_prompt).
+
+    With `version`, pin that exact version; otherwise the latest active. This raw
+    body — the phase's coaching instructions, placeholders intact — IS the live
+    rubric: the judge checks whether the coach followed it, so the rubric tracks
+    the prompt automatically and never needs separate maintenance. The appended
+    action/JSON mechanics, global system context, and recent messages are NOT part
+    of `body` and are intentionally excluded from the rubric. Returns ("", None)
+    if no matching prompt exists.
+    """
+    qs = Prompt.objects.filter(
+        prompt_type=PromptType.COACH, coaching_phase=phase, is_active=True
+    )
+    if version is not None:
+        qs = qs.filter(version=version)
+    prompt = qs.order_by("-version").first()
+    if not prompt:
+        return "", None
+    return prompt.body, prompt.version
+
+
+def load_targeted_checks(
+    phase: str, extra: Optional[List[str]] = None
+) -> List[str]:
+    """Load the per-phase targeted checks plus any `extra` (command-line) checks.
+
+    Targeted checks are explicit, hand-authored pass/fail assertions ("phase X
+    must do Y / must never do Z") — deliberately separate from the prompt-derived
+    rubric. The per-phase file lives at apps/coach/eval/checks/<phase>.md: one
+    check per line; blank lines and lines starting with '#' are ignored, and a
+    single leading '-'/'*' bullet is stripped.
+    """
+    checks: List[str] = []
+    path = CHECKS_DIR / f"{phase}.md"
+    if path.exists():
+        for line in path.read_text(encoding="utf-8").splitlines():
+            s = line.strip()
+            if not s or s.startswith("#"):
+                continue
+            if s[0] in "-*":
+                s = s[1:].strip()
+            if s:
+                checks.append(s)
+    if extra:
+        checks.extend(c.strip() for c in extra if c and c.strip())
+    return checks
 
 
 def collect_new_actions(user, seen_ids: set) -> list:

--- a/server/apps/coach/management/commands/run_coach_eval_spike.py
+++ b/server/apps/coach/management/commands/run_coach_eval_spike.py
@@ -9,11 +9,18 @@ assembly from the DB + real coach LLM):
     seed user at a phase
         -> user-bot (LLM persona) drives the conversation
         -> coach responds via process_message (the same code path the API uses)
-        -> judge (deterministic checks + LLM rubric) returns a verdict
+        -> judge returns a verdict against the phase's own prompt + targeted checks
 
 The persona is loaded from a markdown file (see apps/coach/eval/personas/), and
 the loop is component-aware — it clicks through any video/break gates by
 replaying their button actions. Shared pieces live in apps/coach/eval/harness.py.
+
+The rubric is DERIVED LIVE from the phase's coach Prompt.body — the judge is
+asked "did the coach follow these instructions?" — so it tracks the prompt
+automatically and works for any phase, with nothing to hand-maintain. On top of
+that, per-phase targeted checks (explicit pass/fail assertions in
+apps/coach/eval/checks/<phase>.md, plus any --check flags) are evaluated and
+reported separately.
 
 Runs against the LIVE local database so it exercises whatever prompts are
 currently active (i.e. the ones you just edited).
@@ -29,6 +36,7 @@ Usage:
     python manage.py run_coach_eval_spike --persona casey --max-turns 10 --keep
     python manage.py run_coach_eval_spike --coach-model gpt-4o --prompt-version 10
     python manage.py run_coach_eval_spike --from-scenario "[Auto] Casey @ start of get_to_know_you"
+    python manage.py run_coach_eval_spike --check "Never asks more than one question per message"
 """
 
 import json
@@ -46,6 +54,8 @@ from apps.coach.eval.harness import (
     coach_state_snapshot,
     collect_new_actions,
     load_persona,
+    load_phase_prompt_body,
+    load_targeted_checks,
     pending_component,
     primary_button_actions,
     render_transcript,
@@ -75,22 +85,20 @@ GOAL_PHASES = {
     CoachingPhase.IDENTITY_BRAINSTORMING.value,
 }
 
-RUBRIC = (
-    "You are evaluating the COACH's performance in a 'get to know you' phase of "
-    "an identity coaching conversation. Judge ONLY the coach's messages "
-    "(role=coach). Criteria:\n"
-    "1. Warmth & rapport: the coach is warm, encouraging, and conversational.\n"
-    "2. One thing at a time: the coach does not interrogate with multiple "
-    "stacked questions in a single message.\n"
-    "3. Curiosity & follow-up: the coach builds on what the client said rather "
-    "than asking generic, disconnected questions.\n"
-    "4. Stays on task: the coach is genuinely getting to know the client (their "
-    "life, values, aspirations) and does not derail or hallucinate facts the "
-    "client never said.\n"
-    "5. Forward motion: by the end the coach is moving the client toward the "
-    "next step rather than looping endlessly.\n"
-    "Pass only if the coach is clearly competent across these. Be a strict but "
-    "fair judge."
+# How to judge — the WHAT (the criteria) is derived live from the phase's own
+# Prompt.body at runtime; this only frames HOW to apply it.
+JUDGE_FRAMING = (
+    "You are a strict but fair judge evaluating a COACH in an identity coaching "
+    "conversation. Judge ONLY the coach's messages (role=coach).\n\n"
+    "The standard is the coach's OWN phase instructions, shown below. Decide "
+    "whether the coach actually FOLLOWED them in the transcript. Focus on "
+    "behavioral and conversational adherence — IGNORE output formatting, JSON, "
+    "and action/tool mechanics (those are enforced elsewhere and are not your "
+    "concern). Placeholders like {curly_braces} in the instructions are filled "
+    "with live data at runtime; judge the intent behind them, not the literal "
+    "placeholder.\n\n"
+    "Derive the key behavioral expectations from the instructions yourself, score "
+    "the coach on each as a criterion, and give an overall pass/fail + 1-5 score."
 )
 
 
@@ -100,12 +108,25 @@ class CriterionScore(BaseModel):
     note: str
 
 
+class CheckResult(BaseModel):
+    """Verdict on one explicit, hand-authored targeted check."""
+
+    check: str = Field(description="The targeted check being evaluated (echoed).")
+    passed: bool
+    note: str
+
+
 class JudgeVerdict(BaseModel):
     """LLM-as-judge verdict over the full transcript."""
 
     passed: bool = Field(description="Overall pass/fail for the coach.")
     score: int = Field(description="Overall quality score 1-5.")
-    criteria: List[CriterionScore]
+    criteria: List[CriterionScore] = Field(
+        description="Criteria derived from the phase instructions, each scored."
+    )
+    targeted_checks: List[CheckResult] = Field(
+        description="One result per supplied targeted check; empty if none given."
+    )
     reasoning: str
 
 
@@ -131,8 +152,19 @@ class Command(BaseCommand):
             type=int,
             default=None,
             help=(
-                f"Pin the {START_PHASE.value} prompt to a specific version "
-                "(for before/after comparisons). Defaults to the latest active."
+                "Pin the phase-under-test prompt to a specific version (for "
+                "before/after comparisons). Defaults to the latest active. The "
+                "derived rubric uses this same version's body."
+            ),
+        )
+        parser.add_argument(
+            "--check",
+            action="append",
+            default=None,
+            metavar="ASSERTION",
+            help=(
+                "Add a one-off targeted check (repeatable), evaluated in addition "
+                "to the per-phase checks file (apps/coach/eval/checks/<phase>.md)."
             ),
         )
         parser.add_argument(
@@ -189,7 +221,11 @@ class Command(BaseCommand):
     def _judge(
         self,
         client,
+        *,
+        phase: str,
+        rubric_body: str,
         transcript: Transcript,
+        targeted_checks: Optional[List[str]] = None,
         context: Optional[Transcript] = None,
     ) -> JudgeVerdict:
         convo = render_transcript(transcript, you_label="CLIENT")
@@ -201,8 +237,20 @@ class Command(BaseCommand):
                 "they predate the phase under evaluation. Use them only to know "
                 f"what the client already shared):\n\n{ctx}\n\n"
             )
+        checks_block = ""
+        if targeted_checks:
+            numbered = "\n".join(f"{i + 1}. {c}" for i, c in enumerate(targeted_checks))
+            checks_block = (
+                "TARGETED CHECKS — in addition to the rubric, evaluate each of "
+                "these explicit requirements as a hard yes/no and return a verdict "
+                "+ note for each in `targeted_checks` (echo the check text "
+                f"verbatim):\n{numbered}\n\n"
+            )
         system = (
-            f"{RUBRIC}\n\n{context_block}"
+            f"{JUDGE_FRAMING}\n\n"
+            f"--- BEGIN {phase} PHASE INSTRUCTIONS ---\n{rubric_body}\n"
+            f"--- END {phase} PHASE INSTRUCTIONS ---\n\n"
+            f"{checks_block}{context_block}"
             f"Transcript to evaluate:\n\n{convo}\n\n"
             "Return your structured verdict."
         )
@@ -248,27 +296,32 @@ class Command(BaseCommand):
             start_phase = START_PHASE.value
             scenario_label = "get_to_know_you_spike"
 
-        # The rubric is hard-coded for get_to_know_you. Seeding from a different
-        # phase still runs, but warn that quality scores aren't phase-matched yet
-        # (phase-derived rubrics are the next roadmap item).
-        if start_phase != START_PHASE.value:
-            self.stdout.write(self.style.WARNING(
-                f"NOTE: rubric is get_to_know_you-specific, but this scenario "
-                f"starts at '{start_phase}'. Quality scores may not be meaningful; "
-                f"progression still is."
-            ))
-
         # Phase-scoped version pin: only applies while the user is in start_phase.
         prompt_version = options["prompt_version"]
         prompt_versions = (
             {start_phase: prompt_version} if prompt_version is not None else None
         )
-        version_label = prompt_version if prompt_version is not None else "latest"
+
+        # The rubric IS the phase's own prompt body (the same version the coach
+        # runs), so it tracks the prompt automatically and works for any phase.
+        # Targeted checks layer explicit assertions on top.
+        rubric_body, rubric_version = load_phase_prompt_body(start_phase, prompt_version)
+        if not rubric_body:
+            self.stderr.write(self.style.ERROR(
+                f"No active coach prompt for phase '{start_phase}'"
+                + (f" at version {prompt_version}" if prompt_version else "")
+                + " — cannot derive a rubric. Aborting."
+            ))
+            if not options["keep"]:
+                User.objects.filter(email=cleanup_email).delete()
+            return
+        targeted_checks = load_targeted_checks(start_phase, options["check"])
+        version_label = rubric_version if rubric_version is not None else "?"
 
         self.stdout.write(self.style.HTTP_INFO(
             f"Persona: {persona.name} | coach: {coach_model.value} "
-            f"| start: {start_phase} (v{version_label}) "
-            f"| seed: {scenario_label} "
+            f"| start: {start_phase} (prompt v{version_label}) "
+            f"| seed: {scenario_label} | targeted-checks: {len(targeted_checks)} "
             f"| user-bot: {DEFAULT_USER_BOT_MODEL.value} | judge: {DEFAULT_JUDGE_MODEL.value}"
         ))
 
@@ -364,18 +417,30 @@ class Command(BaseCommand):
                 ))
                 return
 
-            verdict = self._judge(harness_client, transcript, context=prior)
+            verdict = self._judge(
+                harness_client,
+                phase=start_phase,
+                rubric_body=rubric_body,
+                transcript=transcript,
+                targeted_checks=targeted_checks,
+                context=prior,
+            )
 
-            # Quality (LLM rubric) and progression (phase movement) are reported
-            # SEPARATELY and never AND-ed together. A high-quality conversation
+            # Quality (rubric), targeted checks, and progression are reported as
+            # SEPARATE outcomes, never AND-ed together. A high-quality conversation
             # that simply didn't transition within the turn budget is NOT a
             # failure — it's a non-transition, which is its own signal.
-            _emit({
+            report = {
                 **base_report,
                 "status": "ok",
                 "quality": {
                     "passed": verdict.passed,
                     "score": verdict.score,
+                    "rubric_source": {
+                        "phase": start_phase,
+                        "prompt_version": rubric_version,
+                        "pinned": prompt_version is not None,
+                    },
                     "criteria": [c.model_dump() for c in verdict.criteria],
                     "reasoning": verdict.reasoning,
                 },
@@ -387,15 +452,29 @@ class Command(BaseCommand):
                 },
                 "actions": all_actions,
                 "final_coach_state": final_coach_state,
-            })
+            }
+            if targeted_checks:
+                report["targeted_checks"] = [c.model_dump() for c in verdict.targeted_checks]
+            _emit(report)
 
-            # Two independent outcomes — quality is the judge's call; progression
+            # Independent outcomes — quality is the judge's call against the
+            # phase prompt; targeted checks are explicit assertions; progression
             # is informational (phase movement within the turn budget).
             q_style = self.style.SUCCESS if verdict.passed else self.style.ERROR
             self.stdout.write(q_style(
                 f"QUALITY:     {'PASS' if verdict.passed else 'FAIL'}  "
-                f"(judge score {verdict.score}/5)"
+                f"(judge score {verdict.score}/5, vs {start_phase} prompt v{version_label})"
             ))
+            if targeted_checks:
+                passed = sum(1 for c in verdict.targeted_checks if c.passed)
+                total = len(verdict.targeted_checks)
+                c_style = self.style.SUCCESS if passed == total else self.style.ERROR
+                self.stdout.write(c_style(
+                    f"CHECKS:      {passed}/{total} passed"
+                ))
+                for c in verdict.targeted_checks:
+                    mark = "✓" if c.passed else "✗"
+                    self.stdout.write(self.style.HTTP_INFO(f"  {mark} {c.check}"))
             if final_phase != start_phase:
                 prog = f"{start_phase} -> {final_phase}"
             else:

--- a/server/apps/coach/tests/test_eval_harness.py
+++ b/server/apps/coach/tests/test_eval_harness.py
@@ -1,0 +1,51 @@
+"""
+Tests for apps/coach/eval/harness.py (the pure helpers).
+"""
+
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from apps.coach.eval import harness
+from apps.coach.eval.harness import load_targeted_checks
+
+
+class TestLoadTargetedChecks(SimpleTestCase):
+    """load_targeted_checks parses the per-phase file and merges --check extras."""
+
+    def test_loads_checks_from_phase_file(self):
+        """The shipped get_to_know_you file yields its non-comment lines."""
+        checks = load_targeted_checks("get_to_know_you")
+        self.assertTrue(checks, "expected the get_to_know_you checks file to load")
+        # Comments and blank lines are skipped; bullets are stripped.
+        self.assertTrue(all(c and not c.startswith("#") for c in checks))
+        self.assertTrue(all(not c.startswith("- ") for c in checks))
+        self.assertIn(
+            "The coach never asks more than one question in a single message.",
+            checks,
+        )
+
+    def test_unknown_phase_returns_only_extras(self):
+        """A phase with no file falls back to just the command-line extras."""
+        checks = load_targeted_checks("no_such_phase", extra=["one-off check"])
+        self.assertEqual(checks, ["one-off check"])
+
+    def test_unknown_phase_with_no_extras_is_empty(self):
+        self.assertEqual(load_targeted_checks("no_such_phase"), [])
+
+    def test_extras_are_appended_and_stripped(self):
+        """--check extras append after file checks; blank/whitespace ones drop."""
+        base = load_targeted_checks("get_to_know_you")
+        merged = load_targeted_checks(
+            "get_to_know_you", extra=["  extra one  ", "", "   "]
+        )
+        self.assertEqual(merged, base + ["extra one"])
+
+    def test_parses_bullets_blanks_and_comments(self):
+        """Bullet, comment, and blank-line handling on synthetic file contents."""
+        sample = "# header\n\n- first check\n* second check\nthird check\n\n# tail\n"
+        with patch.object(harness.Path, "exists", return_value=True), patch.object(
+            harness.Path, "read_text", return_value=sample
+        ):
+            checks = load_targeted_checks("anything")
+        self.assertEqual(checks, ["first check", "second check", "third check"])


### PR DESCRIPTION
Roadmap item #2 for the eval harness. Replaces the hardcoded, single-phase rubric with one that's derived from the prompt itself, plus explicit targeted checks.

## Derived rubric (quality)

The judge no longer uses a hand-written, `get_to_know_you`-specific rubric. It's handed the phase's own coach **`Prompt.body`** — the *same version the coach ran* (so `--prompt-version` pins both) — and asked *"did the coach follow these instructions?"*. It derives the criteria from the body itself and scores each.

- **Tracks the prompt automatically** — edit the prompt or pin a different version and the standard moves with it. Nothing to maintain in lockstep; works for **any phase**.
- Only the phase **`Prompt.body`** is used — the appended action/JSON mechanics, global system context, and chat history are excluded, so the judge evaluates coaching behavior, not output plumbing.
- `quality.rubric_source` records `{phase, prompt_version, pinned}`.

This removes the obsolete "rubric is get_to_know_you-specific" warning from #130 — `--from-scenario` now judges every phase against its own prompt.

## Targeted checks

Explicit, hand-authored pass/fail assertions ("must do X / must never do Y"), merged from:
- a per-phase file `apps/coach/eval/checks/<phase>.md` (one per line; `#` comments + bullets handled), and
- repeatable `--check "…"` flags.

Reported as their **own** outcome (`CHECKS: n/m passed`), never folded into the quality score, so a failed assertion is visible even when quality passes.

## New / changed

- `harness.py`: `load_phase_prompt_body`, `load_targeted_checks`.
- `run_coach_eval_spike.py`: derived rubric, `--check`, `targeted_checks` in `JudgeVerdict` + report, `rubric_source`, new terminal `CHECKS:` line.
- Seed `checks/get_to_know_you.md`; unit tests for the checks loader.
- Docs: overview/roadmap → Built; running-evals → new "Rubric & targeted checks" section + updated report example.

## Testing

- Checks-loader unit tests (5) pass; `apps.coach` + `apps.test_scenario` pass (254).
- End-to-end from `[Auto] Casey @ get_to_know_you` (gpt-4o): rubric derived from the real `get_to_know_you` **prompt v6**, judge produced criteria from the body (e.g. "Single Question Per Response"), **QUALITY PASS 5/5**, **CHECKS 4/5** (the one-off `--check "addresses by name"` correctly failed independent of quality), **PROGRESSION get_to_know_you → identity_warm_up**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)