### PR TITLE
feat(coach): per-side coach models in run_coach_eval_diff

### DIFF
--- a/docs/docs/testing/eval-harness/overview.md
+++ b/docs/docs/testing/eval-harness/overview.md
@@ -71,7 +71,7 @@ commands wire them together.
 | **Coach** | The real pipeline: `process_message` → `build_coach_prompt` → `PromptManager` → coach LLM → action handler. | [Prompt Manager](/docs/core-systems/prompt-manager/overview), [Action Handler](/docs/core-systems/action-handler/overview) |
 | **Drive loop** | Seeds a user, drives (or replays) the conversation, records turns + actions + state. Shared by both commands. | `harness.drive_eval` |
 | **Judge** | An LLM-as-judge scoring the transcript against the phase's derived rubric + targeted checks. Stronger model. | `harness.judge_transcript` |
-| **Diff** | Drives a baseline version, replays the same turns against a candidate, and reports the delta + a pairwise comparison. | `run_coach_eval_diff` command |
+| **Diff** | Drives a baseline, replays the same turns against a candidate, and reports the delta + a pairwise comparison. The variable can be the prompt version, the coach model, or both. | `run_coach_eval_diff` command |
 | **Scenario builder** | Drives a persona from the intro phase and (optionally) freezes the end-state as a per-phase starting scenario. | `build_eval_scenario` command |
 
 ### Models used by the harness
@@ -147,6 +147,14 @@ prompt) and **after** (new prompt) on the same scenario. The harness supports th
 via [phase-scoped prompt-version pinning](/docs/testing/eval-harness/prompt-versioning):
 run the baseline pinned to the old version, run the candidate pinned to the new
 version, and diff the outcomes.
+
+The same machinery isolates a **model** change too. The replay holds the client
+side fixed, so whatever you choose to vary becomes the only difference between the
+two runs — the prompt version, the coach model, or both. Pin the *same* prompt
+version on both sides and give each a different `--baseline-model` /
+`--candidate-model`, and the diff attributes the behavior change to the model
+rather than the prompt (exactly the question raised by a GPT-4o → GPT-5.4 upgrade).
+See [Diffing two runs](/docs/testing/eval-harness/running-evals#diffing-two-runs).
 
 ### Transcript vs. judgment (the caching model)
 

--- a/docs/docs/testing/eval-harness/roadmap.md
+++ b/docs/docs/testing/eval-harness/roadmap.md
@@ -50,12 +50,13 @@ The core loop and the scenario-building tooling are in place.
   coach-model/version are replay defaults; override with the flags (typically a new
   `--prompt-version`). See
   [Running Evals → Replay](/docs/testing/eval-harness/running-evals#replay-a-run).
-- **Baseline ↔ candidate diff** — `run_coach_eval_diff` drives a baseline version
-  with the user-bot, replays the *same* user turns against a candidate version, and
-  reports the delta: per-version quality score, targeted-check changes
-  (fixed/regressed), progression, and a **pairwise** judge that compares the two
-  transcripts directly. See
-  [Running Evals → Diffing two versions](/docs/testing/eval-harness/running-evals#diffing-two-versions).
+- **Baseline ↔ candidate diff** — `run_coach_eval_diff` drives a baseline with the
+  user-bot, replays the *same* user turns against a candidate, and reports the
+  delta: per-side quality score, targeted-check changes (fixed/regressed),
+  progression, and a **pairwise** judge that compares the two transcripts directly.
+  The variable can be the prompt version, the coach model (`--baseline-model` /
+  `--candidate-model`), or both. See
+  [Running Evals → Diffing two runs](/docs/testing/eval-harness/running-evals#diffing-two-runs).
 - **`run_coach_eval` MCP tool** — the `dev-coach-docs` MCP server exposes a
   `run_coach_eval` tool that POSTs to a new `POST /api/v1/eval/run` backend
   endpoint, so the edit-prompt → eval → iterate loop runs without shelling into

--- a/docs/docs/testing/eval-harness/running-evals.md
+++ b/docs/docs/testing/eval-harness/running-evals.md
@@ -192,33 +192,62 @@ the only variable:
 4. **Compare the two reports** — quality score + per-criterion reasoning, targeted
    checks, and progression.
 
-For a one-shot, structured comparison, use the [diff command](#diffing-two-versions)
+For a one-shot, structured comparison, use the [diff command](#diffing-two-runs)
 instead of eyeballing two reports.
 
 The version pin is **phase-scoped** (details:
 [Prompt Version Pinning](/docs/testing/eval-harness/prompt-versioning)).
 
-## Diffing two versions
+## Diffing two runs
 
 `run_coach_eval_diff` automates the before/after in one command: it drives the
-**baseline** version with the user-bot, **replays the same user turns** against the
-**candidate** version, then reports the delta.
+**baseline** with the user-bot, **replays the same user turns** against the
+**candidate**, then reports the delta. Because the replay holds the client side
+fixed, whatever you choose to vary is the *only* difference between the two runs.
+
+There are **two independent axes** you can vary:
+
+- **Prompt** — `--baseline-version` / `--candidate-version`.
+- **Model** — `--coach-model` sets the model for **both** sides; `--baseline-model`
+  / `--candidate-model` override a **single** side.
+
+Vary one, the other, or both:
+
+| You want to compare… | How |
+| --- | --- |
+| two prompt versions (same model) | `--baseline-version` / `--candidate-version` |
+| two models (same prompt) | pin the **same** version on both sides + `--baseline-model` / `--candidate-model` |
+| a model **and** a prompt change at once | set both version flags and both model flags |
 
 Versions default the way you'd want: **candidate = the latest active version** (the
 one the coach actually runs), **baseline = the version right before it**. So a bare
 run compares "previous vs latest" — exactly the common case after you publish a new
-version. Override either flag to diff against an older version.
+version. Override either flag to diff against an older version. Models default to the
+configured `DEFAULT_AI_MODEL` on both sides.
 
 ```bash
-# Previous vs latest (the usual case — no version flags needed):
+# Previous vs latest prompt (the usual case — no version flags needed):
 docker exec dev-coach-local-backend-1 \
   python manage.py run_coach_eval_diff \
     --from-scenario "[Auto] Casey @ get_to_know_you" --out /tmp/diff.json
 
-# Or pin specific versions:
+# Or pin specific prompt versions:
 docker exec dev-coach-local-backend-1 \
   python manage.py run_coach_eval_diff --baseline-version 4 --candidate-version 6
+
+# Two models on the SAME prompt — pin the same version on both sides and vary the
+# model. This is how you isolate a model change (e.g. a GPT-4o → GPT-5.4 upgrade)
+# from any prompt difference:
+docker exec dev-coach-local-backend-1 \
+  python manage.py run_coach_eval_diff \
+    --from-scenario "[Auto] Casey @ i_am_statement" \
+    --baseline-version 1 --candidate-version 1 \
+    --baseline-model gpt-4o --candidate-model gpt-5.4
 ```
+
+Each side's prompt version and model are echoed in the run header and the terminal
+`PROMPTS:` / `MODELS:` summary lines, and recorded per-side in the report JSON
+(`baseline.model` / `candidate.model`).
 
 It reports four things:
 
@@ -236,11 +265,13 @@ It reports four things:
   beats differencing two absolute scores.
 
 Flags: `--candidate-version` (defaults to latest active), `--baseline-version`
-(defaults to the version right before the candidate), `--from-scenario`,
-`--persona`, `--coach-model` (one model for both runs — the prompt is the
-variable), `--check`, `--max-turns`, `--out PATH`, `--keep`. If there's no version
-below the candidate (only one exists), it errors and asks you to pass
-`--baseline-version`.
+(defaults to the version right before the candidate), `--coach-model` (model for
+both sides; defaults to `DEFAULT_AI_MODEL`), `--baseline-model` / `--candidate-model`
+(override the model on one side), `--from-scenario`, `--persona`, `--check`,
+`--max-turns`, `--out PATH`, `--keep`. If there's no version below the candidate
+(only one exists) and you haven't pinned `--candidate-version` equal to it, it
+errors and asks you to pass `--baseline-version` — pass the same version to both
+flags when you only want to vary the model.
 
 > **One sample, live coach.** Replay fixes the *user* turns, but the coach is still
 > a live LLM and the pairwise judge has mild position bias — one diff is a single

--- a/server/apps/coach/management/commands/run_coach_eval_diff.py
+++ b/server/apps/coach/management/commands/run_coach_eval_diff.py
@@ -15,12 +15,21 @@ Runs the SAME conversation against two prompt versions and reports the delta:
         -> report the delta (quality score, targeted checks, progression,
            pairwise preference)
 
-Replay holds the user side fixed, so the prompt version is the only thing that
-differs between the two runs. Each run's quality rubric is still derived from its
-OWN prompt body (a v11 run is judged against v11's instructions); the targeted
-checks are constant across versions, so they give a clean apples-to-apples delta.
-The pairwise judge compares the two transcripts directly (more reliable than
-differencing two absolute scores).
+Replay holds the user side fixed, so what differs between the two runs is
+whatever axis you choose to vary — the prompt version, the coach model, or both.
+Each run's quality rubric is still derived from its OWN prompt body (a v11 run is
+judged against v11's instructions); the targeted checks are constant across
+versions, so they give a clean apples-to-apples delta. The pairwise judge
+compares the two transcripts directly (more reliable than differencing two
+absolute scores).
+
+Two independent axes:
+  - PROMPT:  --baseline-version / --candidate-version
+  - MODEL:   --coach-model sets BOTH sides; --baseline-model / --candidate-model
+             override a single side. So you can hold the prompt fixed and vary
+             only the model (same version on both sides + different models), vary
+             only the prompt (one model, two versions — the original behavior),
+             or vary both at once.
 
 Shares all the machinery (seeding, drive loop, judge) with run_coach_eval_spike
 via apps/coach/eval/harness.py.
@@ -34,6 +43,12 @@ Usage:
     python manage.py run_coach_eval_diff                          # latest-1 vs latest
     python manage.py run_coach_eval_diff --baseline-version 4     # v4 vs latest
     python manage.py run_coach_eval_diff --baseline-version 10 --candidate-version 11
+    # Same prompt, two models (pin one version on both sides, vary the model):
+    python manage.py run_coach_eval_diff --baseline-version 6 --candidate-version 6 \
+        --baseline-model gpt-4o --candidate-model gpt-5.4
+    # Two models AND two prompts at once:
+    python manage.py run_coach_eval_diff --baseline-version 6 --candidate-version 7 \
+        --baseline-model gpt-4o --candidate-model gpt-5.4
     python manage.py run_coach_eval_diff --from-scenario "[Auto] Casey @ get_to_know_you" \
         --out /tmp/diff.json
 """
@@ -103,7 +118,26 @@ class Command(BaseCommand):
             "--coach-model",
             type=str,
             default=None,
-            help="Coach model for BOTH runs (the variable is the prompt, not the model).",
+            help=(
+                "Coach model for BOTH sides. Defaults to the configured "
+                "DEFAULT_AI_MODEL. Override a single side with --baseline-model / "
+                "--candidate-model."
+            ),
+        )
+        parser.add_argument(
+            "--baseline-model",
+            type=str,
+            default=None,
+            help=(
+                "Coach model for the BASELINE side only (overrides --coach-model). "
+                "Pin the same prompt version on both sides to vary only the model."
+            ),
+        )
+        parser.add_argument(
+            "--candidate-model",
+            type=str,
+            default=None,
+            help="Coach model for the CANDIDATE side only (overrides --coach-model).",
         )
         parser.add_argument(
             "--baseline-version",
@@ -195,6 +229,18 @@ class Command(BaseCommand):
             return None
         return lower[0], candidate_v  # lower[0] is the largest below candidate
 
+    def _resolve_models(self, coach_model, baseline_model, candidate_model):
+        """Resolve per-side coach models to concrete AIModels.
+
+        --coach-model sets both sides; --baseline-model / --candidate-model
+        override a single side. Any side left unset falls back to --coach-model,
+        which itself falls back to the configured DEFAULT_AI_MODEL. Returns
+        (baseline_model, candidate_model).
+        """
+        baseline = AIModel.get_or_default(baseline_model or coach_model)
+        candidate = AIModel.get_or_default(candidate_model or coach_model)
+        return baseline, candidate
+
     def _make_emit(self, label):
         def emit(kind: str, text: str) -> None:
             if kind == "client":
@@ -279,7 +325,9 @@ class Command(BaseCommand):
 
     # --- orchestration --------------------------------------------------------
     def handle(self, *args, **options):
-        coach_model = AIModel.get_or_default(options["coach_model"])
+        baseline_model, candidate_model = self._resolve_models(
+            options["coach_model"], options["baseline_model"], options["candidate_model"]
+        )
         persona = load_persona(options["persona"])
         harness_client = AIServiceFactory.create(DEFAULT_USER_BOT_MODEL).client
         scenario_name = options["from_scenario"]
@@ -319,8 +367,14 @@ class Command(BaseCommand):
                 ))
             targeted_checks = load_targeted_checks(start_phase, options["check"])
 
+            if baseline_model == candidate_model:
+                model_desc = f"coach: {candidate_model.value}"
+            else:
+                model_desc = (
+                    f"coach: {baseline_model.value} -> {candidate_model.value}"
+                )
             self.stdout.write(self.style.HTTP_INFO(
-                f"Diff | persona: {persona.name} | coach: {coach_model.value} "
+                f"Diff | persona: {persona.name} | {model_desc} "
                 f"| phase: {start_phase} | seed: {scenario_name or 'cold get_to_know_you'} "
                 f"| baseline v{baseline_v} vs candidate v{candidate_v} "
                 f"| checks: {len(targeted_checks)}"
@@ -328,7 +382,7 @@ class Command(BaseCommand):
 
             baseline = self._run_side(
                 label="baseline", version=baseline_v, user=user,
-                start_phase=start_phase, prior=prior, coach_model=coach_model,
+                start_phase=start_phase, prior=prior, coach_model=baseline_model,
                 max_turns=max_turns, harness_client=harness_client,
                 targeted_checks=targeted_checks, persona=persona, replay_turns=None,
             )
@@ -341,7 +395,7 @@ class Command(BaseCommand):
             cleanup_emails.add(email)
             candidate = self._run_side(
                 label="candidate", version=candidate_v, user=user,
-                start_phase=start_phase, prior=prior, coach_model=coach_model,
+                start_phase=start_phase, prior=prior, coach_model=candidate_model,
                 max_turns=max_turns, harness_client=harness_client,
                 targeted_checks=targeted_checks, persona=None, replay_turns=user_turns,
             )
@@ -362,7 +416,8 @@ class Command(BaseCommand):
                 start_phase=start_phase,
                 scenario_name=scenario_name,
                 persona=persona,
-                coach_model=coach_model,
+                baseline_model=baseline_model,
+                candidate_model=candidate_model,
                 user_turns=user_turns,
                 targeted_checks=targeted_checks,
                 baseline=baseline,
@@ -401,8 +456,9 @@ class Command(BaseCommand):
             })
         return out
 
-    def _report(self, *, start_phase, scenario_name, persona, coach_model,
-                user_turns, targeted_checks, baseline, candidate, pairwise, out_path):
+    def _report(self, *, start_phase, scenario_name, persona, baseline_model,
+                candidate_model, user_turns, targeted_checks, baseline, candidate,
+                pairwise, out_path):
         bv, cv = baseline["verdict"], candidate["verdict"]
         b_phase = baseline["run"].final_phase
         c_phase = candidate["run"].final_phase
@@ -413,16 +469,17 @@ class Command(BaseCommand):
             "phase": start_phase,
             "scenario": scenario_name or "cold get_to_know_you",
             "persona": persona.persona_id,
-            "coach_model": coach_model.value,
             "user_turns": user_turns,
             "baseline": {
                 "prompt_version": baseline["prompt_version"],
+                "model": baseline_model.value,
                 "quality": {"passed": bv.passed, "score": bv.score},
                 "final_phase": b_phase,
                 "transitioned": b_phase != start_phase,
             },
             "candidate": {
                 "prompt_version": candidate["prompt_version"],
+                "model": candidate_model.value,
                 "quality": {"passed": cv.passed, "score": cv.score},
                 "final_phase": c_phase,
                 "transitioned": c_phase != start_phase,
@@ -453,6 +510,10 @@ class Command(BaseCommand):
         bvers, cvers = baseline["prompt_version"], candidate["prompt_version"]
         self.stdout.write(self.style.HTTP_INFO(
             f"\nPROMPTS:  baseline v{bvers}  vs  candidate v{cvers}"
+        ))
+        self.stdout.write(self.style.HTTP_INFO(
+            f"MODELS:   baseline {baseline_model.value}  vs  "
+            f"candidate {candidate_model.value}"
         ))
         delta = cv.score - bv.score
         arrow = "▲" if delta > 0 else ("▼" if delta < 0 else "=")

--- a/server/apps/coach/tests/test_eval_diff.py
+++ b/server/apps/coach/tests/test_eval_diff.py
@@ -10,6 +10,7 @@ from django.test import SimpleTestCase
 from apps.coach.eval.harness import CheckResult
 from apps.coach.management.commands import run_coach_eval_diff
 from apps.coach.management.commands.run_coach_eval_diff import Command
+from enums.ai import AIModel
 
 
 def _verdict(checks):
@@ -47,6 +48,41 @@ class TestCheckDeltas(SimpleTestCase):
         rows = self.cmd._check_deltas(baseline, candidate)
         self.assertEqual([r["check"] for r in rows], ["a"])
         self.assertEqual(rows[0]["change"], "regressed")
+
+
+class TestResolveModels(SimpleTestCase):
+    """--coach-model sets both sides; --baseline/--candidate-model override one."""
+
+    def setUp(self):
+        self.cmd = Command()
+
+    def test_all_unset_defaults_both_sides(self):
+        default = AIModel.get_or_default(None)
+        self.assertEqual(self.cmd._resolve_models(None, None, None), (default, default))
+
+    def test_coach_model_sets_both_sides(self):
+        self.assertEqual(
+            self.cmd._resolve_models("gpt-4o", None, None),
+            (AIModel.GPT_4O, AIModel.GPT_4O),
+        )
+
+    def test_per_side_overrides_coach_model(self):
+        self.assertEqual(
+            self.cmd._resolve_models("gpt-4o", "gpt-5.4", None),
+            (AIModel.GPT_5_4, AIModel.GPT_4O),
+        )
+
+    def test_both_sides_explicit(self):
+        self.assertEqual(
+            self.cmd._resolve_models(None, "gpt-4o", "gpt-5.4"),
+            (AIModel.GPT_4O, AIModel.GPT_5_4),
+        )
+
+    def test_candidate_override_only_baseline_falls_back(self):
+        self.assertEqual(
+            self.cmd._resolve_models("gpt-4o", None, "gpt-5.4"),
+            (AIModel.GPT_4O, AIModel.GPT_5_4),
+        )
 
 
 class TestResolveVersions(SimpleTestCase):


### PR DESCRIPTION
## What

Adds **model** as an independent variation axis to `run_coach_eval_diff`, so the replay harness can compare two coach models on the *same* prompt — not just two prompts on the same model.

- `--coach-model` still sets the model for **both** sides (unchanged).
- New `--baseline-model` / `--candidate-model` override a **single** side.

This unlocks all three combinations:
| baseline | candidate | how |
|---|---|---|
| same model, **diff prompt** | | `--baseline-version` / `--candidate-version` (original behavior) |
| **diff model**, same prompt | | pin the same version both sides + `--baseline-model` / `--candidate-model` |
| **diff model, diff prompt** | | both axes at once |

## Why

We moved the live coach from GPT-4o → GPT-5.4 and the I Am phase now behaves differently (Leigh Anne: "asking 3 questions, harder/longer than before"). To attribute that to the model vs. the prompt we need a clean, replayed, same-prompt A/B between the two models. The diff harness already holds the client side fixed via replay; this just lets the model be the thing that differs.

## How

- New pure `_resolve_models(coach_model, baseline_model, candidate_model)` helper — each side falls back to `--coach-model`, which falls back to `DEFAULT_AI_MODEL`. Unit-tested the same way as `_resolve_versions`.
- Each side's resolved model is threaded into its own `_run_side` call.
- Per-side `model` surfaced in the report JSON and a new `MODELS:` terminal summary line; the run header shows `coach: <base> -> <cand>` when they differ.

## Example

```
python manage.py run_coach_eval_diff --from-scenario "[Auto] Casey @ i_am_statement" \
    --baseline-version 1 --candidate-version 1 \
    --baseline-model gpt-4o --candidate-model gpt-5.4
```

## Testing

- `python manage.py test apps.coach.tests.test_eval_diff --settings=settings.test` → 16 passing (5 new `_resolve_models` cases).
- `run_coach_eval_diff --help` shows the new flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)