### PR TITLE
feat(coach): baseline↔candidate diff command (run_coach_eval_diff)

### DIFF
--- a/docs/docs/testing/eval-harness/overview.md
+++ b/docs/docs/testing/eval-harness/overview.md
@@ -69,7 +69,9 @@ commands wire them together.
 | **User-bot** | An LLM driven by the persona + the running transcript; returns the client's next message. Cheap model. | `harness.user_bot_reply` |
 | **Component driver** | Clicks through gating UI components (session videos, breaks) by replaying their button actions — no per-component hardcoding. | `harness.pending_component`, `primary_button_actions` |
 | **Coach** | The real pipeline: `process_message` → `build_coach_prompt` → `PromptManager` → coach LLM → action handler. | [Prompt Manager](/docs/core-systems/prompt-manager/overview), [Action Handler](/docs/core-systems/action-handler/overview) |
-| **Judge** | Deterministic assertions + an LLM-as-judge scoring the transcript against a rubric. Stronger model. | `run_coach_eval_spike` (`_judge`) |
+| **Drive loop** | Seeds a user, drives (or replays) the conversation, records turns + actions + state. Shared by both commands. | `harness.drive_eval` |
+| **Judge** | An LLM-as-judge scoring the transcript against the phase's derived rubric + targeted checks. Stronger model. | `harness.judge_transcript` |
+| **Diff** | Drives a baseline version, replays the same turns against a candidate, and reports the delta + a pairwise comparison. | `run_coach_eval_diff` command |
 | **Scenario builder** | Drives a persona from the intro phase and (optionally) freezes the end-state as a per-phase starting scenario. | `build_eval_scenario` command |
 
 ### Models used by the harness
@@ -203,9 +205,10 @@ scenarios.
   `build_eval_scenario` chain builder (dry-run by default, opt-in freeze); seeding
   the eval directly from a frozen scenario (`--from-scenario`); rubrics derived
   live from the phase `Prompt.body` + per-phase targeted checks; replay mode
-  (`--save-run` / `--replay`) to re-run the exact user turns against a new prompt.
-- **Planned:** baseline-vs-candidate diffing (over replayed turns) and a
-  `run_coach_eval` MCP tool. See the [Roadmap](/docs/testing/eval-harness/roadmap).
+  (`--save-run` / `--replay`) to re-run the exact user turns against a new prompt;
+  baseline↔candidate diffing (`run_coach_eval_diff`) with a pairwise judge.
+- **Planned:** transcript caching, a `run_coach_eval` MCP tool, and suites /
+  k-run pass rates. See the [Roadmap](/docs/testing/eval-harness/roadmap).
 
 ## Related Documentation
 

--- a/docs/docs/testing/eval-harness/roadmap.md
+++ b/docs/docs/testing/eval-harness/roadmap.md
@@ -50,12 +50,15 @@ The core loop and the scenario-building tooling are in place.
   coach-model/version are replay defaults; override with the flags (typically a new
   `--prompt-version`). See
   [Running Evals → Replay](/docs/testing/eval-harness/running-evals#replay-a-run).
+- **Baseline ↔ candidate diff** — `run_coach_eval_diff` drives a baseline version
+  with the user-bot, replays the *same* user turns against a candidate version, and
+  reports the delta: per-version quality score, targeted-check changes
+  (fixed/regressed), progression, and a **pairwise** judge that compares the two
+  transcripts directly. See
+  [Running Evals → Diffing two versions](/docs/testing/eval-harness/running-evals#diffing-two-versions).
 
 ## Planned
 
-- **Baseline ↔ candidate diff** — run two prompt versions over the *same* (replayed)
-  user turns and report the delta (progression, targeted checks, per-version rubric
-  scores, pairwise preference).
 - **Transcript caching** — persist baseline transcripts keyed on
   `(phase, prompt_version, model, scenario, user_turns)` — *not* on the rubric — so
   a baseline is generated once and re-judged cheaply when requirements change. See

--- a/docs/docs/testing/eval-harness/running-evals.md
+++ b/docs/docs/testing/eval-harness/running-evals.md
@@ -190,11 +190,52 @@ the only variable:
      python manage.py run_coach_eval_spike --replay /tmp/v10.json --prompt-version 11
    ```
 4. **Compare the two reports** — quality score + per-criterion reasoning, targeted
-   checks, and progression. (An automated baseline↔candidate *diff* command is the
-   [next roadmap item](/docs/testing/eval-harness/roadmap).)
+   checks, and progression.
+
+For a one-shot, structured comparison, use the [diff command](#diffing-two-versions)
+instead of eyeballing two reports.
 
 The version pin is **phase-scoped** (details:
 [Prompt Version Pinning](/docs/testing/eval-harness/prompt-versioning)).
+
+## Diffing two versions
+
+`run_coach_eval_diff` automates the before/after in one command: it drives the
+**baseline** version with the user-bot, **replays the same user turns** against the
+**candidate** version, then reports the delta.
+
+```bash
+docker exec dev-coach-local-backend-1 \
+  python manage.py run_coach_eval_diff \
+    --from-scenario "[Auto] Casey @ get_to_know_you" \
+    --baseline-version 10 --candidate-version 11 \
+    --out /tmp/diff.json
+```
+
+It reports four things:
+
+- **Quality** — each version's judge score against **its own** prompt body (a v11
+  run is judged against v11's instructions). Because the standard differs per
+  version, treat this as "does each version do what it intends?", not a like-for-like
+  number — the pairwise result below is the apples-to-apples call.
+- **Targeted checks** — the same assertions run against both, paired by text and
+  labelled `fixed` / `regressed` / `same` / `new`. These *are* like-for-like (the
+  checks are constant across versions).
+- **Progression** — whether each version transitioned the phase.
+- **Pairwise** — the judge sees **both transcripts over identical client turns**
+  (blind-labelled Coach A / Coach B) and picks the better one, per aspect, with
+  reasoning. This is the most reliable signal — comparing two transcripts directly
+  beats differencing two absolute scores.
+
+Flags: `--baseline-version` / `--candidate-version` (both default to latest active;
+a warning fires if they resolve equal), `--from-scenario`, `--persona`,
+`--coach-model` (one model for both runs — the prompt is the variable), `--check`,
+`--max-turns`, `--out PATH`, `--keep`.
+
+> **One sample, live coach.** Replay fixes the *user* turns, but the coach is still
+> a live LLM and the pairwise judge has mild position bias — one diff is a single
+> data point. For a decision, run it a few times and weigh the targeted checks
+> (deterministic) alongside the pairwise trend.
 
 ## Reading the report
 

--- a/docs/docs/testing/eval-harness/running-evals.md
+++ b/docs/docs/testing/eval-harness/running-evals.md
@@ -204,12 +204,20 @@ The version pin is **phase-scoped** (details:
 **baseline** version with the user-bot, **replays the same user turns** against the
 **candidate** version, then reports the delta.
 
+Versions default the way you'd want: **candidate = the latest active version** (the
+one the coach actually runs), **baseline = the version right before it**. So a bare
+run compares "previous vs latest" — exactly the common case after you publish a new
+version. Override either flag to diff against an older version.
+
 ```bash
+# Previous vs latest (the usual case — no version flags needed):
 docker exec dev-coach-local-backend-1 \
   python manage.py run_coach_eval_diff \
-    --from-scenario "[Auto] Casey @ get_to_know_you" \
-    --baseline-version 10 --candidate-version 11 \
-    --out /tmp/diff.json
+    --from-scenario "[Auto] Casey @ get_to_know_you" --out /tmp/diff.json
+
+# Or pin specific versions:
+docker exec dev-coach-local-backend-1 \
+  python manage.py run_coach_eval_diff --baseline-version 4 --candidate-version 6
 ```
 
 It reports four things:
@@ -227,10 +235,12 @@ It reports four things:
   reasoning. This is the most reliable signal — comparing two transcripts directly
   beats differencing two absolute scores.
 
-Flags: `--baseline-version` / `--candidate-version` (both default to latest active;
-a warning fires if they resolve equal), `--from-scenario`, `--persona`,
-`--coach-model` (one model for both runs — the prompt is the variable), `--check`,
-`--max-turns`, `--out PATH`, `--keep`.
+Flags: `--candidate-version` (defaults to latest active), `--baseline-version`
+(defaults to the version right before the candidate), `--from-scenario`,
+`--persona`, `--coach-model` (one model for both runs — the prompt is the
+variable), `--check`, `--max-turns`, `--out PATH`, `--keep`. If there's no version
+below the candidate (only one exists), it errors and asks you to pass
+`--baseline-version`.
 
 > **One sample, live coach.** Replay fixes the *user* turns, but the coach is still
 > a live LLM and the pairwise judge has mild position bias — one diff is a single

--- a/server/apps/coach/eval/harness.py
+++ b/server/apps/coach/eval/harness.py
@@ -10,20 +10,30 @@ whatever prompts are currently active in the database.
 """
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
+from django.contrib.auth import get_user_model
 from pydantic import BaseModel, Field
 
 from apps.actions.models import Action
 from apps.chat_messages.models import ChatMessage
+from apps.coach.functions.public.process_message import process_message
+from apps.coach_states.models import CoachState
 from apps.coach_states.serializers.coach_state_serializer import CoachStateSerializer
 from apps.prompts.models import Prompt
+from apps.test_scenario.functions.admin.instantiate_test_scenario import (
+    instantiate_test_scenario,
+)
+from apps.test_scenario.models import TestScenario
 from enums.ai import AIModel
 from enums.component_type import ComponentType
 from enums.message_role import MessageRole
 from enums.prompt_type import PromptType
 from services.ai.utils.openai import structured_completion
+
+User = get_user_model()
 
 # Component types that genuinely GATE the conversation — the client must click a
 # button (which carries a real action) to proceed. Other components (e.g.
@@ -298,3 +308,252 @@ def collect_new_actions(user, seen_ids: set) -> list:
             {"action": a.action_type, "params": a.parameters, "summary": a.result_summary}
         )
     return out
+
+
+# --- seeding ------------------------------------------------------------------
+#
+# Two ways to put a throwaway user into the state an eval starts from: a cold
+# user freshly created at a phase, or a full hydration of a frozen TestScenario
+# (real prior history). Both are idempotent and shared by the eval commands.
+
+
+def seed_cold_user(email: str, phase: str) -> "User":
+    """Create a fresh throwaway user at `phase` (deleting any prior one)."""
+    User.objects.filter(email=email).delete()  # idempotent
+    user = User.objects.create_user(email=email, password="Coach123!")
+    coach_state = CoachState.objects.get(user=user)  # auto-created by signal
+    coach_state.current_phase = phase
+    coach_state.save(update_fields=["current_phase"])
+    return user
+
+
+def seed_scenario_user(name: str) -> Tuple["User", str, str]:
+    """Hydrate a frozen TestScenario and return (user, email, start_phase).
+
+    Full hydration (chat history, identities, coach state, notes, actions,
+    breaks) so the eval resumes from real prior history. The start phase is
+    whatever the scenario's coach state was frozen at. Raises
+    TestScenario.DoesNotExist if no scenario has that exact name.
+    """
+    scenario = TestScenario.objects.get(name=name)
+    result = instantiate_test_scenario(
+        scenario,
+        create_user=True,
+        create_chat_messages=True,
+        create_identities=True,
+        create_coach_state=True,
+        create_user_notes=True,
+        create_actions=True,
+        create_breaks=True,
+    )
+    user = result["user"]
+    start_phase = CoachState.objects.get(user=user).current_phase
+    return user, result["email"], start_phase
+
+
+# --- driving one conversation -------------------------------------------------
+
+
+@dataclass
+class DriveResult:
+    """The outcome of driving one eval conversation."""
+
+    transcript: Transcript
+    user_turns: List[str]
+    actions: list
+    final_coach_state: dict
+    final_phase: str
+    run_error: Optional[str] = None
+
+
+def drive_eval(
+    user,
+    *,
+    coach_model: AIModel,
+    prompt_versions: Optional[dict],
+    start_phase: str,
+    max_turns: int,
+    harness_client=None,
+    persona: Optional[PersonaSpec] = None,
+    prior: Optional[Transcript] = None,
+    replay_turns: Optional[List[str]] = None,
+    emit: Optional[Callable[[str, str], None]] = None,
+) -> DriveResult:
+    """Drive ONE eval conversation against the real coach pipeline.
+
+    Supply either a `persona` (the user-bot generates each turn) or
+    `replay_turns` (recorded turns replayed verbatim). Component gates
+    (video/break) are clicked through dynamically and don't consume a turn. The
+    loop stops on phase transition, on pipeline error, when the turn budget is
+    hit, or when replay turns run out.
+
+    `emit(kind, text)` receives live progress events for the caller to render —
+    kinds: "gate", "client", "coach", "action", "info", "error". Defaults to a
+    no-op. Returns a DriveResult; a pipeline failure is reported via
+    `run_error` (not raised) so the caller can treat it as an error outcome
+    rather than a coaching-quality result.
+    """
+    emit = emit or (lambda kind, text: None)
+    prior = prior or []
+    transcript: Transcript = []
+    replay_idx = 0
+    # Prior-history actions exist on a hydrated user; record their ids so only
+    # actions taken DURING this run are reported.
+    seen_action_ids = set(
+        Action.objects.filter(user=user).values_list("id", flat=True)
+    )
+    actions: list = []
+    run_error = None
+
+    for _ in range(max_turns):
+        comp = pending_component(user)
+        if comp:
+            acts = primary_button_actions(comp)
+            emit("gate", f"{comp.get('component_type')} -> {[a.get('action') for a in acts]}")
+            ok, data, err = process_message(
+                user, None, acts, coach_model, prompt_versions
+            )
+        else:
+            if replay_turns is not None:
+                if replay_idx >= len(replay_turns):
+                    emit("info", f"replay exhausted after {replay_idx} user turns")
+                    break
+                user_msg = replay_turns[replay_idx]
+                replay_idx += 1
+            else:
+                user_msg = user_bot_reply(
+                    harness_client, DEFAULT_USER_BOT_MODEL, persona, prior + transcript
+                )
+            transcript.append(("user", user_msg))
+            emit("client", user_msg)
+            ok, data, err = process_message(
+                user, user_msg, None, coach_model, prompt_versions
+            )
+
+        if not ok:
+            run_error = err
+            emit("error", err)
+            break
+
+        coach_msg = data.get("message", "")
+        if coach_msg:
+            transcript.append(("coach", coach_msg))
+            emit("coach", coach_msg)
+
+        coach_state = CoachState.objects.get(user=user)
+        new_actions = collect_new_actions(user, seen_action_ids)
+        actions.extend(new_actions)
+        if new_actions:
+            emit("action", ", ".join(a["action"] for a in new_actions))
+
+        if coach_state.current_phase != start_phase:
+            emit("info", f"phase transitioned to: {coach_state.current_phase}")
+            break
+
+    final_coach_state = coach_state_snapshot(CoachState.objects.get(user=user))
+    return DriveResult(
+        transcript=transcript,
+        user_turns=[t[1] for t in transcript if t[0] == "user"],
+        actions=actions,
+        final_coach_state=final_coach_state,
+        final_phase=final_coach_state["current_phase"],
+        run_error=run_error,
+    )
+
+
+# --- judging ------------------------------------------------------------------
+#
+# The rubric is DERIVED LIVE from the phase's own coach Prompt.body (the same
+# version the coach ran): the judge is asked "did the coach follow these
+# instructions?" and derives the criteria from the body itself, so it tracks the
+# prompt automatically and needs no maintenance. Targeted checks layer explicit,
+# hand-authored pass/fail assertions on top.
+
+JUDGE_FRAMING = (
+    "You are a strict but fair judge evaluating a COACH in an identity coaching "
+    "conversation. Judge ONLY the coach's messages (role=coach).\n\n"
+    "The standard is the coach's OWN phase instructions, shown below. Decide "
+    "whether the coach actually FOLLOWED them in the transcript. Focus on "
+    "behavioral and conversational adherence — IGNORE output formatting, JSON, "
+    "and action/tool mechanics (those are enforced elsewhere and are not your "
+    "concern). Placeholders like {curly_braces} in the instructions are filled "
+    "with live data at runtime; judge the intent behind them, not the literal "
+    "placeholder.\n\n"
+    "Derive the key behavioral expectations from the instructions yourself, score "
+    "the coach on each as a criterion, and give an overall pass/fail + 1-5 score."
+)
+
+
+class CriterionScore(BaseModel):
+    name: str
+    passed: bool
+    note: str
+
+
+class CheckResult(BaseModel):
+    """Verdict on one explicit, hand-authored targeted check."""
+
+    check: str = Field(description="The targeted check being evaluated (echoed).")
+    passed: bool
+    note: str
+
+
+class JudgeVerdict(BaseModel):
+    """LLM-as-judge verdict over the full transcript."""
+
+    passed: bool = Field(description="Overall pass/fail for the coach.")
+    score: int = Field(description="Overall quality score 1-5.")
+    criteria: List[CriterionScore] = Field(
+        description="Criteria derived from the phase instructions, each scored."
+    )
+    targeted_checks: List[CheckResult] = Field(
+        description="One result per supplied targeted check; empty if none given."
+    )
+    reasoning: str
+
+
+def judge_transcript(
+    client,
+    *,
+    phase: str,
+    rubric_body: str,
+    transcript: Transcript,
+    targeted_checks: Optional[List[str]] = None,
+    context: Optional[Transcript] = None,
+    judge_model: AIModel = DEFAULT_JUDGE_MODEL,
+) -> JudgeVerdict:
+    """Judge a transcript against the phase's derived rubric + targeted checks."""
+    convo = render_transcript(transcript, you_label="CLIENT")
+    context_block = ""
+    if context:
+        ctx = render_transcript(context, you_label="CLIENT")
+        context_block = (
+            "PRIOR CONVERSATION (context only — do NOT score these messages; "
+            "they predate the phase under evaluation. Use them only to know "
+            f"what the client already shared):\n\n{ctx}\n\n"
+        )
+    checks_block = ""
+    if targeted_checks:
+        numbered = "\n".join(f"{i + 1}. {c}" for i, c in enumerate(targeted_checks))
+        checks_block = (
+            "TARGETED CHECKS — in addition to the rubric, evaluate each of these "
+            "explicit requirements as a hard yes/no and return a verdict + note "
+            "for each in `targeted_checks` (echo the check text "
+            f"verbatim):\n{numbered}\n\n"
+        )
+    system = (
+        f"{JUDGE_FRAMING}\n\n"
+        f"--- BEGIN {phase} PHASE INSTRUCTIONS ---\n{rubric_body}\n"
+        f"--- END {phase} PHASE INSTRUCTIONS ---\n\n"
+        f"{checks_block}{context_block}"
+        f"Transcript to evaluate:\n\n{convo}\n\n"
+        "Return your structured verdict."
+    )
+    completion = structured_completion(
+        client=client,
+        messages=[{"role": "system", "content": system}],
+        model=judge_model,
+        response_format=JudgeVerdict,
+        temperature=0.0,
+    )
+    return completion.choices[0].message.parsed

--- a/server/apps/coach/eval/harness.py
+++ b/server/apps/coach/eval/harness.py
@@ -248,6 +248,22 @@ def load_phase_prompt_body(
     return prompt.body, prompt.version
 
 
+def active_prompt_versions(phase: str) -> List[int]:
+    """Return the active coach-prompt version numbers for `phase`, newest first.
+
+    The coach pipeline always runs the latest (highest) version; this just
+    enumerates what exists so the diff command can resolve "latest" and "the one
+    before latest" as defaults.
+    """
+    return list(
+        Prompt.objects.filter(
+            prompt_type=PromptType.COACH, coaching_phase=phase, is_active=True
+        )
+        .order_by("-version")
+        .values_list("version", flat=True)
+    )
+
+
 def load_targeted_checks(
     phase: str, extra: Optional[List[str]] = None
 ) -> List[str]:

--- a/server/apps/coach/management/commands/run_coach_eval_diff.py
+++ b/server/apps/coach/management/commands/run_coach_eval_diff.py
@@ -25,11 +25,17 @@ differencing two absolute scores).
 Shares all the machinery (seeding, drive loop, judge) with run_coach_eval_spike
 via apps/coach/eval/harness.py.
 
+Versions default the way you'd want: candidate = the LATEST active version (what
+the coach actually runs), baseline = the version right before it. So a bare run
+compares "previous vs latest". Override either with --baseline-version /
+--candidate-version (e.g. to diff against an older version).
+
 Usage:
+    python manage.py run_coach_eval_diff                          # latest-1 vs latest
+    python manage.py run_coach_eval_diff --baseline-version 4     # v4 vs latest
     python manage.py run_coach_eval_diff --baseline-version 10 --candidate-version 11
-    python manage.py run_coach_eval_diff --candidate-version 11   # baseline = latest
     python manage.py run_coach_eval_diff --from-scenario "[Auto] Casey @ get_to_know_you" \
-        --baseline-version 10 --candidate-version 11 --out /tmp/diff.json
+        --out /tmp/diff.json
 """
 
 import json
@@ -43,6 +49,7 @@ from apps.coach.eval.harness import (
     DEFAULT_JUDGE_MODEL,
     DEFAULT_USER_BOT_MODEL,
     Transcript,
+    active_prompt_versions,
     chat_history_transcript,
     drive_eval,
     judge_transcript,
@@ -102,13 +109,16 @@ class Command(BaseCommand):
             "--baseline-version",
             type=int,
             default=None,
-            help="Baseline prompt version. Defaults to the latest active.",
+            help=(
+                "Baseline prompt version (the OLD one). Defaults to the version "
+                "right before the candidate (i.e. latest-1)."
+            ),
         )
         parser.add_argument(
             "--candidate-version",
             type=int,
             default=None,
-            help="Candidate prompt version. Defaults to the latest active.",
+            help="Candidate prompt version (the NEW one). Defaults to the latest active.",
         )
         parser.add_argument(
             "--from-scenario",
@@ -145,6 +155,45 @@ class Command(BaseCommand):
             return user, email, start_phase, chat_history_transcript(user)
         user = seed_cold_user(DIFF_EMAIL, DEFAULT_START_PHASE.value)
         return user, DIFF_EMAIL, DEFAULT_START_PHASE.value, []
+
+    def _resolve_versions(self, phase, baseline_version, candidate_version):
+        """Resolve baseline/candidate to concrete version numbers.
+
+        Candidate defaults to the LATEST active version (what the coach actually
+        runs); baseline defaults to the version right before the candidate. Returns
+        (baseline_v, candidate_v), or None (after printing why) if a version is
+        missing or there's nothing below the candidate to diff against.
+        """
+        versions = active_prompt_versions(phase)  # newest first
+        if not versions:
+            self.stderr.write(self.style.ERROR(
+                f"No active coach prompt for phase '{phase}'."
+            ))
+            return None
+        candidate_v = candidate_version if candidate_version is not None else versions[0]
+        if candidate_v not in versions:
+            self.stderr.write(self.style.ERROR(
+                f"Candidate version v{candidate_v} not found for phase '{phase}'. "
+                f"Active versions: {versions}"
+            ))
+            return None
+        if baseline_version is not None:
+            if baseline_version not in versions:
+                self.stderr.write(self.style.ERROR(
+                    f"Baseline version v{baseline_version} not found for phase "
+                    f"'{phase}'. Active versions: {versions}"
+                ))
+                return None
+            return baseline_version, candidate_v
+        lower = [v for v in versions if v < candidate_v]
+        if not lower:
+            self.stderr.write(self.style.ERROR(
+                f"No version below candidate v{candidate_v} for phase '{phase}' "
+                f"(active versions: {versions}). Create a newer prompt version or "
+                "pass --baseline-version explicitly."
+            ))
+            return None
+        return lower[0], candidate_v  # lower[0] is the largest below candidate
 
     def _make_emit(self, label):
         def emit(kind: str, text: str) -> None:
@@ -238,13 +287,6 @@ class Command(BaseCommand):
         baseline_version = options["baseline_version"]
         candidate_version = options["candidate_version"]
 
-        if baseline_version == candidate_version:
-            self.stdout.write(self.style.WARNING(
-                "NOTE: baseline and candidate resolve to the same version "
-                f"({baseline_version if baseline_version is not None else 'latest'}) "
-                "— the diff will only reflect coach/user-bot nondeterminism."
-            ))
-
         cleanup_emails = set()
         try:
             # --- Baseline: drive fresh with the user-bot ----------------------
@@ -260,17 +302,32 @@ class Command(BaseCommand):
                 ))
                 return
             cleanup_emails.add(email)
+
+            # Resolve versions now that we know the phase. Candidate defaults to
+            # the LATEST active version (what the coach actually runs); baseline
+            # defaults to the version right before it. v1 is never a default.
+            resolved = self._resolve_versions(
+                start_phase, baseline_version, candidate_version
+            )
+            if resolved is None:
+                return
+            baseline_v, candidate_v = resolved
+            if baseline_v == candidate_v:
+                self.stdout.write(self.style.WARNING(
+                    f"NOTE: baseline and candidate are both v{baseline_v} — the diff "
+                    "will only reflect coach/user-bot nondeterminism."
+                ))
             targeted_checks = load_targeted_checks(start_phase, options["check"])
 
             self.stdout.write(self.style.HTTP_INFO(
                 f"Diff | persona: {persona.name} | coach: {coach_model.value} "
                 f"| phase: {start_phase} | seed: {scenario_name or 'cold get_to_know_you'} "
-                f"| baseline v{baseline_version or 'latest'} vs candidate "
-                f"v{candidate_version or 'latest'} | checks: {len(targeted_checks)}"
+                f"| baseline v{baseline_v} vs candidate v{candidate_v} "
+                f"| checks: {len(targeted_checks)}"
             ))
 
             baseline = self._run_side(
-                label="baseline", version=baseline_version, user=user,
+                label="baseline", version=baseline_v, user=user,
                 start_phase=start_phase, prior=prior, coach_model=coach_model,
                 max_turns=max_turns, harness_client=harness_client,
                 targeted_checks=targeted_checks, persona=persona, replay_turns=None,
@@ -283,7 +340,7 @@ class Command(BaseCommand):
             user, email, start_phase, prior = self._seed(scenario_name)
             cleanup_emails.add(email)
             candidate = self._run_side(
-                label="candidate", version=candidate_version, user=user,
+                label="candidate", version=candidate_v, user=user,
                 start_phase=start_phase, prior=prior, coach_model=coach_model,
                 max_turns=max_turns, harness_client=harness_client,
                 targeted_checks=targeted_checks, persona=None, replay_turns=user_turns,
@@ -292,7 +349,7 @@ class Command(BaseCommand):
                 return
 
             # --- Pairwise comparison over the two transcripts -----------------
-            candidate_body, _ = load_phase_prompt_body(start_phase, candidate_version)
+            candidate_body, _ = load_phase_prompt_body(start_phase, candidate_v)
             pairwise = self._pairwise(
                 harness_client,
                 phase=start_phase,

--- a/server/apps/coach/management/commands/run_coach_eval_diff.py
+++ b/server/apps/coach/management/commands/run_coach_eval_diff.py
@@ -1,0 +1,428 @@
+"""
+run_coach_eval_diff
+
+Baseline ↔ candidate diff for coach prompt changes — "did my edit help?".
+
+Runs the SAME conversation against two prompt versions and reports the delta:
+
+    seed user at a phase
+        -> drive BASELINE (--baseline-version) with the user-bot, judge it
+        -> RE-seed an identical user
+        -> REPLAY the baseline's exact user turns against CANDIDATE
+           (--candidate-version), judge it
+        -> pairwise judge: show both coach transcripts (same client turns) and
+           ask which performed better
+        -> report the delta (quality score, targeted checks, progression,
+           pairwise preference)
+
+Replay holds the user side fixed, so the prompt version is the only thing that
+differs between the two runs. Each run's quality rubric is still derived from its
+OWN prompt body (a v11 run is judged against v11's instructions); the targeted
+checks are constant across versions, so they give a clean apples-to-apples delta.
+The pairwise judge compares the two transcripts directly (more reliable than
+differencing two absolute scores).
+
+Shares all the machinery (seeding, drive loop, judge) with run_coach_eval_spike
+via apps/coach/eval/harness.py.
+
+Usage:
+    python manage.py run_coach_eval_diff --baseline-version 10 --candidate-version 11
+    python manage.py run_coach_eval_diff --candidate-version 11   # baseline = latest
+    python manage.py run_coach_eval_diff --from-scenario "[Auto] Casey @ get_to_know_you" \
+        --baseline-version 10 --candidate-version 11 --out /tmp/diff.json
+"""
+
+import json
+from typing import List, Optional
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+from pydantic import BaseModel, Field
+
+from apps.coach.eval.harness import (
+    DEFAULT_JUDGE_MODEL,
+    DEFAULT_USER_BOT_MODEL,
+    Transcript,
+    chat_history_transcript,
+    drive_eval,
+    judge_transcript,
+    load_phase_prompt_body,
+    load_persona,
+    load_targeted_checks,
+    render_transcript,
+    save_eval_run,
+    seed_cold_user,
+    seed_scenario_user,
+)
+from apps.test_scenario.models import TestScenario
+from enums.ai import AIModel
+from enums.coaching_phase import CoachingPhase
+from services.ai.ai_service_factory import AIServiceFactory
+from services.ai.utils.openai import structured_completion
+
+User = get_user_model()
+
+DIFF_EMAIL = "coach-eval-diff@testscenario.com"
+DEFAULT_START_PHASE = CoachingPhase.GET_TO_KNOW_YOU
+
+# A/B are shown to the pairwise judge instead of baseline/candidate so it can't
+# be biased toward "the newer one". We map back after.
+_AB_TO_ROLE = {"A": "baseline", "B": "candidate", "tie": "tie"}
+
+
+class PairwiseAspect(BaseModel):
+    aspect: str
+    winner: str = Field(description="'A', 'B', or 'tie'.")
+    note: str
+
+
+class PairwiseVerdict(BaseModel):
+    """Direct comparison of two coach transcripts over identical client turns."""
+
+    winner: str = Field(description="Overall better coach: 'A', 'B', or 'tie'.")
+    aspects: List[PairwiseAspect] = Field(
+        description="Per-aspect comparisons (e.g. warmth, focus, forward motion)."
+    )
+    reasoning: str
+
+
+class Command(BaseCommand):
+    help = "Diff two coach prompt versions over the same (replayed) conversation."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--max-turns", type=int, default=20)
+        parser.add_argument("--persona", type=str, default="casey")
+        parser.add_argument(
+            "--coach-model",
+            type=str,
+            default=None,
+            help="Coach model for BOTH runs (the variable is the prompt, not the model).",
+        )
+        parser.add_argument(
+            "--baseline-version",
+            type=int,
+            default=None,
+            help="Baseline prompt version. Defaults to the latest active.",
+        )
+        parser.add_argument(
+            "--candidate-version",
+            type=int,
+            default=None,
+            help="Candidate prompt version. Defaults to the latest active.",
+        )
+        parser.add_argument(
+            "--from-scenario",
+            type=str,
+            default=None,
+            metavar="NAME",
+            help="Seed both runs from a frozen TestScenario instead of cold-seeding.",
+        )
+        parser.add_argument(
+            "--check",
+            action="append",
+            default=None,
+            metavar="ASSERTION",
+            help="Add a one-off targeted check (repeatable), on top of the phase file.",
+        )
+        parser.add_argument(
+            "--out",
+            type=str,
+            default=None,
+            metavar="PATH",
+            help="Write the full diff report to PATH as JSON.",
+        )
+        parser.add_argument(
+            "--keep",
+            action="store_true",
+            help="Keep the throwaway test user instead of deleting it on exit.",
+        )
+
+    # --- seeding (fresh, identical state for each run) -------------------------
+    def _seed(self, scenario_name):
+        """Return (user, cleanup_email, start_phase, prior) for a fresh run."""
+        if scenario_name:
+            user, email, start_phase = seed_scenario_user(scenario_name)
+            return user, email, start_phase, chat_history_transcript(user)
+        user = seed_cold_user(DIFF_EMAIL, DEFAULT_START_PHASE.value)
+        return user, DIFF_EMAIL, DEFAULT_START_PHASE.value, []
+
+    def _make_emit(self, label):
+        def emit(kind: str, text: str) -> None:
+            if kind == "client":
+                self.stdout.write(self.style.WARNING(f"[{label}] CLIENT: {text}"))
+            elif kind == "coach":
+                self.stdout.write(self.style.SUCCESS(f"[{label}] COACH: {text}"))
+            elif kind == "error":
+                self.stderr.write(self.style.ERROR(f"[{label}] failed: {text}"))
+            # gate/action/info are suppressed in diff mode to keep output readable
+        return emit
+
+    def _pairwise(self, client, *, phase, reference_body, transcript_a, transcript_b):
+        convo_a = render_transcript(transcript_a, you_label="CLIENT")
+        convo_b = render_transcript(transcript_b, you_label="CLIENT")
+        system = (
+            "You are comparing two COACHES, A and B, who each responded to the "
+            f"SAME client messages in the {phase} phase of identity coaching. The "
+            "client's turns are identical in both transcripts; only the coach "
+            "differs. Decide which coach served the client better. Judge coaching "
+            "behavior and conversational quality — IGNORE output formatting/JSON.\n\n"
+            "Reference — the intended behavior for this phase:\n"
+            f"--- BEGIN INSTRUCTIONS ---\n{reference_body}\n--- END INSTRUCTIONS ---\n\n"
+            f"=== COACH A ===\n{convo_a}\n\n=== COACH B ===\n{convo_b}\n\n"
+            "Return winner ('A', 'B', or 'tie'), per-aspect comparisons, and your "
+            "reasoning. Be willing to call a genuine 'tie'."
+        )
+        completion = structured_completion(
+            client=client,
+            messages=[{"role": "system", "content": system}],
+            model=DEFAULT_JUDGE_MODEL,
+            response_format=PairwiseVerdict,
+            temperature=0.0,
+        )
+        return completion.choices[0].message.parsed
+
+    def _run_side(self, *, label, version, user, start_phase, prior, coach_model,
+                  max_turns, harness_client, targeted_checks, persona, replay_turns):
+        """Drive (or replay) one side, judge it against its own prompt body, and
+        return a dict describing the run, or None if its prompt is missing or the
+        pipeline errored."""
+        rubric_body, rubric_version = load_phase_prompt_body(start_phase, version)
+        if not rubric_body:
+            self.stderr.write(self.style.ERROR(
+                f"No active coach prompt for phase '{start_phase}'"
+                + (f" at version {version}" if version else "") + f" ({label})."
+            ))
+            return None
+        self.stdout.write(self.style.MIGRATE_HEADING(
+            f"\n=== {label.upper()} (prompt v{rubric_version}) ==="
+        ))
+        prompt_versions = {start_phase: version} if version is not None else None
+        run = drive_eval(
+            user,
+            coach_model=coach_model,
+            prompt_versions=prompt_versions,
+            start_phase=start_phase,
+            max_turns=max_turns,
+            harness_client=harness_client,
+            persona=persona,
+            prior=prior,
+            replay_turns=replay_turns,
+            emit=self._make_emit(label),
+        )
+        if run.run_error is not None:
+            self.stderr.write(self.style.ERROR(
+                f"{label} run failed: {run.run_error} — cannot diff."
+            ))
+            return None
+        verdict = judge_transcript(
+            harness_client,
+            phase=start_phase,
+            rubric_body=rubric_body,
+            transcript=run.transcript,
+            targeted_checks=targeted_checks,
+            context=prior,
+        )
+        return {
+            "prompt_version": rubric_version,
+            "run": run,
+            "verdict": verdict,
+        }
+
+    # --- orchestration --------------------------------------------------------
+    def handle(self, *args, **options):
+        coach_model = AIModel.get_or_default(options["coach_model"])
+        persona = load_persona(options["persona"])
+        harness_client = AIServiceFactory.create(DEFAULT_USER_BOT_MODEL).client
+        scenario_name = options["from_scenario"]
+        max_turns = options["max_turns"]
+        baseline_version = options["baseline_version"]
+        candidate_version = options["candidate_version"]
+
+        if baseline_version == candidate_version:
+            self.stdout.write(self.style.WARNING(
+                "NOTE: baseline and candidate resolve to the same version "
+                f"({baseline_version if baseline_version is not None else 'latest'}) "
+                "— the diff will only reflect coach/user-bot nondeterminism."
+            ))
+
+        cleanup_emails = set()
+        try:
+            # --- Baseline: drive fresh with the user-bot ----------------------
+            try:
+                user, email, start_phase, prior = self._seed(scenario_name)
+            except TestScenario.DoesNotExist:
+                names = list(
+                    TestScenario.objects.order_by("name").values_list("name", flat=True)
+                )
+                self.stderr.write(self.style.ERROR(
+                    f"No TestScenario named '{scenario_name}'. Available:\n  "
+                    + "\n  ".join(names or ["(none)"])
+                ))
+                return
+            cleanup_emails.add(email)
+            targeted_checks = load_targeted_checks(start_phase, options["check"])
+
+            self.stdout.write(self.style.HTTP_INFO(
+                f"Diff | persona: {persona.name} | coach: {coach_model.value} "
+                f"| phase: {start_phase} | seed: {scenario_name or 'cold get_to_know_you'} "
+                f"| baseline v{baseline_version or 'latest'} vs candidate "
+                f"v{candidate_version or 'latest'} | checks: {len(targeted_checks)}"
+            ))
+
+            baseline = self._run_side(
+                label="baseline", version=baseline_version, user=user,
+                start_phase=start_phase, prior=prior, coach_model=coach_model,
+                max_turns=max_turns, harness_client=harness_client,
+                targeted_checks=targeted_checks, persona=persona, replay_turns=None,
+            )
+            if baseline is None:
+                return
+            user_turns = baseline["run"].user_turns
+
+            # --- Candidate: re-seed identical, replay the same user turns ------
+            user, email, start_phase, prior = self._seed(scenario_name)
+            cleanup_emails.add(email)
+            candidate = self._run_side(
+                label="candidate", version=candidate_version, user=user,
+                start_phase=start_phase, prior=prior, coach_model=coach_model,
+                max_turns=max_turns, harness_client=harness_client,
+                targeted_checks=targeted_checks, persona=None, replay_turns=user_turns,
+            )
+            if candidate is None:
+                return
+
+            # --- Pairwise comparison over the two transcripts -----------------
+            candidate_body, _ = load_phase_prompt_body(start_phase, candidate_version)
+            pairwise = self._pairwise(
+                harness_client,
+                phase=start_phase,
+                reference_body=candidate_body,
+                transcript_a=baseline["run"].transcript,
+                transcript_b=candidate["run"].transcript,
+            )
+
+            self._report(
+                start_phase=start_phase,
+                scenario_name=scenario_name,
+                persona=persona,
+                coach_model=coach_model,
+                user_turns=user_turns,
+                targeted_checks=targeted_checks,
+                baseline=baseline,
+                candidate=candidate,
+                pairwise=pairwise,
+                out_path=options["out"],
+            )
+        finally:
+            if not options["keep"]:
+                for email in cleanup_emails:
+                    User.objects.filter(email=email).delete()
+                self.stdout.write("\n(cleaned up throwaway users)")
+            else:
+                self.stdout.write(f"\n(kept throwaway users: {sorted(cleanup_emails)})")
+
+    # --- reporting ------------------------------------------------------------
+    def _check_deltas(self, baseline_verdict, candidate_verdict):
+        """Pair targeted-check results by check text; classify each change."""
+        b = {c.check: c.passed for c in baseline_verdict.targeted_checks}
+        out = []
+        for c in candidate_verdict.targeted_checks:
+            was = b.get(c.check)
+            if was is None:
+                change = "new"
+            elif was == c.passed:
+                change = "same"
+            elif c.passed:
+                change = "fixed"
+            else:
+                change = "regressed"
+            out.append({
+                "check": c.check,
+                "baseline": was,
+                "candidate": c.passed,
+                "change": change,
+            })
+        return out
+
+    def _report(self, *, start_phase, scenario_name, persona, coach_model,
+                user_turns, targeted_checks, baseline, candidate, pairwise, out_path):
+        bv, cv = baseline["verdict"], candidate["verdict"]
+        b_phase = baseline["run"].final_phase
+        c_phase = candidate["run"].final_phase
+        check_deltas = self._check_deltas(bv, cv)
+        winner_role = _AB_TO_ROLE.get(pairwise.winner.strip(), pairwise.winner)
+
+        report = {
+            "phase": start_phase,
+            "scenario": scenario_name or "cold get_to_know_you",
+            "persona": persona.persona_id,
+            "coach_model": coach_model.value,
+            "user_turns": user_turns,
+            "baseline": {
+                "prompt_version": baseline["prompt_version"],
+                "quality": {"passed": bv.passed, "score": bv.score},
+                "final_phase": b_phase,
+                "transitioned": b_phase != start_phase,
+            },
+            "candidate": {
+                "prompt_version": candidate["prompt_version"],
+                "quality": {"passed": cv.passed, "score": cv.score},
+                "final_phase": c_phase,
+                "transitioned": c_phase != start_phase,
+            },
+            "deltas": {
+                "quality_score": cv.score - bv.score,
+                "targeted_checks": check_deltas,
+            },
+            "pairwise": {
+                "winner": winner_role,
+                "aspects": [
+                    {"aspect": a.aspect, "winner": _AB_TO_ROLE.get(a.winner.strip(), a.winner), "note": a.note}
+                    for a in pairwise.aspects
+                ],
+                "reasoning": pairwise.reasoning,
+            },
+        }
+
+        self.stdout.write("\n" + "=" * 70)
+        self.stdout.write(self.style.MIGRATE_HEADING("DIFF REPORT"))
+        self.stdout.write(json.dumps(report, indent=2))
+        self.stdout.write("=" * 70)
+        if out_path:
+            save_eval_run(out_path, report)
+            self.stdout.write(self.style.SUCCESS(f"(wrote diff -> {out_path})"))
+
+        # --- terminal summary ---
+        bvers, cvers = baseline["prompt_version"], candidate["prompt_version"]
+        self.stdout.write(self.style.HTTP_INFO(
+            f"\nPROMPTS:  baseline v{bvers}  vs  candidate v{cvers}"
+        ))
+        delta = cv.score - bv.score
+        arrow = "▲" if delta > 0 else ("▼" if delta < 0 else "=")
+        q_style = self.style.SUCCESS if delta > 0 else (
+            self.style.ERROR if delta < 0 else self.style.HTTP_INFO)
+        self.stdout.write(q_style(
+            f"QUALITY:  v{bvers} {bv.score}/5  ->  v{cvers} {cv.score}/5  ({arrow} {delta:+d})"
+        ))
+        if targeted_checks:
+            fixed = [d["check"] for d in check_deltas if d["change"] == "fixed"]
+            regressed = [d["check"] for d in check_deltas if d["change"] == "regressed"]
+            b_pass = sum(1 for d in check_deltas if d["baseline"])
+            c_pass = sum(1 for d in check_deltas if d["candidate"])
+            c_style = self.style.ERROR if regressed else self.style.SUCCESS
+            self.stdout.write(c_style(
+                f"CHECKS:   v{bvers} {b_pass}/{len(check_deltas)}  ->  "
+                f"v{cvers} {c_pass}/{len(check_deltas)}  "
+                f"(fixed {len(fixed)}, regressed {len(regressed)})"
+            ))
+            for d in check_deltas:
+                if d["change"] in ("fixed", "regressed", "new"):
+                    mark = {"fixed": "▲", "regressed": "▼", "new": "+"}[d["change"]]
+                    self.stdout.write(self.style.HTTP_INFO(f"  {mark} {d['check']}"))
+        self.stdout.write(self.style.HTTP_INFO(
+            f"PROGRESS: v{bvers} {'transitioned' if b_phase != start_phase else 'no'}"
+            f"  ->  v{cvers} {'transitioned' if c_phase != start_phase else 'no'}"
+        ))
+        p_style = self.style.SUCCESS if winner_role == "candidate" else (
+            self.style.ERROR if winner_role == "baseline" else self.style.HTTP_INFO)
+        self.stdout.write(p_style(f"PAIRWISE: {winner_role} preferred"))

--- a/server/apps/coach/management/commands/run_coach_eval_spike.py
+++ b/server/apps/coach/management/commands/run_coach_eval_spike.py
@@ -13,7 +13,8 @@ assembly from the DB + real coach LLM):
 
 The persona is loaded from a markdown file (see apps/coach/eval/personas/), and
 the loop is component-aware — it clicks through any video/break gates by
-replaying their button actions. Shared pieces live in apps/coach/eval/harness.py.
+replaying their button actions. The reusable pieces (seeding, the drive loop, the
+judge) live in apps/coach/eval/harness.py and are shared with run_coach_eval_diff.
 
 The rubric is DERIVED LIVE from the phase's coach Prompt.body — the judge is
 asked "did the coach follow these instructions?" — so it tracks the prompt
@@ -49,96 +50,41 @@ Usage:
 """
 
 import json
-from typing import List, Optional, Tuple
 
+from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
-from pydantic import BaseModel, Field
 
-from apps.actions.models import Action
 from apps.coach.eval.harness import (
     DEFAULT_JUDGE_MODEL,
     DEFAULT_USER_BOT_MODEL,
     Transcript,
     chat_history_transcript,
-    coach_state_snapshot,
-    collect_new_actions,
+    drive_eval,
+    judge_transcript,
     load_eval_run,
     load_persona,
     load_phase_prompt_body,
     load_targeted_checks,
-    pending_component,
-    primary_button_actions,
-    render_transcript,
     save_eval_run,
-    user_bot_reply,
-)
-from apps.coach.functions.public.process_message import process_message
-from apps.coach_states.models import CoachState
-from apps.test_scenario.functions.admin.instantiate_test_scenario import (
-    instantiate_test_scenario,
+    seed_cold_user,
+    seed_scenario_user,
 )
 from apps.test_scenario.models import TestScenario
-from django.contrib.auth import get_user_model
 from enums.ai import AIModel
 from enums.coaching_phase import CoachingPhase
 from services.ai.ai_service_factory import AIServiceFactory
-from services.ai.utils.openai import structured_completion
 
 User = get_user_model()
 
 SPIKE_EMAIL = "coach-eval-spike@testscenario.com"
 
-# --- The single spike scenario -------------------------------------------------
+# --- The default cold-seed scenario --------------------------------------------
 START_PHASE = CoachingPhase.GET_TO_KNOW_YOU
 # Goal: the get_to_know_you phase should end by transitioning the user onward.
 GOAL_PHASES = {
     CoachingPhase.IDENTITY_WARMUP.value,
     CoachingPhase.IDENTITY_BRAINSTORMING.value,
 }
-
-# How to judge — the WHAT (the criteria) is derived live from the phase's own
-# Prompt.body at runtime; this only frames HOW to apply it.
-JUDGE_FRAMING = (
-    "You are a strict but fair judge evaluating a COACH in an identity coaching "
-    "conversation. Judge ONLY the coach's messages (role=coach).\n\n"
-    "The standard is the coach's OWN phase instructions, shown below. Decide "
-    "whether the coach actually FOLLOWED them in the transcript. Focus on "
-    "behavioral and conversational adherence — IGNORE output formatting, JSON, "
-    "and action/tool mechanics (those are enforced elsewhere and are not your "
-    "concern). Placeholders like {curly_braces} in the instructions are filled "
-    "with live data at runtime; judge the intent behind them, not the literal "
-    "placeholder.\n\n"
-    "Derive the key behavioral expectations from the instructions yourself, score "
-    "the coach on each as a criterion, and give an overall pass/fail + 1-5 score."
-)
-
-
-class CriterionScore(BaseModel):
-    name: str
-    passed: bool
-    note: str
-
-
-class CheckResult(BaseModel):
-    """Verdict on one explicit, hand-authored targeted check."""
-
-    check: str = Field(description="The targeted check being evaluated (echoed).")
-    passed: bool
-    note: str
-
-
-class JudgeVerdict(BaseModel):
-    """LLM-as-judge verdict over the full transcript."""
-
-    passed: bool = Field(description="Overall pass/fail for the coach.")
-    score: int = Field(description="Overall quality score 1-5.")
-    criteria: List[CriterionScore] = Field(
-        description="Criteria derived from the phase instructions, each scored."
-    )
-    targeted_checks: List[CheckResult] = Field(
-        description="One result per supplied targeted check; empty if none given."
-    )
-    reasoning: str
 
 
 class Command(BaseCommand):
@@ -218,83 +164,22 @@ class Command(BaseCommand):
             help="Keep the throwaway test user instead of deleting it on exit.",
         )
 
-    # --- seed -----------------------------------------------------------------
-    def _seed_user(self) -> User:
-        User.objects.filter(email=SPIKE_EMAIL).delete()  # idempotent
-        user = User.objects.create_user(email=SPIKE_EMAIL, password="Coach123!")
-        coach_state = CoachState.objects.get(user=user)  # auto-created by signal
-        coach_state.current_phase = START_PHASE.value
-        coach_state.save(update_fields=["current_phase"])
-        return user
-
-    def _seed_from_scenario(self, name: str) -> Tuple[User, str, str]:
-        """Hydrate a frozen TestScenario and return (user, email, start_phase).
-
-        Full hydration (chat history, identities, coach state, notes, actions,
-        breaks) so the eval resumes from real prior history. The start phase is
-        whatever the scenario's coach state was frozen at. Raises
-        TestScenario.DoesNotExist if no scenario has that exact name.
-        """
-        scenario = TestScenario.objects.get(name=name)
-        result = instantiate_test_scenario(
-            scenario,
-            create_user=True,
-            create_chat_messages=True,
-            create_identities=True,
-            create_coach_state=True,
-            create_user_notes=True,
-            create_actions=True,
-            create_breaks=True,
-        )
-        user = result["user"]
-        start_phase = CoachState.objects.get(user=user).current_phase
-        return user, result["email"], start_phase
-
-    # --- judge ----------------------------------------------------------------
-    def _judge(
-        self,
-        client,
-        *,
-        phase: str,
-        rubric_body: str,
-        transcript: Transcript,
-        targeted_checks: Optional[List[str]] = None,
-        context: Optional[Transcript] = None,
-    ) -> JudgeVerdict:
-        convo = render_transcript(transcript, you_label="CLIENT")
-        context_block = ""
-        if context:
-            ctx = render_transcript(context, you_label="CLIENT")
-            context_block = (
-                "PRIOR CONVERSATION (context only — do NOT score these messages; "
-                "they predate the phase under evaluation. Use them only to know "
-                f"what the client already shared):\n\n{ctx}\n\n"
-            )
-        checks_block = ""
-        if targeted_checks:
-            numbered = "\n".join(f"{i + 1}. {c}" for i, c in enumerate(targeted_checks))
-            checks_block = (
-                "TARGETED CHECKS — in addition to the rubric, evaluate each of "
-                "these explicit requirements as a hard yes/no and return a verdict "
-                "+ note for each in `targeted_checks` (echo the check text "
-                f"verbatim):\n{numbered}\n\n"
-            )
-        system = (
-            f"{JUDGE_FRAMING}\n\n"
-            f"--- BEGIN {phase} PHASE INSTRUCTIONS ---\n{rubric_body}\n"
-            f"--- END {phase} PHASE INSTRUCTIONS ---\n\n"
-            f"{checks_block}{context_block}"
-            f"Transcript to evaluate:\n\n{convo}\n\n"
-            "Return your structured verdict."
-        )
-        completion = structured_completion(
-            client=client,
-            messages=[{"role": "system", "content": system}],
-            model=DEFAULT_JUDGE_MODEL,
-            response_format=JudgeVerdict,
-            temperature=0.0,
-        )
-        return completion.choices[0].message.parsed
+    def _make_emit(self):
+        """Render drive_eval's live progress events with the command's styling."""
+        def emit(kind: str, text: str) -> None:
+            if kind == "gate":
+                self.stdout.write(self.style.HTTP_INFO(f"[click-through: {text}]"))
+            elif kind == "client":
+                self.stdout.write(self.style.WARNING(f"\nCLIENT: {text}"))
+            elif kind == "coach":
+                self.stdout.write(self.style.SUCCESS(f"COACH: {text}"))
+            elif kind == "action":
+                self.stdout.write(self.style.HTTP_INFO(f"  ↳ actions: {text}"))
+            elif kind == "error":
+                self.stderr.write(self.style.ERROR(f"process_message failed: {text}"))
+            else:  # info
+                self.stdout.write(self.style.HTTP_INFO(f"\n[{text}]"))
+        return emit
 
     # --- orchestration --------------------------------------------------------
     def handle(self, *args, **options):
@@ -330,7 +215,7 @@ class Command(BaseCommand):
         prior: Transcript = []
         if scenario_name:
             try:
-                user, cleanup_email, start_phase = self._seed_from_scenario(scenario_name)
+                user, cleanup_email, start_phase = seed_scenario_user(scenario_name)
             except TestScenario.DoesNotExist:
                 names = list(
                     TestScenario.objects.order_by("name").values_list("name", flat=True)
@@ -343,7 +228,7 @@ class Command(BaseCommand):
             prior = chat_history_transcript(user)
             scenario_label = scenario_name
         else:
-            user = self._seed_user()
+            user = seed_cold_user(SPIKE_EMAIL, START_PHASE.value)
             cleanup_email = SPIKE_EMAIL
             start_phase = START_PHASE.value
             scenario_label = "get_to_know_you_spike"
@@ -377,86 +262,29 @@ class Command(BaseCommand):
             f"| user-bot: {DEFAULT_USER_BOT_MODEL.value} | judge: {DEFAULT_JUDGE_MODEL.value}"
         ))
 
-        transcript: Transcript = []
-        replay_idx = 0
-        # Prior-history actions exist on the hydrated user; record their ids so
-        # collect_new_actions only reports what the coach does DURING this eval.
-        seen_action_ids: set = set(
-            Action.objects.filter(user=user).values_list("id", flat=True)
-        )
-        all_actions: list = []
-        transition_reached = False
-        run_error = None
-
         try:
-            for _ in range(max_turns):
-                # Click through any gating component (video/break) before talking.
-                comp = pending_component(user)
-                if comp:
-                    actions = primary_button_actions(comp)
-                    self.stdout.write(self.style.HTTP_INFO(
-                        f"[click-through: {comp.get('component_type')} "
-                        f"-> {[a.get('action') for a in actions]}]"
-                    ))
-                    ok, data, err = process_message(
-                        user, None, actions, coach_model, prompt_versions
-                    )
-                else:
-                    if replay_turns is not None:
-                        # Replay the recorded user turns verbatim (no user-bot),
-                        # so the only variable vs the saved run is the prompt/model.
-                        if replay_idx >= len(replay_turns):
-                            self.stdout.write(self.style.HTTP_INFO(
-                                f"\n[replay exhausted after {replay_idx} user turns]"
-                            ))
-                            break
-                        user_msg = replay_turns[replay_idx]
-                        replay_idx += 1
-                    else:
-                        user_msg = user_bot_reply(
-                            harness_client, DEFAULT_USER_BOT_MODEL, persona, prior + transcript
-                        )
-                    transcript.append(("user", user_msg))
-                    self.stdout.write(self.style.WARNING(f"\nCLIENT: {user_msg}"))
-                    ok, data, err = process_message(
-                        user, user_msg, None, coach_model, prompt_versions
-                    )
+            run = drive_eval(
+                user,
+                coach_model=coach_model,
+                prompt_versions=prompt_versions,
+                start_phase=start_phase,
+                max_turns=max_turns,
+                harness_client=harness_client,
+                persona=None if replay_turns is not None else persona,
+                prior=prior,
+                replay_turns=replay_turns,
+                emit=self._make_emit(),
+            )
 
-                if not ok:
-                    run_error = err
-                    self.stderr.write(self.style.ERROR(f"process_message failed: {err}"))
-                    break
-
-                coach_msg = data.get("message", "")
-                if coach_msg:
-                    transcript.append(("coach", coach_msg))
-                    self.stdout.write(self.style.SUCCESS(f"COACH: {coach_msg}"))
-
-                # Observability: what did the coach actually DO this turn?
-                coach_state = CoachState.objects.get(user=user)
-                acts = collect_new_actions(user, seen_action_ids)
-                all_actions.extend(acts)
-                if acts:
-                    self.stdout.write(self.style.HTTP_INFO(
-                        "  ↳ actions: " + ", ".join(a["action"] for a in acts)
-                    ))
-
-                if coach_state.current_phase != start_phase:
-                    transition_reached = coach_state.current_phase in GOAL_PHASES
-                    self.stdout.write(self.style.HTTP_INFO(
-                        f"\n[phase transitioned to: {coach_state.current_phase}]"
-                    ))
-                    break
-
-            final_coach_state = coach_state_snapshot(CoachState.objects.get(user=user))
-            final_phase = final_coach_state["current_phase"]
+            final_phase = run.final_phase
+            transition_reached = final_phase in GOAL_PHASES
 
             base_report = {
                 "scenario": scenario_label,
                 "persona": persona.persona_id,
                 "coach_model": coach_model.value,
                 "prompt_version": version_label,
-                "turns": len([t for t in transcript if t[0] == "user"]),
+                "turns": len(run.user_turns),
             }
 
             def _emit(report: dict) -> None:
@@ -470,8 +298,8 @@ class Command(BaseCommand):
                     save_eval_run(options["save_run"], {
                         **report,
                         "scenario_seed": scenario_name,
-                        "user_turns": [t[1] for t in transcript if t[0] == "user"],
-                        "transcript": [{"role": r, "text": t} for r, t in transcript],
+                        "user_turns": run.user_turns,
+                        "transcript": [{"role": r, "text": t} for r, t in run.transcript],
                     })
                     self.stdout.write(self.style.SUCCESS(
                         f"(saved run -> {options['save_run']})"
@@ -480,24 +308,24 @@ class Command(BaseCommand):
             # A pipeline failure (e.g. the coach returning malformed JSON) is an
             # ERROR, not a coaching-quality result. Skip the judge so an infra
             # hiccup never gets laundered into a fake low score.
-            if run_error is not None:
+            if run.run_error is not None:
                 _emit({
                     **base_report,
                     "status": "error",
-                    "error": run_error,
-                    "actions": all_actions,
-                    "final_coach_state": final_coach_state,
+                    "error": run.run_error,
+                    "actions": run.actions,
+                    "final_coach_state": run.final_coach_state,
                 })
                 self.stdout.write(self.style.ERROR(
                     "RESULT: ERROR — pipeline failure; judge skipped"
                 ))
                 return
 
-            verdict = self._judge(
+            verdict = judge_transcript(
                 harness_client,
                 phase=start_phase,
                 rubric_body=rubric_body,
-                transcript=transcript,
+                transcript=run.transcript,
                 targeted_checks=targeted_checks,
                 context=prior,
             )
@@ -526,8 +354,8 @@ class Command(BaseCommand):
                     "transitioned": final_phase != start_phase,
                     "reached_goal_phase": transition_reached,
                 },
-                "actions": all_actions,
-                "final_coach_state": final_coach_state,
+                "actions": run.actions,
+                "final_coach_state": run.final_coach_state,
             }
             if targeted_checks:
                 report["targeted_checks"] = [c.model_dump() for c in verdict.targeted_checks]
@@ -545,9 +373,7 @@ class Command(BaseCommand):
                 passed = sum(1 for c in verdict.targeted_checks if c.passed)
                 total = len(verdict.targeted_checks)
                 c_style = self.style.SUCCESS if passed == total else self.style.ERROR
-                self.stdout.write(c_style(
-                    f"CHECKS:      {passed}/{total} passed"
-                ))
+                self.stdout.write(c_style(f"CHECKS:      {passed}/{total} passed"))
                 for c in verdict.targeted_checks:
                     mark = "✓" if c.passed else "✗"
                     self.stdout.write(self.style.HTTP_INFO(f"  {mark} {c.check}"))

--- a/server/apps/coach/tests/test_eval_diff.py
+++ b/server/apps/coach/tests/test_eval_diff.py
@@ -1,0 +1,47 @@
+"""
+Tests for the pure delta logic in run_coach_eval_diff.
+"""
+
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+
+from apps.coach.eval.harness import CheckResult
+from apps.coach.management.commands.run_coach_eval_diff import Command
+
+
+def _verdict(checks):
+    """A stand-in JudgeVerdict carrying just the targeted_checks the delta uses."""
+    return SimpleNamespace(
+        targeted_checks=[CheckResult(check=c, passed=p, note="") for c, p in checks]
+    )
+
+
+class TestCheckDeltas(SimpleTestCase):
+    """_check_deltas pairs targeted checks by text and classifies each change."""
+
+    def setUp(self):
+        self.cmd = Command()
+
+    def test_classifies_fixed_regressed_same(self):
+        baseline = _verdict([("one q", True), ("no facts", False), ("builds", True)])
+        candidate = _verdict([("one q", True), ("no facts", True), ("builds", False)])
+        deltas = {d["check"]: d for d in self.cmd._check_deltas(baseline, candidate)}
+        self.assertEqual(deltas["one q"]["change"], "same")
+        self.assertEqual(deltas["no facts"]["change"], "fixed")
+        self.assertEqual(deltas["builds"]["change"], "regressed")
+
+    def test_check_only_in_candidate_is_new(self):
+        baseline = _verdict([("a", True)])
+        candidate = _verdict([("a", True), ("b", True)])
+        deltas = {d["check"]: d for d in self.cmd._check_deltas(baseline, candidate)}
+        self.assertEqual(deltas["b"]["change"], "new")
+        self.assertIsNone(deltas["b"]["baseline"])
+
+    def test_iterates_candidate_checks(self):
+        """The delta is driven by the candidate's checks (what we're judging now)."""
+        baseline = _verdict([("a", True), ("dropped", True)])
+        candidate = _verdict([("a", False)])
+        rows = self.cmd._check_deltas(baseline, candidate)
+        self.assertEqual([r["check"] for r in rows], ["a"])
+        self.assertEqual(rows[0]["change"], "regressed")

--- a/server/apps/coach/tests/test_eval_diff.py
+++ b/server/apps/coach/tests/test_eval_diff.py
@@ -1,12 +1,14 @@
 """
-Tests for the pure delta logic in run_coach_eval_diff.
+Tests for the pure delta + version-resolution logic in run_coach_eval_diff.
 """
 
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
 from apps.coach.eval.harness import CheckResult
+from apps.coach.management.commands import run_coach_eval_diff
 from apps.coach.management.commands.run_coach_eval_diff import Command
 
 
@@ -45,3 +47,40 @@ class TestCheckDeltas(SimpleTestCase):
         rows = self.cmd._check_deltas(baseline, candidate)
         self.assertEqual([r["check"] for r in rows], ["a"])
         self.assertEqual(rows[0]["change"], "regressed")
+
+
+class TestResolveVersions(SimpleTestCase):
+    """Candidate defaults to latest; baseline to the version right before it."""
+
+    def setUp(self):
+        self.cmd = Command()
+
+    def _resolve(self, active, baseline, candidate):
+        with patch.object(
+            run_coach_eval_diff, "active_prompt_versions", return_value=active
+        ):
+            return self.cmd._resolve_versions("get_to_know_you", baseline, candidate)
+
+    def test_defaults_to_previous_vs_latest(self):
+        self.assertEqual(self._resolve([6, 5, 4], None, None), (5, 6))
+
+    def test_explicit_baseline_keeps_latest_candidate(self):
+        self.assertEqual(self._resolve([6, 5, 4], 4, None), (4, 6))
+
+    def test_explicit_candidate_takes_version_below_it(self):
+        self.assertEqual(self._resolve([6, 5, 4], None, 5), (4, 5))
+
+    def test_both_explicit(self):
+        self.assertEqual(self._resolve([6, 5, 4], 4, 6), (4, 6))
+
+    def test_single_version_has_no_baseline(self):
+        self.assertIsNone(self._resolve([6], None, None))
+
+    def test_missing_candidate_version_errors(self):
+        self.assertIsNone(self._resolve([6, 5], None, 9))
+
+    def test_missing_baseline_version_errors(self):
+        self.assertIsNone(self._resolve([6, 5], 3, 6))
+
+    def test_no_active_prompts_errors(self):
+        self.assertIsNone(self._resolve([], None, None))


### PR DESCRIPTION
Roadmap item #3, built on the replay engine from #132. Answers "did my prompt edit help?" in one command.

## What it does

`run_coach_eval_diff` drives a **baseline** version with the user-bot, **replays the same user turns** against a **candidate** version (so the prompt is the only variable), then reports the delta:

- **Quality** — each version judged against **its own** prompt body (a v11 run vs v11's instructions). Per-version, not like-for-like — the pairwise result is the apples-to-apples call.
- **Targeted checks** — the same assertions on both, paired by text and labelled `fixed` / `regressed` / `same` / `new` (these *are* like-for-like).
- **Progression** — did each version transition the phase.
- **Pairwise** — the judge sees **both transcripts over identical client turns** (blind-labelled Coach A / B to avoid newer-is-better bias) and picks the better one, per aspect, with reasoning. Comparing transcripts directly beats differencing two absolute scores.

```bash
docker exec dev-coach-local-backend-1 \
  python manage.py run_coach_eval_diff \
    --from-scenario "[Auto] Casey @ get_to_know_you" \
    --baseline-version 10 --candidate-version 11 --out /tmp/diff.json
```

Flags: `--baseline-version` / `--candidate-version` (default latest; warns if equal), `--from-scenario`, `--persona`, `--coach-model` (one model for both runs), `--check`, `--max-turns`, `--out`, `--keep`.

## Refactor (commit 1)

To avoid duplicating the loop, the reusable pieces moved from `run_coach_eval_spike` into `apps/coach/eval/harness.py`: `seed_cold_user` / `seed_scenario_user`, `drive_eval` (+ `DriveResult`), and `judge_transcript` (+ the verdict models). The spike now delegates to them — **behavior, flags, report shape, and terminal output unchanged** (verified by an identical cold-seed run).

## Testing

- Unit tests for the check-delta classifier; full `apps.coach` suite passes (99).
- Spike regression: refactored cold-seed run → QUALITY 5/5, CHECKS 4/4, identical output.
- End-to-end diff (v1 vs v6 over a frozen get_to_know_you scenario, gpt-4o): produced per-version scores, check deltas, progression, and a pairwise winner with per-aspect notes; wrote `--out` JSON. (Notably it flagged the latest v6 as *worse* than v1 on this sample — exactly the kind of signal this tool exists to surface.)

> One diff is a single sample (live coach + mild pairwise position bias); the docs note to run a few and weigh the deterministic checks alongside the pairwise trend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)