### PR TITLE
feat(onboarding): require name capture + editable name on account

### DIFF
--- a/client/src/api/user.ts
+++ b/client/src/api/user.ts
@@ -1,6 +1,7 @@
 import { COACH_BASE_URL } from "@/constants/api";
 import { authFetch } from "@/utils/authFetch";
 import { createLogger, LogLevel } from "@/lib/logger";
+import type { User } from "@/types/user";
 
 const log = createLogger("userApi", LogLevel.DEBUG);
 
@@ -14,6 +15,26 @@ export async function fetchUserProfile() {
   if (!response.ok) throw new Error("Failed to fetch user profile");
   const data = await response.json();
   log.debug("Successfully fetched user profile", data);
+  return data;
+}
+
+/**
+ * Update the current authenticated user's profile (partial).
+ * PATCH /user/me/
+ *
+ * Used for editable profile fields such as first/last name.
+ */
+export async function updateUserProfile(
+  updates: Partial<Pick<User, "first_name" | "last_name">>
+): Promise<User> {
+  log.debug("Updating user profile", updates);
+  const response = await authFetch(`${COACH_BASE_URL}/user/me`, {
+    method: "PATCH",
+    body: JSON.stringify(updates),
+  });
+  if (!response.ok) throw new Error("Failed to update profile");
+  const data = await response.json();
+  log.debug("Successfully updated user profile", data);
   return data;
 }
 

--- a/client/src/hooks/use-update-profile.ts
+++ b/client/src/hooks/use-update-profile.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { updateUserProfile } from "@/api/user";
+import type { User } from "@/types/user";
+
+/**
+ * useUpdateProfile hook
+ * ---------------------
+ * Mutation for partially updating the current user's profile (e.g. first/last
+ * name) via PATCH /user/me/. On success it writes the returned profile straight
+ * into the ["user", "profile"] cache so the UI reflects the change immediately.
+ *
+ * Used in: Account page name editing, onboarding name capture step.
+ */
+export function useUpdateProfile() {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation<
+    User,
+    Error,
+    Partial<Pick<User, "first_name" | "last_name">>
+  >({
+    mutationFn: updateUserProfile,
+    onSuccess: (data) => {
+      queryClient.setQueryData(["user", "profile"], data);
+      queryClient.invalidateQueries({ queryKey: ["user", "profile"] });
+    },
+  });
+
+  return {
+    updateProfile: mutation.mutateAsync,
+    isUpdating: mutation.isPending,
+    updateError: mutation.error,
+  };
+}

--- a/client/src/pages/account/Account.tsx
+++ b/client/src/pages/account/Account.tsx
@@ -1,5 +1,6 @@
 import { useAuth } from "@/hooks/use-auth";
 import { useProfile } from "@/hooks/use-profile";
+import { useUpdateProfile } from "@/hooks/use-update-profile";
 import { useUserAppearance } from "@/hooks/use-user-appearance";
 import { useImpersonation } from "@/context/ImpersonationContext";
 import { useQuery } from "@tanstack/react-query";
@@ -46,6 +47,7 @@ export default function Account() {
   const viewedProfile = isImpersonating ? impersonatedProfile : profile;
 
   const { appearance, updateAppearance, isUpdating } = useUserAppearance(viewedUserId);
+  const { updateProfile } = useUpdateProfile();
 
   const handleLogout = async () => {
     try {
@@ -79,7 +81,16 @@ export default function Account() {
 
         {/* Account tab — account info + sign out */}
         <TabsContent value="account" className="space-y-6">
-          <AccountInformation profile={viewedProfile ?? null} />
+          <AccountInformation
+            profile={viewedProfile ?? null}
+            onSave={
+              isImpersonating
+                ? undefined
+                : async (updates) => {
+                    await updateProfile(updates);
+                  }
+            }
+          />
 
           {/* Logout Section — hidden when impersonating */}
           {!isImpersonating && (

--- a/client/src/pages/account/components/AccountInformation.tsx
+++ b/client/src/pages/account/components/AccountInformation.tsx
@@ -1,3 +1,7 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { NameFields, type NameValue } from "./NameFields";
 import type { User } from "@/types/user";
 
 /**
@@ -7,9 +11,23 @@ import type { User } from "@/types/user";
  * Receives profile data as a prop from the parent Account page,
  * which handles impersonation-aware data fetching.
  *
+ * When an `onSave` callback is provided the Name field becomes editable
+ * (the parent owns persistence). It is omitted while impersonating, leaving
+ * the card read-only.
+ *
  * Used in: Account page.
  */
-export function AccountInformation({ profile }: { profile: User | null }) {
+export function AccountInformation({
+  profile,
+  onSave,
+}: {
+  profile: User | null;
+  onSave?: (updates: NameValue) => Promise<void>;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState<NameValue>({ first_name: "", last_name: "" });
+  const [isSaving, setIsSaving] = useState(false);
+
   if (!profile) {
     return (
       <div className="bg-card rounded-lg border p-6">
@@ -19,24 +37,86 @@ export function AccountInformation({ profile }: { profile: User | null }) {
     );
   }
 
+  const fullName =
+    [profile.first_name, profile.last_name].filter(Boolean).join(" ") || null;
+
+  const startEditing = () => {
+    setDraft({
+      first_name: profile.first_name ?? "",
+      last_name: profile.last_name ?? "",
+    });
+    setIsEditing(true);
+  };
+
+  const handleSave = async () => {
+    if (!onSave) return;
+    setIsSaving(true);
+    try {
+      await onSave({
+        first_name: draft.first_name.trim(),
+        last_name: draft.last_name.trim(),
+      });
+      toast.success("Name updated");
+      setIsEditing(false);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to update name";
+      toast.error(message);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
   return (
     <div className="bg-card rounded-lg border p-6 space-y-4">
       <h2 className="text-xl font-medium mb-4">Account Information</h2>
-      
+
       <div className="space-y-3">
         <div>
           <label className="text-sm font-medium text-muted-foreground">Email</label>
           <p className="text-base mt-1">{profile.email || "Not available"}</p>
         </div>
 
-        {(profile.first_name || profile.last_name) && (
-          <div>
-            <label className="text-sm font-medium text-muted-foreground">Name</label>
-            <p className="text-base mt-1">
-              {[profile.first_name, profile.last_name].filter(Boolean).join(" ") || "Not available"}
-            </p>
-          </div>
-        )}
+        <div>
+          <label className="text-sm font-medium text-muted-foreground">Name</label>
+          {isEditing ? (
+            <div className="mt-2 space-y-4">
+              <NameFields value={draft} onChange={setDraft} disabled={isSaving} />
+              <div className="flex items-center gap-3">
+                <Button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={isSaving}
+                  className="nv-gradient-button text-white"
+                >
+                  {isSaving ? "Saving..." : "Save"}
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => setIsEditing(false)}
+                  disabled={isSaving}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="mt-1 flex items-center justify-between gap-3">
+              <p className="text-base">{fullName || "Not set"}</p>
+              {onSave && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={startEditing}
+                >
+                  Edit
+                </Button>
+              )}
+            </div>
+          )}
+        </div>
 
         {profile.created_at && (
           <div>

--- a/client/src/pages/account/components/NameFields.tsx
+++ b/client/src/pages/account/components/NameFields.tsx
@@ -1,0 +1,46 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export type NameValue = { first_name: string; last_name: string };
+
+/**
+ * NameFields Component
+ * --------------------
+ * Bare first-name / last-name input pair. Presentational only — the parent owns
+ * the value and persistence. Shared by the account page (name editing) and the
+ * onboarding name-capture step, mirroring how AppearanceFields is reused.
+ */
+export function NameFields({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: NameValue;
+  onChange: (value: NameValue) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <div className="space-y-2">
+        <Label htmlFor="first_name">First name</Label>
+        <Input
+          id="first_name"
+          value={value.first_name}
+          disabled={disabled}
+          onChange={(e) => onChange({ ...value, first_name: e.target.value })}
+          placeholder="First name"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="last_name">Last name</Label>
+        <Input
+          id="last_name"
+          value={value.last_name}
+          disabled={disabled}
+          onChange={(e) => onChange({ ...value, last_name: e.target.value })}
+          placeholder="Last name"
+        />
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/onboarding/Onboarding.tsx
+++ b/client/src/pages/onboarding/Onboarding.tsx
@@ -4,41 +4,60 @@ import { motion } from "framer-motion";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { useProfile } from "@/hooks/use-profile";
+import { useUpdateProfile } from "@/hooks/use-update-profile";
 import { useUserAppearance } from "@/hooks/use-user-appearance";
 import {
   AppearanceFields,
   APPEARANCE_FIELDS,
   countFilledFields,
 } from "@/pages/account/components/appearance";
+import { NameFields, type NameValue } from "@/pages/account/components/NameFields";
 import { ReferenceImageUploader } from "@/pages/account/components/ReferenceImageUploader";
 import type { UserAppearance } from "@/types/userAppearance";
 
 const nvLogoSmall = "/neovita_logo_small.png";
 
-type Step = "appearance" | "photos";
+type Step = "name" | "appearance" | "photos";
+
+const STEP_NUMBER: Record<Step, number> = { name: 1, appearance: 2, photos: 3 };
 
 /**
  * Onboarding (/onboarding)
  *
  * Guided post-email-verification setup. A just-verified user is routed here
- * (instead of straight to /chat) to optionally fill out the two image-related
- * profile pieces before meeting the coach:
- *   1. Appearance preferences  2. Reference photos
+ * (instead of straight to /chat) to fill out their profile before meeting the
+ * coach:
+ *   1. Name (required)  2. Appearance preferences  3. Reference photos
  *
- * Both steps are skippable — nothing here gates the coach. They gate image
- * generation later, which is why we encourage (but don't require) them now.
- * Reuses the same components the account page uses, so anything set here is
- * editable later from the account page.
+ * The name step is required — it has no skip and blocks until both names are
+ * filled. The appearance and photo steps are skippable; nothing there gates the
+ * coach (they gate image generation later). Reuses the same components the
+ * account page uses, so anything set here is editable later from the account page.
  */
 export default function Onboarding() {
   const navigate = useNavigate();
   const { profile } = useProfile();
+  const { updateProfile, isUpdating: isSavingName } = useUpdateProfile();
   const { appearance, updateAppearance, isUpdating } = useUserAppearance(
     profile?.id ?? null
   );
 
-  const [step, setStep] = useState<Step>("appearance");
+  const [step, setStep] = useState<Step>("name");
+  const [localName, setLocalName] = useState<NameValue>({
+    first_name: "",
+    last_name: "",
+  });
   const [localAppearance, setLocalAppearance] = useState<UserAppearance>({});
+
+  // Seed the editable name copy once the profile loads (pre-fill if already set).
+  useEffect(() => {
+    if (profile) {
+      setLocalName({
+        first_name: profile.first_name ?? "",
+        last_name: profile.last_name ?? "",
+      });
+    }
+  }, [profile]);
 
   // Seed the editable copy once the saved appearance loads.
   useEffect(() => {
@@ -46,8 +65,25 @@ export default function Onboarding() {
   }, [appearance]);
 
   const filledCount = countFilledFields(localAppearance);
+  const nameComplete =
+    localName.first_name.trim().length > 0 &&
+    localName.last_name.trim().length > 0;
 
   const goToChat = () => navigate({ to: "/chat" });
+
+  const handleSaveName = async () => {
+    try {
+      await updateProfile({
+        first_name: localName.first_name.trim(),
+        last_name: localName.last_name.trim(),
+      });
+      setStep("appearance");
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to save your name";
+      toast.error(message);
+    }
+  };
 
   const handleSaveAppearance = async () => {
     try {
@@ -80,10 +116,35 @@ export default function Onboarding() {
           transition={{ duration: 0.4 }}
         >
           <p className="text-sm font-medium text-[color:var(--nv-violet-blue)]">
-            Step {step === "appearance" ? 1 : 2} of 2
+            Step {STEP_NUMBER[step]} of 3
           </p>
 
-          {step === "appearance" ? (
+          {step === "name" ? (
+            <>
+              <h1 className="mt-1 text-[26px] font-medium text-black">
+                What should we call you?
+              </h1>
+              <p className="mt-3 text-[15px] leading-relaxed text-black/70">
+                Let&rsquo;s start with your name &mdash; it&rsquo;s how your coach
+                will address you throughout your journey.
+              </p>
+
+              <div className="mt-6">
+                <NameFields value={localName} onChange={setLocalName} />
+              </div>
+
+              <div className="mt-8 flex items-center justify-end gap-3">
+                <Button
+                  type="button"
+                  onClick={handleSaveName}
+                  disabled={!nameComplete || isSavingName}
+                  className="nv-gradient-button text-white"
+                >
+                  {isSavingName ? "Saving..." : "Save & continue"}
+                </Button>
+              </div>
+            </>
+          ) : step === "appearance" ? (
             <>
               <h1 className="mt-1 text-[26px] font-medium text-black">
                 How should we picture you?


### PR DESCRIPTION
## What & why

Registration's multi-form onboarding flow didn't capture the user's name, and the account page showed name read-only. This adds a **required** name step to onboarding and makes the name **editable** from the account page.

## Changes

- **Onboarding (`Onboarding.tsx`)** — new **"What should we call you?"** step as **step 1 of 3** at the front of the flow. It is non-skippable: no Skip button, and *Save & continue* is disabled until both first and last name are filled. Saves via `PATCH /user/me`, pre-filled if a name already exists. Appearance + photos steps remain skippable as before.
- **Account tab (`AccountInformation.tsx` / `Account.tsx`)** — the **Name** field is now editable (Edit → inline first/last inputs → Save / Cancel) on the same tab as Sign Out. Editing is disabled while impersonating (card stays read-only for admins).
- **Shared `NameFields`** presentational component, reused by both surfaces (mirrors the existing `AppearanceFields` reuse pattern).
- **`useUpdateProfile`** mutation hook wrapping `PATCH /user/me`, writing the result back into the profile cache.

Frontend-only — the backend already accepts `first_name`/`last_name` on `PATCH /user/me/` (writable in `UserProfileSerializer`).

## Testing

- `npx tsc --noEmit` — clean (no errors in changed files)
- `npx vitest run` — 275/275 pass
- No new biome lint findings (pre-existing `noLabelWithoutControl` / `noNonNullAssertion` patterns only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)