### PR TITLE
feat(coach): no-op the coach during identity visualization + gate the chat

### DIFF
--- a/client/src/lib/__tests__/studio-lock.test.ts
+++ b/client/src/lib/__tests__/studio-lock.test.ts
@@ -1,9 +1,17 @@
 import { describe, it, expect } from "vitest";
-import { isStudioLocked, STUDIO_LOCKED_MESSAGE } from "@/lib/studio-lock";
+import {
+  isStudioLocked,
+  isCoachingComplete,
+  STUDIO_LOCKED_MESSAGE,
+  VISUALIZATION_INTRO_VIDEO_KEY,
+} from "@/lib/studio-lock";
 import { CoachingPhase } from "@/enums/coachingPhase";
 import type { CoachState } from "@/types/coachState";
 
-function coachStateInPhase(phase: CoachingPhase): CoachState {
+function coachStateInPhase(
+  phase: CoachingPhase,
+  shownVideos: string[] = [],
+): CoachState {
   return {
     id: "cs-1",
     user: "user-1",
@@ -11,6 +19,7 @@ function coachStateInPhase(phase: CoachingPhase): CoachState {
     who_you_are: null,
     who_you_want_to_be: null,
     asked_questions: null,
+    shown_videos: shownVideos,
     updated_at: "2026-01-01T00:00:00Z",
   };
 }
@@ -37,5 +46,41 @@ describe("isStudioLocked", () => {
 
   it("exposes a stable user-facing message", () => {
     expect(STUDIO_LOCKED_MESSAGE).toBe("This isn't available yet.");
+  });
+});
+
+describe("isCoachingComplete", () => {
+  it("is false in the visualization phase until the intro video is acked", () => {
+    // Phase flips to visualization early (before the intro video), so the
+    // phase alone must NOT mark coaching complete.
+    expect(
+      isCoachingComplete(
+        coachStateInPhase(CoachingPhase.IDENTITY_VISUALIZATION, []),
+      ),
+    ).toBe(false);
+  });
+
+  it("is true once the visualization intro video is acknowledged", () => {
+    expect(
+      isCoachingComplete(
+        coachStateInPhase(CoachingPhase.IDENTITY_VISUALIZATION, [
+          VISUALIZATION_INTRO_VIDEO_KEY,
+        ]),
+      ),
+    ).toBe(true);
+  });
+
+  it("is false outside the visualization phase even if the key is present", () => {
+    expect(
+      isCoachingComplete(
+        coachStateInPhase(CoachingPhase.I_AM_STATEMENT, [
+          VISUALIZATION_INTRO_VIDEO_KEY,
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it("is false for an unknown coach state", () => {
+    expect(isCoachingComplete(undefined)).toBe(false);
   });
 });

--- a/client/src/lib/studio-lock.ts
+++ b/client/src/lib/studio-lock.ts
@@ -17,3 +17,34 @@ export const STUDIO_LOCKED_MESSAGE = "This isn't available yet.";
 export function isStudioLocked(coachState: CoachState | undefined): boolean {
   return coachState?.current_phase !== CoachingPhase.IDENTITY_VISUALIZATION;
 }
+
+/**
+ * Session-video key for the identity visualization intro. Acknowledging this
+ * video is the true "coaching is finished" moment.
+ */
+export const VISUALIZATION_INTRO_VIDEO_KEY = "visualization_session_intro";
+
+/**
+ * True once the user has actually finished the coaching flow: they are in the
+ * identity visualization phase AND have acknowledged the visualization intro
+ * video.
+ *
+ * Why not just the phase? The coach flips `current_phase` to visualization
+ * early — during the I-Am transition turn, before the I-Am outro video, the
+ * between-session break, and the visualization intro video. Keying off the
+ * phase alone fires too soon. Gating on the intro-video acknowledgement
+ * sequences correctly: outro → break → intro video → done.
+ *
+ * This is the shared trigger for both the unlock animation and the
+ * "Go to the Studio" chat gate.
+ */
+export function isCoachingComplete(
+  coachState: CoachState | undefined,
+): boolean {
+  if (coachState?.current_phase !== CoachingPhase.IDENTITY_VISUALIZATION) {
+    return false;
+  }
+  return (coachState.shown_videos ?? []).includes(
+    VISUALIZATION_INTRO_VIDEO_KEY,
+  );
+}

--- a/client/src/pages/chat/components/ChatInterface.tsx
+++ b/client/src/pages/chat/components/ChatInterface.tsx
@@ -4,7 +4,7 @@ import { VisualizationChatGate } from "@/pages/chat/components/VisualizationChat
 import { ChatMessages } from "@/pages/chat/components/ChatMessages";
 import { useChatMessages } from "@/hooks/use-chat-messages";
 import { useCoachState } from "@/hooks/use-coach-state";
-import { CoachingPhase } from "@/enums/coachingPhase";
+import { isCoachingComplete } from "@/lib/studio-lock";
 import { ConversationExporter } from "@/pages/chat/components/ConversationExporter";
 import { ConversationResetter } from "@/pages/chat/components/ConversationResetter";
 import { TestScenarioSessionFreezer } from "@/pages/test/components/TestScenarioSessionFreezer";
@@ -34,11 +34,13 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({ onResetSuccess }) 
   const { profile, isAdmin } = useProfile();
   const { isImpersonating, targetUserId } = useUserTarget();
 
-  // Identity visualization is a no-op coaching phase: the coach does nothing,
-  // so the composer is replaced with a panel pointing the user to the Studio.
+  // Once coaching is complete (visualization phase reached AND the
+  // visualization intro video acknowledged), the coach does nothing, so the
+  // composer is replaced with a panel pointing the user to the Studio. Gating
+  // on the intro-video ack — not the phase alone — keeps this from firing
+  // before the I-Am outro video, the break, and the intro video have played.
   const { coachState } = useCoachState();
-  const inVisualization =
-    coachState?.current_phase === CoachingPhase.IDENTITY_VISUALIZATION;
+  const coachingComplete = isCoachingComplete(coachState);
   const freezeUserId = isImpersonating
     ? targetUserId
     : profile?.id
@@ -139,7 +141,7 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({ onResetSuccess }) 
         componentConfig={componentConfig}
         onSendUserMessageToCoach={handleSendMessage}
       />
-      {inVisualization ? (
+      {coachingComplete ? (
         <VisualizationChatGate />
       ) : (
         <ChatControls

--- a/client/src/pages/chat/components/ChatInterface.tsx
+++ b/client/src/pages/chat/components/ChatInterface.tsx
@@ -1,7 +1,10 @@
 import React, { useRef, useEffect, useCallback } from "react";
 import { ChatControls } from "@/pages/chat/components/ChatControls";
+import { VisualizationChatGate } from "@/pages/chat/components/VisualizationChatGate";
 import { ChatMessages } from "@/pages/chat/components/ChatMessages";
 import { useChatMessages } from "@/hooks/use-chat-messages";
+import { useCoachState } from "@/hooks/use-coach-state";
+import { CoachingPhase } from "@/enums/coachingPhase";
 import { ConversationExporter } from "@/pages/chat/components/ConversationExporter";
 import { ConversationResetter } from "@/pages/chat/components/ConversationResetter";
 import { TestScenarioSessionFreezer } from "@/pages/test/components/TestScenarioSessionFreezer";
@@ -30,6 +33,12 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({ onResetSuccess }) 
   // logged-in user (regular /chat). Hidden for non-admins.
   const { profile, isAdmin } = useProfile();
   const { isImpersonating, targetUserId } = useUserTarget();
+
+  // Identity visualization is a no-op coaching phase: the coach does nothing,
+  // so the composer is replaced with a panel pointing the user to the Studio.
+  const { coachState } = useCoachState();
+  const inVisualization =
+    coachState?.current_phase === CoachingPhase.IDENTITY_VISUALIZATION;
   const freezeUserId = isImpersonating
     ? targetUserId
     : profile?.id
@@ -130,10 +139,14 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({ onResetSuccess }) 
         componentConfig={componentConfig}
         onSendUserMessageToCoach={handleSendMessage}
       />
-      <ChatControls
-        isProcessingMessage={updateStatus === "pending"}
-        onSendMessage={handleSendMessage}
-      />
+      {inVisualization ? (
+        <VisualizationChatGate />
+      ) : (
+        <ChatControls
+          isProcessingMessage={updateStatus === "pending"}
+          onSendMessage={handleSendMessage}
+        />
+      )}
       <div className="flex gap-2 p-2 border-t border-border bg-muted/50">
         <ConversationExporter />
         <ConversationResetter onResetSuccess={onResetSuccess} />

--- a/client/src/pages/chat/components/VisualizationChatGate.tsx
+++ b/client/src/pages/chat/components/VisualizationChatGate.tsx
@@ -1,0 +1,38 @@
+import { useNavigate } from "@tanstack/react-router";
+import { Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+/**
+ * VisualizationChatGate
+ *
+ * Replaces the chat composer once the user reaches the identity
+ * visualization phase. The coach does nothing in this phase (the backend
+ * skips the LLM), so there is nothing to chat about — the user's remaining
+ * work happens in the Studio. This panel makes that explicit and sends them
+ * there.
+ *
+ * Rendered by ChatInterface in place of <ChatControls> when
+ * coachState.current_phase === IDENTITY_VISUALIZATION.
+ */
+export const VisualizationChatGate: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="_VisualizationChatGate bg-gold-200 dark:bg-[#333333] sm:p-4">
+      <div className="flex flex-col items-center gap-3 text-center px-4 py-5">
+        <p className="text-sm text-neutral-700 dark:text-neutral-200 max-w-md">
+          You've finished your coaching sessions. There's nothing more to chat
+          about here — head to your Studio to bring your identities to life.
+        </p>
+        <Button
+          type="button"
+          onClick={() => navigate({ to: "/studio" })}
+          className="gap-2"
+        >
+          <Sparkles className="w-4 h-4" />
+          Go to the Studio
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/server/apps/coach/functions/public/process_message.py
+++ b/server/apps/coach/functions/public/process_message.py
@@ -22,6 +22,7 @@ from apps.coach.utils import (
 from apps.coach_states.models import Break, CoachState
 from apps.users.models import User
 from enums.ai import AIModel
+from enums.coaching_phase import CoachingPhase
 from enums.component_type import ComponentType
 from enums.message_role import MessageRole
 from services.logger import configure_logging
@@ -135,6 +136,22 @@ def process_message(
                 final_prompt="",
                 on_break=on_break,
                 component_config=user_component_config,
+            )
+            return True, response_data, None
+
+        # Identity Visualization is a no-op coaching phase: the coach does not
+        # converse here. The user's work happens in the Studio (which unlocks
+        # at this phase), and the chat composer is replaced client-side with a
+        # "Go to the Studio" prompt. Skip the LLM entirely so no coach message
+        # is generated. User component actions above (e.g. acknowledging the
+        # visualization intro video) have already run.
+        if coach_state.current_phase == CoachingPhase.IDENTITY_VISUALIZATION.value:
+            on_break = user.breaks.filter(ended_at__isnull=True).exists()
+            response_data = build_coach_response_data(
+                coach_message="",
+                final_prompt="",
+                on_break=on_break,
+                component_config=None,
             )
             return True, response_data, None
 

--- a/server/apps/coach/tests/test_process_message.py
+++ b/server/apps/coach/tests/test_process_message.py
@@ -11,6 +11,7 @@ from django.test import SimpleTestCase
 
 from apps.coach.functions.public.process_message import process_message
 from enums.ai import AIModel
+from enums.coaching_phase import CoachingPhase
 from enums.message_role import MessageRole
 
 PATCH_BASE = "apps.coach.functions.public.process_message"
@@ -306,6 +307,91 @@ class TestProcessMessageSkipLlmRule(SimpleTestCase):
         m["generate_coach_ai_response"].assert_called_once()
         m["apply_coach_response_actions"].assert_called_once()
         self.assertEqual(data["message"], "Coach reply")
+
+
+class TestProcessMessageVisualizationNoOp(SimpleTestCase):
+    """Identity Visualization is a no-op coaching phase: the coach does not
+    converse, so the LLM is skipped and no coach message is written."""
+
+    def _run(self, m, message="Hello"):
+        user = _make_user()
+        with (
+            patch(f"{PATCH_BASE}.ensure_initial_message_exists", m["ensure_initial_message_exists"]),
+            patch(f"{PATCH_BASE}.add_chat_message", m["add_chat_message"]),
+            patch(f"{PATCH_BASE}.CoachState", m["CoachState"]),
+            patch(f"{PATCH_BASE}.apply_user_component_actions", m["apply_user_component_actions"]),
+            patch(f"{PATCH_BASE}.build_coach_prompt", m["build_coach_prompt"]),
+            patch(f"{PATCH_BASE}.get_recent_chat_messages_for_prompt", m["get_recent_chat_messages_for_prompt"]),
+            patch(f"{PATCH_BASE}.generate_coach_ai_response", m["generate_coach_ai_response"]),
+            patch(f"{PATCH_BASE}.apply_coach_response_actions", m["apply_coach_response_actions"]),
+            patch(f"{PATCH_BASE}.build_coach_response_data", m["build_coach_response_data"]),
+            patch(f"{PATCH_BASE}.Break", m["Break"]),
+        ):
+            return process_message(user, message, None, AIModel.GPT_4O)
+
+    def test_skips_llm_in_visualization_phase(self):
+        """In identity_visualization the LLM is never built or called."""
+        m = _make_process_message_mocks()
+        m["coach_state"].current_phase = CoachingPhase.IDENTITY_VISUALIZATION.value
+
+        success, _data, error = self._run(m)
+
+        self.assertTrue(success)
+        self.assertIsNone(error)
+        m["build_coach_prompt"].assert_not_called()
+        m["generate_coach_ai_response"].assert_not_called()
+        m["apply_coach_response_actions"].assert_not_called()
+
+    def test_no_coach_message_written_in_visualization(self):
+        """Only the user message is saved — no empty coach reply bubble."""
+        m = _make_process_message_mocks()
+        m["coach_state"].current_phase = CoachingPhase.IDENTITY_VISUALIZATION.value
+
+        self._run(m, message="Hello")
+
+        # add_chat_message is called once (the user message) and never for a
+        # COACH reply.
+        roles = [c.args[2] for c in m["add_chat_message"].call_args_list]
+        self.assertEqual(roles, [MessageRole.USER])
+
+    def test_response_is_empty_noop_payload(self):
+        """The returned payload carries an empty message and no component."""
+        m = _make_process_message_mocks()
+        m["coach_state"].current_phase = CoachingPhase.IDENTITY_VISUALIZATION.value
+
+        self._run(m)
+
+        kwargs = m["build_coach_response_data"].call_args.kwargs
+        self.assertEqual(kwargs["coach_message"], "")
+        self.assertEqual(kwargs["final_prompt"], "")
+        self.assertIsNone(kwargs["component_config"])
+
+    def test_user_component_actions_still_run_in_visualization(self):
+        """The visualization intro video ACK must still be processed even
+        though the LLM is skipped."""
+        m = _make_process_message_mocks()
+        m["coach_state"].current_phase = CoachingPhase.IDENTITY_VISUALIZATION.value
+
+        self._run(m)
+
+        m["apply_user_component_actions"].assert_called_once()
+
+    def test_component_skip_llm_rule_takes_precedence(self):
+        """If a user action returns a component (e.g. END_BREAK → intro video)
+        while already in visualization, that component is still returned —
+        the no-op guard does not swallow it."""
+        m = _make_process_message_mocks()
+        m["coach_state"].current_phase = CoachingPhase.IDENTITY_VISUALIZATION.value
+        component = MagicMock()
+        component.component_type = "session_video"
+        component.model_dump.return_value = {"component_type": "session_video"}
+        m["apply_user_component_actions"] = MagicMock(return_value=component)
+
+        success, _data, _err = self._run(m)
+
+        self.assertTrue(success)
+        builder_kwargs = m["build_coach_response_data"].call_args.kwargs
+        self.assertIs(builder_kwargs["component_config"], component)
 
 
 class TestProcessMessageErrorHandling(SimpleTestCase):


### PR DESCRIPTION
## What

Identity Visualization becomes a phase where **the coach does nothing**. The user's remaining work happens in the Studio (which unlocks at this phase), so there's no coaching conversation here. PR #3 in the studio-lock series (after rename #137 and lock #138).

**Backend (`process_message`):** after the user component actions run — so the visualization intro-video ACK and `END_BREAK` still work — short-circuit before the LLM when `current_phase == identity_visualization` and return an empty no-op payload. No coach message is written. This stops the placeholder visualization-phase prompt from emitting that long "walk through one of your identities" message.

**Frontend (`ChatInterface`):** when `current_phase == identity_visualization`, the composer is replaced with `VisualizationChatGate` — a small panel stating coaching is complete, with a **"Go to the Studio"** button.

## Why

The visualization phase was never meant to coach; it had a leftover placeholder prompt. We're gating it: coach silent, user sent to the Studio.

## Scope / non-goals

- The unlock animation modal is the next PR (#4); this PR is just the no-op + chat gate.
- The placeholder visualization `Prompt` row is now simply never used (LLM is skipped before prompt selection); no prompt/DB changes here.
- The `current_phase` read in the chat is inside the impersonation context, so this works correctly when impersonating a test user.

## Verification

- Backend: `python manage.py test apps.coach.tests.test_process_message` — 22 passing, incl. 5 new visualization-no-op tests (LLM skipped, no coach message written, empty payload, user actions still run, component skip-LLM precedence).
- Frontend: `npx tsc --noEmit` clean, `npm run build` passes, `npm test` 279 passing.