### PR TITLE
feat(coach): replay mode for coach evals (--save-run / --replay)

### DIFF
--- a/docs/docs/testing/eval-harness/overview.md
+++ b/docs/docs/testing/eval-harness/overview.md
@@ -202,9 +202,10 @@ scenarios.
   loading; component-aware driving; phase-scoped prompt-version pinning; the
   `build_eval_scenario` chain builder (dry-run by default, opt-in freeze); seeding
   the eval directly from a frozen scenario (`--from-scenario`); rubrics derived
-  live from the phase `Prompt.body` + per-phase targeted checks.
-- **Planned:** baseline-vs-candidate diffing with replay and a `run_coach_eval`
-  MCP tool. See the [Roadmap](/docs/testing/eval-harness/roadmap).
+  live from the phase `Prompt.body` + per-phase targeted checks; replay mode
+  (`--save-run` / `--replay`) to re-run the exact user turns against a new prompt.
+- **Planned:** baseline-vs-candidate diffing (over replayed turns) and a
+  `run_coach_eval` MCP tool. See the [Roadmap](/docs/testing/eval-harness/roadmap).
 
 ## Related Documentation
 

--- a/docs/docs/testing/eval-harness/roadmap.md
+++ b/docs/docs/testing/eval-harness/roadmap.md
@@ -44,13 +44,18 @@ The core loop and the scenario-building tooling are in place.
   (explicit pass/fail assertions in `apps/coach/eval/checks/<phase>.md`, plus
   `--check` flags) reported as their own outcome. See
   [Running Evals → Rubric & targeted checks](/docs/testing/eval-harness/running-evals#rubric--targeted-checks).
+- **Replay mode** — `--save-run PATH` records a run's exact user turns (+ report)
+  to a JSON artifact; `--replay PATH` re-runs those turns instead of the user-bot,
+  so the prompt/model is the only variable. The artifact's persona/scenario/
+  coach-model/version are replay defaults; override with the flags (typically a new
+  `--prompt-version`). See
+  [Running Evals → Replay](/docs/testing/eval-harness/running-evals#replay-a-run).
 
 ## Planned
 
-- **Baseline ↔ candidate diff** — run two prompt versions and report the delta
-  (deterministic outcome + per-criterion rubric scores).
-- **Replay mode** — reuse a baseline run's exact user turns against the candidate
-  prompt, so the only variable is the prompt (removes user-bot variance).
+- **Baseline ↔ candidate diff** — run two prompt versions over the *same* (replayed)
+  user turns and report the delta (progression, targeted checks, per-version rubric
+  scores, pairwise preference).
 - **Transcript caching** — persist baseline transcripts keyed on
   `(phase, prompt_version, model, scenario, user_turns)` — *not* on the rubric — so
   a baseline is generated once and re-judged cheaply when requirements change. See

--- a/docs/docs/testing/eval-harness/running-evals.md
+++ b/docs/docs/testing/eval-harness/running-evals.md
@@ -75,6 +75,8 @@ cd server \
 | `--prompt-version N` | latest active | Pin the phase-under-test prompt to a specific version. This is how you run before/after — see [Prompt Version Pinning](/docs/testing/eval-harness/prompt-versioning). The derived rubric uses this same version's body. |
 | `--from-scenario NAME` | off (cold-seed) | Hydrate a frozen [TestScenario](/docs/testing/eval-harness/scenario-chain) by exact name (real prior history) and pick the eval up from that scenario's phase, instead of cold-seeding a fresh user at `get_to_know_you`. |
 | `--check ASSERTION` | none | Add a one-off [targeted check](#rubric--targeted-checks) (repeatable), evaluated on top of the per-phase checks file. |
+| `--save-run PATH` | off | Write the run (recorded user turns + full report) to a JSON artifact for later [`--replay`](#replay-a-run) or inspection. |
+| `--replay PATH` | off | [Replay](#replay-a-run) the user turns from a saved artifact instead of generating new ones with the user-bot. |
 | `--keep` | off | Keep the throwaway test user instead of deleting it. |
 
 ## Seeding from a frozen scenario
@@ -141,20 +143,55 @@ Each check gets its own `passed` + `note`. Checks are reported as their **own
 outcome** (`CHECKS: n/m passed`) — never folded into the quality score — so a
 failed assertion is visible even when overall quality passes.
 
+## Replay a run
+
+Every eval drives a *fresh* conversation, so two runs differ both by whatever you
+changed **and** by user-bot randomness. Replay removes the second variable: it
+records one run's exact user turns and feeds them back verbatim, so a re-run
+differs only by the prompt/model.
+
+```bash
+# 1. Record a run (note --save-run):
+docker exec dev-coach-local-backend-1 \
+  python manage.py run_coach_eval_spike --prompt-version 10 --save-run /tmp/v10.json
+
+# 2. Replay those same turns against a new version:
+docker exec dev-coach-local-backend-1 \
+  python manage.py run_coach_eval_spike --replay /tmp/v10.json --prompt-version 11
+```
+
+- The artifact is the **full report plus the recorded `user_turns`** (and the
+  transcript + seed). It's written for both successful and errored runs.
+- On replay, the artifact's **persona, scenario seed, coach model, and prompt
+  version are used as defaults** — pass the flags to override. The common case is
+  overriding `--prompt-version` to test a new version on identical turns.
+- Component gates (videos/breaks) are still clicked through dynamically; only the
+  typed user turns are replayed. If the recorded turns run out before the phase
+  transitions, the run stops (`[replay exhausted after N user turns]`).
+- The coach is still a live LLM, so its *replies* can vary run-to-run — replay
+  fixes the **user** side, not coach sampling. For a rigorous read, replay a few
+  times or lean on the targeted checks (which are deterministic assertions).
+
 ## Before / after comparison
 
-A change is only meaningful relative to a baseline.
+A change is only meaningful relative to a baseline. Use replay so the prompt is
+the only variable:
 
-1. **Baseline** against the old prompt version (say v10):
+1. **Baseline** against the old version, recording the turns:
    ```bash
    docker exec dev-coach-local-backend-1 \
-     python manage.py run_coach_eval_spike --prompt-version 10
+     python manage.py run_coach_eval_spike --prompt-version 10 --save-run /tmp/v10.json
    ```
 2. **Create the new prompt version** (e.g. via the `dev-coach-docs` MCP server's
    `create_new_coach_prompt` tool — it auto-assigns the next version).
-3. **Candidate** against the new version (`--prompt-version 11`).
-4. **Compare the two reports** — deterministic outcome + the judge's per-criterion
-   scores and reasoning.
+3. **Candidate** — replay the *same* turns against the new version:
+   ```bash
+   docker exec dev-coach-local-backend-1 \
+     python manage.py run_coach_eval_spike --replay /tmp/v10.json --prompt-version 11
+   ```
+4. **Compare the two reports** — quality score + per-criterion reasoning, targeted
+   checks, and progression. (An automated baseline↔candidate *diff* command is the
+   [next roadmap item](/docs/testing/eval-harness/roadmap).)
 
 The version pin is **phase-scoped** (details:
 [Prompt Version Pinning](/docs/testing/eval-harness/prompt-versioning)).

--- a/server/apps/coach/eval/harness.py
+++ b/server/apps/coach/eval/harness.py
@@ -9,6 +9,7 @@ The harness drives the REAL coach pipeline via `process_message`, so it exercise
 whatever prompts are currently active in the database.
 """
 
+import json
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -262,6 +263,21 @@ def load_targeted_checks(
     if extra:
         checks.extend(c.strip() for c in extra if c and c.strip())
     return checks
+
+
+def save_eval_run(path: str, data: dict) -> None:
+    """Persist an eval run artifact (the report plus its `user_turns`) as JSON.
+
+    The artifact doubles as the replay source: `load_eval_run` reads it back and
+    the eval re-runs the recorded user turns (see run_coach_eval_spike --replay),
+    so the only thing that changes is the prompt/model under test.
+    """
+    Path(path).write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def load_eval_run(path: str) -> dict:
+    """Load an eval run artifact written by `save_eval_run`."""
+    return json.loads(Path(path).read_text(encoding="utf-8"))
 
 
 def collect_new_actions(user, seen_ids: set) -> list:

--- a/server/apps/coach/management/commands/run_coach_eval_spike.py
+++ b/server/apps/coach/management/commands/run_coach_eval_spike.py
@@ -31,12 +31,21 @@ TestScenario (real prior history, built via build_eval_scenario) and pick the
 eval up from that scenario's phase. Either way the throwaway user is deleted on
 exit unless --keep is passed.
 
+Replay: --save-run PATH writes the run (user turns + report) to a JSON artifact;
+--replay PATH re-runs those exact user turns instead of generating new ones with
+the user-bot. Combined with a different --prompt-version, replay removes user-bot
+variance so the prompt is the only thing that changed — the basis for a fair
+before/after. The artifact's persona/scenario/coach-model/version are used as
+defaults on replay; pass the flags to override (e.g. a new --prompt-version).
+
 Usage:
     python manage.py run_coach_eval_spike
     python manage.py run_coach_eval_spike --persona casey --max-turns 10 --keep
     python manage.py run_coach_eval_spike --coach-model gpt-4o --prompt-version 10
     python manage.py run_coach_eval_spike --from-scenario "[Auto] Casey @ start of get_to_know_you"
     python manage.py run_coach_eval_spike --check "Never asks more than one question per message"
+    python manage.py run_coach_eval_spike --prompt-version 11 --save-run /tmp/v11.json
+    python manage.py run_coach_eval_spike --replay /tmp/v11.json --prompt-version 12
 """
 
 import json
@@ -53,12 +62,14 @@ from apps.coach.eval.harness import (
     chat_history_transcript,
     coach_state_snapshot,
     collect_new_actions,
+    load_eval_run,
     load_persona,
     load_phase_prompt_body,
     load_targeted_checks,
     pending_component,
     primary_button_actions,
     render_transcript,
+    save_eval_run,
     user_bot_reply,
 )
 from apps.coach.functions.public.process_message import process_message
@@ -180,6 +191,28 @@ class Command(BaseCommand):
             ),
         )
         parser.add_argument(
+            "--save-run",
+            type=str,
+            default=None,
+            metavar="PATH",
+            help=(
+                "Write the run (recorded user turns + full report) to a JSON "
+                "artifact at PATH, for later --replay or inspection."
+            ),
+        )
+        parser.add_argument(
+            "--replay",
+            type=str,
+            default=None,
+            metavar="PATH",
+            help=(
+                "Replay the user turns from a saved-run artifact instead of "
+                "generating new ones with the user-bot. Persona / scenario / "
+                "coach-model / prompt-version default from the artifact; pass the "
+                "flags to override (e.g. --prompt-version to test a new version)."
+            ),
+        )
+        parser.add_argument(
             "--keep",
             action="store_true",
             help="Keep the throwaway test user instead of deleting it on exit.",
@@ -265,6 +298,25 @@ class Command(BaseCommand):
 
     # --- orchestration --------------------------------------------------------
     def handle(self, *args, **options):
+        # Replay: load the saved run's user turns and let its recorded
+        # persona / scenario / coach-model / version stand in as defaults, so the
+        # only thing that changes is whatever you override on the CLI (typically
+        # --prompt-version). Explicit flags always win.
+        replay_turns = None
+        if options["replay"]:
+            artifact = load_eval_run(options["replay"])
+            replay_turns = artifact.get("user_turns") or []
+            for key in ("coach_model", "prompt_version"):
+                if options[key] is None and artifact.get(key) is not None:
+                    options[key] = artifact[key]
+            if options["from_scenario"] is None and artifact.get("scenario_seed"):
+                options["from_scenario"] = artifact["scenario_seed"]
+            if artifact.get("persona"):
+                options["persona"] = artifact["persona"]
+            self.stdout.write(self.style.HTTP_INFO(
+                f"[replay: {len(replay_turns)} user turns from {options['replay']}]"
+            ))
+
         max_turns = options["max_turns"]
         coach_model = AIModel.get_or_default(options["coach_model"])
         persona = load_persona(options["persona"])
@@ -326,6 +378,7 @@ class Command(BaseCommand):
         ))
 
         transcript: Transcript = []
+        replay_idx = 0
         # Prior-history actions exist on the hydrated user; record their ids so
         # collect_new_actions only reports what the coach does DURING this eval.
         seen_action_ids: set = set(
@@ -349,9 +402,20 @@ class Command(BaseCommand):
                         user, None, actions, coach_model, prompt_versions
                     )
                 else:
-                    user_msg = user_bot_reply(
-                        harness_client, DEFAULT_USER_BOT_MODEL, persona, prior + transcript
-                    )
+                    if replay_turns is not None:
+                        # Replay the recorded user turns verbatim (no user-bot),
+                        # so the only variable vs the saved run is the prompt/model.
+                        if replay_idx >= len(replay_turns):
+                            self.stdout.write(self.style.HTTP_INFO(
+                                f"\n[replay exhausted after {replay_idx} user turns]"
+                            ))
+                            break
+                        user_msg = replay_turns[replay_idx]
+                        replay_idx += 1
+                    else:
+                        user_msg = user_bot_reply(
+                            harness_client, DEFAULT_USER_BOT_MODEL, persona, prior + transcript
+                        )
                     transcript.append(("user", user_msg))
                     self.stdout.write(self.style.WARNING(f"\nCLIENT: {user_msg}"))
                     ok, data, err = process_message(
@@ -400,6 +464,18 @@ class Command(BaseCommand):
                 self.stdout.write(self.style.MIGRATE_HEADING("EVAL REPORT"))
                 self.stdout.write(json.dumps(report, indent=2))
                 self.stdout.write("=" * 70)
+                if options["save_run"]:
+                    # The report plus the recorded user turns + seed IS the replay
+                    # artifact: --replay reads these back to re-run the same turns.
+                    save_eval_run(options["save_run"], {
+                        **report,
+                        "scenario_seed": scenario_name,
+                        "user_turns": [t[1] for t in transcript if t[0] == "user"],
+                        "transcript": [{"role": r, "text": t} for r, t in transcript],
+                    })
+                    self.stdout.write(self.style.SUCCESS(
+                        f"(saved run -> {options['save_run']})"
+                    ))
 
             # A pipeline failure (e.g. the coach returning malformed JSON) is an
             # ERROR, not a coaching-quality result. Skip the judge so an infra

--- a/server/apps/coach/tests/test_eval_harness.py
+++ b/server/apps/coach/tests/test_eval_harness.py
@@ -2,12 +2,14 @@
 Tests for apps/coach/eval/harness.py (the pure helpers).
 """
 
+import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
 from apps.coach.eval import harness
-from apps.coach.eval.harness import load_targeted_checks
+from apps.coach.eval.harness import load_eval_run, load_targeted_checks, save_eval_run
 
 
 class TestLoadTargetedChecks(SimpleTestCase):
@@ -49,3 +51,20 @@ class TestLoadTargetedChecks(SimpleTestCase):
         ):
             checks = load_targeted_checks("anything")
         self.assertEqual(checks, ["first check", "second check", "third check"])
+
+
+class TestEvalRunArtifact(SimpleTestCase):
+    """save_eval_run / load_eval_run round-trip the replay artifact."""
+
+    def test_round_trip(self):
+        data = {
+            "persona": "casey",
+            "scenario_seed": "[Auto] Casey @ get_to_know_you",
+            "coach_model": "gpt-4o",
+            "prompt_version": 6,
+            "user_turns": ["hi", "I'm Casey", "grew up in Norcross"],
+        }
+        with tempfile.TemporaryDirectory() as d:
+            path = str(Path(d) / "run.json")
+            save_eval_run(path, data)
+            self.assertEqual(load_eval_run(path), data)


### PR DESCRIPTION
Roadmap item #4 (replay mode), and the engine for #3 (baseline↔candidate diff, next PR).

## Why

Every eval drives a *fresh* conversation, so two runs differ both by whatever you changed **and** by user-bot randomness. Replay removes the second variable: record one run's exact user turns and feed them back verbatim, so a re-run differs only by the prompt/model.

## What

- **`--save-run PATH`** — writes the full report plus the recorded `user_turns` (and transcript + scenario seed) to a JSON artifact. Written for both successful and errored runs.
- **`--replay PATH`** — re-runs those user turns verbatim instead of calling the user-bot. The artifact's **persona / scenario seed / coach-model / prompt-version** become defaults; CLI flags override (the common case is `--prompt-version` to test a new version on identical turns).
- Component gates (videos/breaks) are still clicked through dynamically; only typed user turns are replayed. If turns run out before transition: `[replay exhausted after N user turns]`.
- The coach is still a live LLM, so replay fixes the **user** side, not coach sampling — noted in the docs.
- New harness helpers `save_eval_run` / `load_eval_run`.

## Testing

- Round-trip unit test for the artifact I/O; `apps.coach` suite passes (96).
- End-to-end: recorded an 8-turn gpt-4o run with `--save-run`, then `--replay` reproduced the **byte-identical** 8 CLIENT turns (coach-model defaulted from the artifact, prompt v6), QUALITY 5/5, CHECKS 4/4 — only the coach side can now vary.

## Next

PR for the **baseline↔candidate diff** command (run two versions over the same replayed turns, report the delta + pairwise preference) follows once this merges — keeping to one PR at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)