### PR TITLE
test(coach): add no-repeat targeted check for get_to_know_you eval

### DIFF
--- a/server/apps/coach/eval/checks/get_to_know_you.md
+++ b/server/apps/coach/eval/checks/get_to_know_you.md
@@ -12,3 +12,4 @@
 - The coach never invents or assumes facts about the client that the client did not actually say.
 - The coach builds on what the client just shared rather than asking generic, disconnected questions.
 - The coach does not begin Identity work (brainstorming or naming identities) during this phase.
+- The coach never re-asks or re-opens a topic already covered in the Asked-Questions list, even in reworded form.


### PR DESCRIPTION
Adds one targeted check to `apps/coach/eval/checks/get_to_know_you.md`:

> The coach never re-asks or re-opens a topic already covered in the Asked-Questions list, even in reworded form.

This locks in the phase's core invariant (cover the five topics once each, no repeats) as an explicit, deterministic assertion the eval evaluates on every run. It has been passing on the live `get_to_know_you` prompt (v6).

No prompt change ships here — see the discussion below for why the explored v7 was dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)