### PR TITLE
feat(studio): lock the Studio until the visualization phase

### DIFF
--- a/client/src/components/mobile/MobileAuthFooter.tsx
+++ b/client/src/components/mobile/MobileAuthFooter.tsx
@@ -1,5 +1,8 @@
 import { useRouterState, useNavigate } from "@tanstack/react-router";
+import { toast } from "sonner";
 import type { NavItem } from "@/types/navItem";
+import { useCoachState } from "@/hooks/use-coach-state";
+import { isStudioLocked, STUDIO_LOCKED_MESSAGE } from "@/lib/studio-lock";
 import MobileFooterNavItemActive from "./MobileFooterNavItemActive";
 import MobileFooterNavItemInactive from "./MobileFooterNavItemInactive";
 
@@ -16,6 +19,8 @@ export default function MobileAuthFooter() {
   const routerState = useRouterState();
   const pathname = routerState.location.pathname;
   const navigate = useNavigate();
+  const { coachState } = useCoachState();
+  const studioLocked = isStudioLocked(coachState);
 
   const navItems: Array<NavItem> = [
     {
@@ -25,7 +30,7 @@ export default function MobileAuthFooter() {
     },
     { to: "/chat", label: "Chat", icon: "/ai-bubble-white.svg" },
     { to: "/iams", label: "I Am's", icon: "/list.svg" },
-    { to: "/studio", label: "Studio", icon: "/brush.svg" },
+    { to: "/studio", label: "Studio", icon: "/brush.svg", locked: studioLocked },
   ];
 
   return (
@@ -36,12 +41,18 @@ export default function MobileAuthFooter() {
           "linear-gradient(220deg, var(--nv-royal-purple, #531E96) -34.16%, var(--nv-violet-blue, #6A5FFB) 50%)",
       }}
     >
-      {navItems.map(({ to, label, icon }) => {
+      {navItems.map(({ to, label, icon, locked }) => {
         const isActive = pathname === to || pathname.startsWith(to + "/");
         // Chat icon: always use white icon
         const iconSrc = icon;
 
-        const handleClick = () => navigate({ to });
+        const handleClick = () => {
+          if (locked) {
+            toast(STUDIO_LOCKED_MESSAGE);
+            return;
+          }
+          navigate({ to });
+        };
 
         return isActive ? (
           <MobileFooterNavItemActive
@@ -55,6 +66,7 @@ export default function MobileAuthFooter() {
             key={to}
             icon={iconSrc}
             label={label}
+            locked={locked}
             onClick={handleClick}
           />
         );

--- a/client/src/components/mobile/MobileFooterNavItemInactive.tsx
+++ b/client/src/components/mobile/MobileFooterNavItemInactive.tsx
@@ -1,3 +1,5 @@
+import { Lock } from "lucide-react";
+
 /**
  * MobileFooterNavItemInactive
  *
@@ -9,17 +11,20 @@
  * Props:
  * - icon: The icon source path to display
  * - label: The accessibility label for the button
+ * - locked: When true, overlays a lock badge and dims the icon
  * - onClick: Function to call when the button is clicked
  */
 interface MobileFooterNavItemInactiveProps {
   icon: string;
   label: string;
+  locked?: boolean;
   onClick: () => void;
 }
 
 export default function MobileFooterNavItemInactive({
   icon,
   label,
+  locked,
   onClick,
 }: MobileFooterNavItemInactiveProps) {
   return (
@@ -29,7 +34,16 @@ export default function MobileFooterNavItemInactive({
       className="flex justify-center items-center aspect-square shrink-0 rounded-full w-[60px] h-[60px] bg-[color:var(--nv-pale-lavender-50)]"
       aria-label={label}
     >
-      <img src={icon} alt={label} className="w-8 h-8 brightness-0 invert" />
+      <span className="relative inline-flex">
+        <img
+          src={icon}
+          alt={label}
+          className={`w-8 h-8 brightness-0 invert ${locked ? "opacity-60" : ""}`}
+        />
+        {locked && (
+          <Lock className="absolute -bottom-1 -right-1 w-4 h-4 text-[color:var(--nv-royal-purple)]" />
+        )}
+      </span>
     </button>
   );
 }

--- a/client/src/layout/AuthLayout.tsx
+++ b/client/src/layout/AuthLayout.tsx
@@ -2,10 +2,13 @@ import { useRouterState, useNavigate } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { FlaskConical, ScrollText, Shield, Users } from "lucide-react";
+import { FlaskConical, Lock, ScrollText, Shield, Users } from "lucide-react";
+import { toast } from "sonner";
 import MobileAuthHeader from "@/components/mobile/MobileAuthHeader";
 import MobileAuthFooter from "@/components/mobile/MobileAuthFooter";
 import { useProfile } from "@/hooks/use-profile";
+import { useCoachState } from "@/hooks/use-coach-state";
+import { isStudioLocked, STUDIO_LOCKED_MESSAGE } from "@/lib/studio-lock";
 import type { NavItem } from "@/types/navItem";
 import { ImpersonationBanner } from "@/components/ImpersonationBanner";
 
@@ -87,7 +90,7 @@ function SidebarContent({
       </div>
 
       <nav className="flex-1 flex flex-col gap-6 pt-6 px-3">
-        {navItems.map(({ to, label, icon }) => {
+        {navItems.map(({ to, label, icon, locked }) => {
           const isActive = pathname === to || pathname.startsWith(to + "/");
           const isChatIcon = icon === "/ai-bubble-white.svg";
           const iconSrc = isChatIcon
@@ -105,6 +108,10 @@ function SidebarContent({
               key={to}
               type="button"
               onClick={() => {
+                if (locked) {
+                  toast(STUDIO_LOCKED_MESSAGE);
+                  return;
+                }
                 navigate({ to });
               }}
               className={
@@ -114,11 +121,16 @@ function SidebarContent({
                   : "bg-[var(--nv-lilac-white)] ring-1 ring-[#b8b8b8]/60 hover:bg-[var(--nv-pale-lavender)] hover:ring-[var(--nv-royal-purple)]/30")
               }
             >
-              <img
-                src={iconSrc}
-                alt=""
-                className={`w-6 h-6 flex-shrink-0 ${iconFilter}`}
-              />
+              <span className="relative flex-shrink-0">
+                <img
+                  src={iconSrc}
+                  alt=""
+                  className={`w-6 h-6 ${iconFilter} ${locked ? "opacity-50" : ""}`}
+                />
+                {locked && (
+                  <Lock className="absolute -bottom-1 -right-1 w-3.5 h-3.5 text-[color:var(--nv-royal-purple)]" />
+                )}
+              </span>
               <AnimatePresence initial={false}>
                 {(expanded || isMobile) && (
                   <motion.span
@@ -270,6 +282,8 @@ export default function AuthLayout({ children }: { children?: ReactNode }) {
   const pathname = routerState.location.pathname;
   const navigate = useNavigate();
   const { isAdmin } = useProfile();
+  const { coachState } = useCoachState();
+  const studioLocked = isStudioLocked(coachState);
 
   const navItems: Array<NavItem> = [
     { to: "/chat", label: "AI Coach", icon: "/ai-bubble-white.svg" },
@@ -279,7 +293,7 @@ export default function AuthLayout({ children }: { children?: ReactNode }) {
       icon: "/users-round.svg",
     },
     { to: "/iams", label: "I Am's", icon: "/list.svg" },
-    { to: "/studio", label: "Studio", icon: "/brush.svg" },
+    { to: "/studio", label: "Studio", icon: "/brush.svg", locked: studioLocked },
   ];
 
   const bottomItems: Array<NavItem> = [

--- a/client/src/lib/__tests__/studio-lock.test.ts
+++ b/client/src/lib/__tests__/studio-lock.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { isStudioLocked, STUDIO_LOCKED_MESSAGE } from "@/lib/studio-lock";
+import { CoachingPhase } from "@/enums/coachingPhase";
+import type { CoachState } from "@/types/coachState";
+
+function coachStateInPhase(phase: CoachingPhase): CoachState {
+  return {
+    id: "cs-1",
+    user: "user-1",
+    current_phase: phase,
+    who_you_are: null,
+    who_you_want_to_be: null,
+    asked_questions: null,
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("isStudioLocked", () => {
+  it("is unlocked only in the identity visualization phase", () => {
+    expect(
+      isStudioLocked(coachStateInPhase(CoachingPhase.IDENTITY_VISUALIZATION)),
+    ).toBe(false);
+  });
+
+  it("is locked in every other phase", () => {
+    const otherPhases = Object.values(CoachingPhase).filter(
+      (p) => p !== CoachingPhase.IDENTITY_VISUALIZATION,
+    );
+    for (const phase of otherPhases) {
+      expect(isStudioLocked(coachStateInPhase(phase))).toBe(true);
+    }
+  });
+
+  it("is locked when the coach state is unknown (still loading / failed)", () => {
+    expect(isStudioLocked(undefined)).toBe(true);
+  });
+
+  it("exposes a stable user-facing message", () => {
+    expect(STUDIO_LOCKED_MESSAGE).toBe("This isn't available yet.");
+  });
+});

--- a/client/src/lib/studio-lock.ts
+++ b/client/src/lib/studio-lock.ts
@@ -1,0 +1,19 @@
+import { CoachingPhase } from "@/enums/coachingPhase";
+import type { CoachState } from "@/types/coachState";
+
+/**
+ * User-facing message shown when someone tries to open the Studio before
+ * it has been unlocked. Shared by the nav (desktop + mobile) and the
+ * /studio route guard so the wording stays consistent.
+ */
+export const STUDIO_LOCKED_MESSAGE = "This isn't available yet.";
+
+/**
+ * The Studio unlocks only once the user reaches the identity visualization
+ * phase. Any earlier phase — or an as-yet-unknown coach state (still
+ * loading / failed to load) — is treated as locked, so we never flash an
+ * unlocked Studio to a user who hasn't earned it.
+ */
+export function isStudioLocked(coachState: CoachState | undefined): boolean {
+  return coachState?.current_phase !== CoachingPhase.IDENTITY_VISUALIZATION;
+}

--- a/client/src/routes/_authenticated/studio/index.tsx
+++ b/client/src/routes/_authenticated/studio/index.tsx
@@ -1,10 +1,44 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
+import { toast } from "sonner";
 import Studio from "@/pages/studio/Studio";
+import { useCoachState } from "@/hooks/use-coach-state";
+import { isStudioLocked, STUDIO_LOCKED_MESSAGE } from "@/lib/studio-lock";
 
 /**
  * /studio route under pathless _authenticated layout.
  * Provides identity image generation functionality.
+ *
+ * Guarded: the Studio is only reachable once the user reaches the identity
+ * visualization phase. Direct navigation while locked redirects to /chat
+ * (mirrors the admin route guard in _authenticated/admin/route.tsx).
  */
 export const Route = createFileRoute("/_authenticated/studio/")({
-  component: Studio,
+  component: StudioGuard,
 });
+
+function StudioGuard() {
+  const { coachState, isLoading } = useCoachState();
+  const navigate = useNavigate();
+  const locked = isStudioLocked(coachState);
+
+  useEffect(() => {
+    if (isLoading) return;
+    if (locked) {
+      toast(STUDIO_LOCKED_MESSAGE);
+      navigate({ to: "/chat" });
+    }
+  }, [isLoading, locked, navigate]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <span className="text-sm text-muted-foreground">Loading…</span>
+      </div>
+    );
+  }
+
+  if (locked) return null;
+
+  return <Studio />;
+}

--- a/client/src/types/navItem.ts
+++ b/client/src/types/navItem.ts
@@ -2,4 +2,5 @@ export type NavItem = {
   to: string; // The route to navigate to
   label: string; // The label to display for the nav item
   icon: string; // The icon to display for the nav item
+  locked?: boolean; // When true, the item shows a lock badge and is not navigable
 };


### PR DESCRIPTION
## What

The Studio is only available once the user reaches the **identity visualization** phase. In every earlier phase it's locked. PR #2 in the studio-lock series (builds on the rename in #137).

- **Nav (desktop sidebar + mobile footer):** the Studio item shows a small lock badge on the bottom-right of its icon and a dimmed icon. Tapping it shows `"This isn't available yet."` instead of navigating.
- **`/studio` route guard** (`StudioGuard`, mirroring `_authenticated/admin/route.tsx`): direct URL navigation while locked toasts the same message and redirects to `/chat`.
- **`lib/studio-lock`** (`isStudioLocked` + `STUDIO_LOCKED_MESSAGE`) is the single source of truth, driven by `CoachState.current_phase`. Unknown/loading state is treated as locked so we never flash an unlocked Studio.

## Why

We're gating the Studio behind coaching progress; it unlocks at the visualization phase (the unlock animation + chat gating land in the following PRs).

## Scope / non-goals

- Frontend only — lock state is read from existing coach state; no backend changes.
- The unlock animation modal and the in-chat "go to Studio" gating are separate PRs.

## Verification

- `npx tsc --noEmit` — clean
- `npm run build` — passes
- `npm test` — 275 passing, plus new `lib/__tests__/studio-lock.test.ts` (4 tests) covering locked/unlocked/unknown phases + the message constant