### PR TITLE
feat(coach): HTTP endpoint to run the coach eval (for the MCP tool)

### DIFF
--- a/docs/docs/testing/eval-harness/overview.md
+++ b/docs/docs/testing/eval-harness/overview.md
@@ -206,9 +206,11 @@ scenarios.
   the eval directly from a frozen scenario (`--from-scenario`); rubrics derived
   live from the phase `Prompt.body` + per-phase targeted checks; replay mode
   (`--save-run` / `--replay`) to re-run the exact user turns against a new prompt;
-  baseline↔candidate diffing (`run_coach_eval_diff`) with a pairwise judge.
-- **Planned:** transcript caching, a `run_coach_eval` MCP tool, and suites /
-  k-run pass rates. See the [Roadmap](/docs/testing/eval-harness/roadmap).
+  baseline↔candidate diffing (`run_coach_eval_diff`) with a pairwise judge; a
+  `run_coach_eval` MCP tool (over `POST /api/v1/eval/run`) so evals run without
+  shelling into Django.
+- **Planned:** transcript caching, an MCP diff tool, and suites / k-run pass
+  rates. See the [Roadmap](/docs/testing/eval-harness/roadmap).
 
 ## Related Documentation
 

--- a/docs/docs/testing/eval-harness/roadmap.md
+++ b/docs/docs/testing/eval-harness/roadmap.md
@@ -56,6 +56,11 @@ The core loop and the scenario-building tooling are in place.
   (fixed/regressed), progression, and a **pairwise** judge that compares the two
   transcripts directly. See
   [Running Evals → Diffing two versions](/docs/testing/eval-harness/running-evals#diffing-two-versions).
+- **`run_coach_eval` MCP tool** — the `dev-coach-docs` MCP server exposes a
+  `run_coach_eval` tool that POSTs to a new `POST /api/v1/eval/run` backend
+  endpoint, so the edit-prompt → eval → iterate loop runs without shelling into
+  Django. (Single-eval; a diff tool can follow.) See
+  [Running Evals → From the MCP server](/docs/testing/eval-harness/running-evals#from-the-mcp-server).
 
 ## Planned
 
@@ -64,8 +69,7 @@ The core loop and the scenario-building tooling are in place.
   a baseline is generated once and re-judged cheaply when requirements change. See
   the caching model in the
   [Overview](/docs/testing/eval-harness/overview#transcript-vs-judgment-the-caching-model).
-- **`run_coach_eval` MCP tool** — on the `dev-coach-docs` MCP server, so the
-  edit-prompt → eval → iterate loop runs without manual command invocation.
+- **`run_coach_eval_diff` MCP tool** — expose the baseline↔candidate diff over MCP too.
 - **Suites & k-run pass rates** — multiple scenarios per phase, and repeated runs to
   handle LLM non-determinism instead of single-sample pass/fail.
 

--- a/docs/docs/testing/eval-harness/running-evals.md
+++ b/docs/docs/testing/eval-harness/running-evals.md
@@ -247,6 +247,35 @@ below the candidate (only one exists), it errors and asks you to pass
 > data point. For a decision, run it a few times and weigh the targeted checks
 > (deterministic) alongside the pairwise trend.
 
+## From the MCP server
+
+You don't have to shell into Django to run a single eval — the `dev-coach-docs`
+MCP server exposes a **`run_coach_eval`** tool. It POSTs to a backend endpoint
+that runs the same loop and returns the report, so the edit-prompt → eval →
+iterate cycle works straight from the MCP client (e.g. alongside
+`create_new_coach_prompt`).
+
+**Backend endpoint:** `POST /api/v1/eval/run` (auth: `X-Api-Key` or admin, same as
+the prompts API). Body fields mirror the command: `persona`, `from_scenario`,
+`coach_model`, `prompt_version`, `checks`, `max_turns`. It returns the report JSON
+(same shape as below). The call is **synchronous** — it holds the connection open
+for the few minutes the eval takes — and the MCP tool uses a long timeout to match.
+
+**Gating:** the endpoint runs the real coach pipeline (OpenAI cost) and creates a
+throwaway user, so it's **on in local/dev (DEBUG) and off in production** by
+default. Override per environment with the `EVAL_HARNESS_ENABLED=true|false` env var.
+
+```bash
+# What the MCP tool does under the hood:
+curl -X POST http://localhost:8000/api/v1/eval/run \
+  -H "X-Api-Key: $DEV_COACH_API_KEY" -H "Content-Type: application/json" \
+  -d '{"from_scenario":"[Auto] Casey @ get_to_know_you","prompt_version":6,"max_turns":12}'
+```
+
+> The MCP server (`~/Programming/MCP/dev-coach/`) loads tools at startup, so after
+> adding/updating a tool you must **restart the MCP server** (reconnect it in the
+> client) before the new tool appears.
+
 ## Reading the report
 
 ```json

--- a/server/apps/api_urls.py
+++ b/server/apps/api_urls.py
@@ -12,7 +12,7 @@ from rest_framework.routers import DefaultRouter
 from apps.authentication.views import AuthViewSet
 
 # Local Modules - Admin Viewsets
-from apps.coach.views import AdminCoachViewSet, CoachViewSet
+from apps.coach.views import AdminCoachViewSet, CoachViewSet, EvalViewSet
 from apps.core.views import CoachingPhaseVideosViewSet, CoreViewSet
 from apps.identities.views import (
     AdminIdentityImageChatViewSet,
@@ -41,6 +41,7 @@ default_router.register(
     basename="core-public-coaching-phase-videos",
 )  # Public Coaching Phase Videos config (feature flag)
 default_router.register(r"coach", CoachViewSet, basename="coach")
+default_router.register(r"eval", EvalViewSet, basename="eval")
 default_router.register(r"user", UserViewSet, basename="user")
 default_router.register(r"identities", IdentityViewSet, basename="identities")
 default_router.register(

--- a/server/apps/coach/eval/harness.py
+++ b/server/apps/coach/eval/harness.py
@@ -573,3 +573,163 @@ def judge_transcript(
         temperature=0.0,
     )
     return completion.choices[0].message.parsed
+
+
+# --- report assembly + one-call orchestration ---------------------------------
+
+
+class EvalError(Exception):
+    """A recoverable eval setup problem (e.g. no prompt for the phase)."""
+
+
+def assemble_eval_report(
+    *,
+    scenario_label: str,
+    persona_id: str,
+    coach_model_value: str,
+    start_phase: str,
+    rubric_version: Optional[int],
+    pinned: bool,
+    run: DriveResult,
+    verdict: Optional["JudgeVerdict"] = None,
+    targeted_checks: Optional[List[str]] = None,
+    goal_phases: Optional[set] = None,
+) -> dict:
+    """Build the canonical eval report dict (shared by the CLI command and the API
+    endpoint so the shape never drifts).
+
+    A pipeline failure (run.run_error set) yields a `status: error` report with no
+    judge result. Otherwise `verdict` is required and the full quality/progression/
+    targeted-checks report is produced. `goal_phases` (optional) drives the
+    informational `reached_goal_phase` flag; None leaves it null.
+    """
+    base = {
+        "scenario": scenario_label,
+        "persona": persona_id,
+        "coach_model": coach_model_value,
+        "prompt_version": rubric_version,
+        "turns": len(run.user_turns),
+    }
+    if run.run_error is not None:
+        return {
+            **base,
+            "status": "error",
+            "error": run.run_error,
+            "actions": run.actions,
+            "final_coach_state": run.final_coach_state,
+        }
+    final_phase = run.final_phase
+    report = {
+        **base,
+        "status": "ok",
+        "quality": {
+            "passed": verdict.passed,
+            "score": verdict.score,
+            "rubric_source": {
+                "phase": start_phase,
+                "prompt_version": rubric_version,
+                "pinned": pinned,
+            },
+            "criteria": [c.model_dump() for c in verdict.criteria],
+            "reasoning": verdict.reasoning,
+        },
+        "progression": {
+            "start_phase": start_phase,
+            "final_phase": final_phase,
+            "transitioned": final_phase != start_phase,
+            "reached_goal_phase": (
+                final_phase in goal_phases if goal_phases else None
+            ),
+        },
+        "actions": run.actions,
+        "final_coach_state": run.final_coach_state,
+    }
+    if targeted_checks:
+        report["targeted_checks"] = [c.model_dump() for c in verdict.targeted_checks]
+    return report
+
+
+def run_phase_eval(
+    *,
+    persona_id: str = "casey",
+    scenario_name: Optional[str] = None,
+    coach_model: AIModel,
+    prompt_version: Optional[int] = None,
+    checks: Optional[List[str]] = None,
+    max_turns: int = 20,
+    cold_phase: str = "get_to_know_you",
+    cold_email: str = "coach-eval-api@testscenario.com",
+    harness_client=None,
+) -> dict:
+    """Run ONE eval end-to-end and return the report dict — no CLI, no I/O.
+
+    Seeds a throwaway user (cold at `cold_phase`, or hydrated from a frozen
+    TestScenario when `scenario_name` is given), drives the conversation with the
+    user-bot, judges it against the phase's derived rubric + targeted checks, and
+    always deletes the throwaway user. This is the callable the API endpoint wraps
+    so the harness can be driven without a management command.
+
+    Raises TestScenario.DoesNotExist for an unknown scenario, FileNotFoundError
+    for an unknown persona, and EvalError when the phase has no active prompt.
+    """
+    from services.ai.ai_service_factory import AIServiceFactory  # local: avoids import cost at module load
+
+    if harness_client is None:
+        harness_client = AIServiceFactory.create(DEFAULT_USER_BOT_MODEL).client
+    persona = load_persona(persona_id)
+
+    if scenario_name:
+        user, cleanup_email, start_phase = seed_scenario_user(scenario_name)
+        prior = chat_history_transcript(user)
+        scenario_label = scenario_name
+    else:
+        user = seed_cold_user(cold_email, cold_phase)
+        cleanup_email = cold_email
+        start_phase = cold_phase
+        prior = []
+        scenario_label = f"cold {cold_phase}"
+
+    try:
+        prompt_versions = (
+            {start_phase: prompt_version} if prompt_version is not None else None
+        )
+        rubric_body, rubric_version = load_phase_prompt_body(start_phase, prompt_version)
+        if not rubric_body:
+            raise EvalError(
+                f"No active coach prompt for phase '{start_phase}'"
+                + (f" at version {prompt_version}" if prompt_version else "")
+            )
+        targeted_checks = load_targeted_checks(start_phase, checks)
+        run = drive_eval(
+            user,
+            coach_model=coach_model,
+            prompt_versions=prompt_versions,
+            start_phase=start_phase,
+            max_turns=max_turns,
+            harness_client=harness_client,
+            persona=persona,
+            prior=prior,
+        )
+        verdict = None
+        if run.run_error is None:
+            verdict = judge_transcript(
+                harness_client,
+                phase=start_phase,
+                rubric_body=rubric_body,
+                transcript=run.transcript,
+                targeted_checks=targeted_checks,
+                context=prior,
+            )
+        return assemble_eval_report(
+            scenario_label=scenario_label,
+            persona_id=persona_id,
+            coach_model_value=coach_model.value,
+            start_phase=start_phase,
+            rubric_version=rubric_version,
+            pinned=prompt_version is not None,
+            run=run,
+            verdict=verdict,
+            targeted_checks=targeted_checks,
+        )
+    finally:
+        User.objects.filter(email=cleanup_email).delete()

--- a/server/apps/coach/management/commands/run_coach_eval_spike.py
+++ b/server/apps/coach/management/commands/run_coach_eval_spike.py
@@ -58,6 +58,7 @@ from apps.coach.eval.harness import (
     DEFAULT_JUDGE_MODEL,
     DEFAULT_USER_BOT_MODEL,
     Transcript,
+    assemble_eval_report,
     chat_history_transcript,
     drive_eval,
     judge_transcript,
@@ -277,15 +278,6 @@ class Command(BaseCommand):
             )
 
             final_phase = run.final_phase
-            transition_reached = final_phase in GOAL_PHASES
-
-            base_report = {
-                "scenario": scenario_label,
-                "persona": persona.persona_id,
-                "coach_model": coach_model.value,
-                "prompt_version": version_label,
-                "turns": len(run.user_turns),
-            }
 
             def _emit(report: dict) -> None:
                 self.stdout.write("\n" + "=" * 70)
@@ -305,17 +297,22 @@ class Command(BaseCommand):
                         f"(saved run -> {options['save_run']})"
                     ))
 
-            # A pipeline failure (e.g. the coach returning malformed JSON) is an
-            # ERROR, not a coaching-quality result. Skip the judge so an infra
-            # hiccup never gets laundered into a fake low score.
+            # The report shape is assembled in the harness so the CLI and the API
+            # endpoint never drift. A pipeline failure (e.g. malformed JSON) is an
+            # ERROR, not a coaching-quality result — the judge is skipped so an
+            # infra hiccup never gets laundered into a fake low score.
+            _report_kwargs = dict(
+                scenario_label=scenario_label,
+                persona_id=persona.persona_id,
+                coach_model_value=coach_model.value,
+                start_phase=start_phase,
+                rubric_version=rubric_version,
+                pinned=prompt_version is not None,
+                run=run,
+                goal_phases=GOAL_PHASES,
+            )
             if run.run_error is not None:
-                _emit({
-                    **base_report,
-                    "status": "error",
-                    "error": run.run_error,
-                    "actions": run.actions,
-                    "final_coach_state": run.final_coach_state,
-                })
+                _emit(assemble_eval_report(**_report_kwargs))
                 self.stdout.write(self.style.ERROR(
                     "RESULT: ERROR — pipeline failure; judge skipped"
                 ))
@@ -329,37 +326,12 @@ class Command(BaseCommand):
                 targeted_checks=targeted_checks,
                 context=prior,
             )
-
-            # Quality (rubric), targeted checks, and progression are reported as
-            # SEPARATE outcomes, never AND-ed together. A high-quality conversation
-            # that simply didn't transition within the turn budget is NOT a
-            # failure — it's a non-transition, which is its own signal.
-            report = {
-                **base_report,
-                "status": "ok",
-                "quality": {
-                    "passed": verdict.passed,
-                    "score": verdict.score,
-                    "rubric_source": {
-                        "phase": start_phase,
-                        "prompt_version": rubric_version,
-                        "pinned": prompt_version is not None,
-                    },
-                    "criteria": [c.model_dump() for c in verdict.criteria],
-                    "reasoning": verdict.reasoning,
-                },
-                "progression": {
-                    "start_phase": start_phase,
-                    "final_phase": final_phase,
-                    "transitioned": final_phase != start_phase,
-                    "reached_goal_phase": transition_reached,
-                },
-                "actions": run.actions,
-                "final_coach_state": run.final_coach_state,
-            }
-            if targeted_checks:
-                report["targeted_checks"] = [c.model_dump() for c in verdict.targeted_checks]
-            _emit(report)
+            # Quality (rubric), targeted checks, and progression are SEPARATE
+            # outcomes, never AND-ed — a high-quality conversation that simply
+            # didn't transition is a non-transition, not a failure.
+            _emit(assemble_eval_report(
+                **_report_kwargs, verdict=verdict, targeted_checks=targeted_checks
+            ))
 
             # Independent outcomes — quality is the judge's call against the
             # phase prompt; targeted checks are explicit assertions; progression

--- a/server/apps/coach/serializers/__init__.py
+++ b/server/apps/coach/serializers/__init__.py
@@ -10,9 +10,11 @@ Exports:
 from .admin_coach_request_serializer import AdminCoachRequestSerializer
 from .coach_request_serializer import CoachRequestSerializer
 from .coach_response_serializer import CoachResponseSerializer
+from .eval_run_serializer import EvalRunSerializer
 
 __all__ = [
     "AdminCoachRequestSerializer",
     "CoachRequestSerializer",
     "CoachResponseSerializer",
+    "EvalRunSerializer",
 ]

--- a/server/apps/coach/serializers/eval_run_serializer.py
+++ b/server/apps/coach/serializers/eval_run_serializer.py
@@ -1,0 +1,38 @@
+"""
+Request serializer for the coach eval endpoint (POST /api/v1/eval/run).
+
+See: apps/coach/serializers/__init__.py
+"""
+
+from rest_framework import serializers
+
+
+class EvalRunSerializer(serializers.Serializer):
+    """Validates the inputs for one automated coach eval run.
+
+    Mirrors run_coach_eval_spike's flags: drive a persona against a phase (cold or
+    from a frozen scenario), optionally pin a prompt version, layer extra targeted
+    checks, and cap the turn budget.
+    """
+
+    persona = serializers.CharField(required=False, default="casey")
+    from_scenario = serializers.CharField(
+        required=False, allow_null=True, default=None,
+        help_text="Exact TestScenario name to hydrate; omit to cold-seed get_to_know_you.",
+    )
+    coach_model = serializers.CharField(
+        required=False, allow_null=True, default=None,
+        help_text="Coach model id; defaults to the configured DEFAULT_AI_MODEL.",
+    )
+    prompt_version = serializers.IntegerField(
+        required=False, allow_null=True, default=None, min_value=1,
+        help_text="Pin the phase prompt (and derived rubric) to this version.",
+    )
+    checks = serializers.ListField(
+        child=serializers.CharField(), required=False, default=list,
+        help_text="One-off targeted checks, on top of the per-phase checks file.",
+    )
+    max_turns = serializers.IntegerField(
+        required=False, default=20, min_value=1, max_value=40,
+        help_text="Cap on conversation turns before the run stops.",
+    )

--- a/server/apps/coach/tests/test_eval_endpoint.py
+++ b/server/apps/coach/tests/test_eval_endpoint.py
@@ -1,0 +1,98 @@
+"""
+Endpoint tests for the coach eval harness API (POST /api/v1/eval/run).
+
+run_phase_eval is mocked throughout — these tests cover auth, the env gate,
+request wiring, and error mapping, NOT the (LLM-driven) eval itself.
+"""
+
+from unittest.mock import patch
+
+from django.test import override_settings
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.coach.eval.harness import EvalError
+from apps.test_scenario.models import TestScenario
+from apps.users.models import User
+
+URL = "/api/v1/eval/run"
+FAKE_REPORT = {"status": "ok", "scenario": "cold get_to_know_you", "quality": {"score": 5}}
+
+
+@override_settings(EVAL_HARNESS_ENABLED="true")
+class EvalEndpointTests(APITestCase):
+    def setUp(self):
+        self.admin = User.objects.create_user(
+            email="admin@example.com", password="TestPass1!", is_staff=True
+        )
+
+    @patch("apps.coach.views.eval_view_set.run_phase_eval", return_value=FAKE_REPORT)
+    def test_runs_and_returns_report(self, mock_run):
+        self.client.force_authenticate(user=self.admin)
+        resp = self.client.post(URL, {"persona": "casey"}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.json(), FAKE_REPORT)
+        # Serializer defaults are forwarded.
+        kwargs = mock_run.call_args.kwargs
+        self.assertEqual(kwargs["persona_id"], "casey")
+        self.assertEqual(kwargs["max_turns"], 20)
+        self.assertIsNone(kwargs["scenario_name"])
+
+    @patch("apps.coach.views.eval_view_set.run_phase_eval", return_value=FAKE_REPORT)
+    def test_forwards_optional_args(self, mock_run):
+        self.client.force_authenticate(user=self.admin)
+        self.client.post(
+            URL,
+            {"from_scenario": "S1", "prompt_version": 5, "checks": ["x"], "max_turns": 8},
+            format="json",
+        )
+        kwargs = mock_run.call_args.kwargs
+        self.assertEqual(kwargs["scenario_name"], "S1")
+        self.assertEqual(kwargs["prompt_version"], 5)
+        self.assertEqual(kwargs["checks"], ["x"])
+        self.assertEqual(kwargs["max_turns"], 8)
+
+    def test_non_admin_rejected(self):
+        regular = User.objects.create_user(email="r@example.com", password="TestPass1!")
+        self.client.force_authenticate(user=regular)
+        resp = self.client.post(URL, {}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    @patch(
+        "apps.coach.views.eval_view_set.run_phase_eval",
+        side_effect=TestScenario.DoesNotExist,
+    )
+    def test_unknown_scenario_404(self, _mock):
+        self.client.force_authenticate(user=self.admin)
+        resp = self.client.post(URL, {"from_scenario": "nope"}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    @patch(
+        "apps.coach.views.eval_view_set.run_phase_eval",
+        side_effect=EvalError("No active coach prompt for phase 'x'"),
+    )
+    def test_eval_error_400(self, _mock):
+        self.client.force_authenticate(user=self.admin)
+        resp = self.client.post(URL, {}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("No active coach prompt", resp.json()["detail"])
+
+    def test_max_turns_over_cap_rejected(self):
+        self.client.force_authenticate(user=self.admin)
+        resp = self.client.post(URL, {"max_turns": 999}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class EvalEndpointGateTests(APITestCase):
+    def setUp(self):
+        self.admin = User.objects.create_user(
+            email="admin2@example.com", password="TestPass1!", is_staff=True
+        )
+
+    @override_settings(EVAL_HARNESS_ENABLED="false")
+    @patch("apps.coach.views.eval_view_set.run_phase_eval", return_value=FAKE_REPORT)
+    def test_disabled_returns_403_and_skips_eval(self, mock_run):
+        self.client.force_authenticate(user=self.admin)
+        resp = self.client.post(URL, {}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+        mock_run.assert_not_called()

--- a/server/apps/coach/views/__init__.py
+++ b/server/apps/coach/views/__init__.py
@@ -4,9 +4,11 @@ Coach views.
 Exports:
     CoachViewSet: Public endpoint for authenticated users to send messages.
     AdminCoachViewSet: Admin endpoint to process messages on behalf of any user.
+    EvalViewSet: Runs the automated coach eval harness (POST /api/v1/eval/run).
 """
 
 from .admin_coach_view_set import AdminCoachViewSet
 from .coach_view_set import CoachViewSet
+from .eval_view_set import EvalViewSet
 
-__all__ = ["CoachViewSet", "AdminCoachViewSet"]
+__all__ = ["CoachViewSet", "AdminCoachViewSet", "EvalViewSet"]

--- a/server/apps/coach/views/eval_view_set.py
+++ b/server/apps/coach/views/eval_view_set.py
@@ -1,0 +1,83 @@
+"""
+HTTP endpoint for the automated coach eval harness.
+
+Exposes run_phase_eval (the same loop as run_coach_eval_spike) over the API so it
+can be driven from the dev-coach-docs MCP server's `run_coach_eval` tool — no
+shelling into the Django container required.
+
+See: apps/coach/views/__init__.py
+"""
+
+from django.conf import settings
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework_api_key.permissions import HasAPIKey
+
+from apps.coach.eval.harness import EvalError, run_phase_eval
+from apps.coach.serializers import EvalRunSerializer
+from apps.test_scenario.models import TestScenario
+from enums.ai import AIModel
+from permissions import IsAdminUser
+from services.logger import configure_logging
+
+log = configure_logging(__name__)
+
+
+def _eval_harness_enabled() -> bool:
+    """On locally/dev (DEBUG) by default; off in production. Override with the
+    EVAL_HARNESS_ENABLED env var (true/false) in any environment."""
+    flag = settings.EVAL_HARNESS_ENABLED
+    if flag is None:
+        return bool(settings.DEBUG)
+    return str(flag).lower() == "true"
+
+
+class EvalViewSet(viewsets.ViewSet):
+    """Run one automated coach eval and return its report.
+
+    POST /api/v1/eval/run — drives a persona against a phase (cold or from a
+    frozen scenario), judges it against the phase's derived rubric + targeted
+    checks, and returns the report JSON. Synchronous: the call runs the real coach
+    pipeline (several minutes of LLM calls) before responding.
+    """
+
+    permission_classes = [HasAPIKey | IsAdminUser]
+
+    @action(detail=False, methods=["post"], url_path="run")
+    def run(self, request):
+        if not _eval_harness_enabled():
+            return Response(
+                {"detail": "The eval harness is disabled in this environment."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        serializer = EvalRunSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+        coach_model = AIModel.get_or_default(data["coach_model"])
+
+        try:
+            report = run_phase_eval(
+                persona_id=data["persona"],
+                scenario_name=data["from_scenario"],
+                coach_model=coach_model,
+                prompt_version=data["prompt_version"],
+                checks=data["checks"],
+                max_turns=data["max_turns"],
+            )
+        except TestScenario.DoesNotExist:
+            names = list(
+                TestScenario.objects.order_by("name").values_list("name", flat=True)
+            )
+            return Response(
+                {"detail": f"No TestScenario named '{data['from_scenario']}'.",
+                 "available": names},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        except FileNotFoundError as e:
+            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except EvalError as e:
+            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(report, status=status.HTTP_200_OK)

--- a/server/settings/common.py
+++ b/server/settings/common.py
@@ -35,6 +35,13 @@ SECRET_KEY = env.str("DJANGO_SECRET_KEY", default="insecuresecretkeydjangoai5496
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
+# Gate for the automated coach eval harness HTTP endpoint (POST /api/v1/eval/run).
+# Unset (None) => follow DEBUG (on locally/dev, off in production). Set
+# EVAL_HARNESS_ENABLED=true/false to override in any environment. The endpoint
+# runs the real coach pipeline (OpenAI cost) and creates throwaway users, so it
+# is off in production by default.
+EVAL_HARNESS_ENABLED = os.environ.get("EVAL_HARNESS_ENABLED")
+
 # Allow all hosts
 ALLOWED_HOSTS = ["*"]
 


### PR DESCRIPTION
Roadmap item #6 (backend half). Lets the eval harness be driven over the API so the `dev-coach-docs` MCP server can run evals without shelling into the Django container.

## What

- **`POST /api/v1/eval/run`** (`EvalViewSet`) — wraps the harness and returns the report JSON. Auth: `HasAPIKey | IsAdminUser` (same as the prompts API). **Synchronous** — it runs the real coach pipeline (several minutes) before responding.
- **`EvalRunSerializer`** — validates `persona` / `from_scenario` / `coach_model` / `prompt_version` / `checks` / `max_turns` (capped at 40).
- **Env gate `EVAL_HARNESS_ENABLED`** — follows `DEBUG` by default (on in local/dev, **off in production**, since it spends OpenAI tokens + creates throwaway users); override per-env with the env var.
- Error mapping: unknown scenario → 404 (with available names), bad persona / no active prompt → 400, disabled env → 403.

## Refactor (commit 1)

Extracted two shared pieces into the harness so the CLI and the endpoint can't drift:
- `assemble_eval_report(...)` — the canonical report dict (ok + error shapes). `run_coach_eval_spike` now builds its report through it (CLI output verified unchanged).
- `run_phase_eval(...)` — run one eval end-to-end and return the report dict, with guaranteed throwaway-user cleanup. The endpoint wraps this.

## MCP server side (separate, non-git repo `~/Programming/MCP/dev-coach/`)

Added a **`run_coach_eval`** tool (mirrors `create_new_coach_prompt`) that POSTs to the endpoint with a long timeout and formats the report. **Not in this PR** (that repo isn't versioned) — the tool file + `server.py` registration are applied locally; the MCP server must be **restarted** to pick it up.

## Testing

- Endpoint tests (auth, env gate on/off, arg forwarding, 404/400 mapping) with the eval mocked — `apps.coach` suite passes (114).
- CLI regression: `run_coach_eval_spike` output unchanged after the refactor.
- **Live HTTP**: real `curl` to `/api/v1/eval/run` returned a full report (score 5, 5 targeted checks, rubric from v6).
- MCP server imports cleanly via its venv and lists `run_coach_eval` among its tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)