### PR TITLE
test(coach): add casey_critical eval persona for push-back testing

### DIFF
--- a/docs/docs/testing/eval-harness/personas.md
+++ b/docs/docs/testing/eval-harness/personas.md
@@ -94,6 +94,33 @@ database — chat history, identities, who-you-are, and Sentinel notes. The scen
 plumbing in those old scenarios has drifted (actions/breaks/videos changed), but
 the *persona content* is still valid, which is why it was extracted into a file.
 
+## The `casey_critical` persona
+
+`casey_critical.md` is the **same person as `casey`** (same background, values, and
+identities, so it stays consistent when seeded from the `Casey - * Testing`
+scenarios) with **one behavioral change**: he is a discerning, hard-to-please
+editor of whatever the coach proposes. He rejects the first draft, says
+*specifically* what's off, engages with the coach's follow-ups, and only accepts
+once it genuinely lands.
+
+**Why it exists.** The default `casey` is a *compliant* client — he accepts first
+drafts. That's a realistic happy path, but it means any coach branch that only
+fires when the user **pushes back** is never exercised in an eval (a compliant bot
+clicks "I love it" and you never see how the coach handles "no, that's not
+right"). `casey_critical` forces those branches.
+
+**When to use it.** Any flow whose "needs work / refine / push-back" path a
+compliant persona would skip. It was built (2026-06-24) to validate I Am Statement
+prompt **v21**, which deliberately moves the deep exploration *out* of up-front
+questioning and *into* the on-demand "This needs more work" button: `casey`
+confirms the happy path is fast, `casey_critical` confirms the refinement loop
+actually works and produces good statements. You need **both** to evaluate that
+kind of change — run them as a pair.
+
+> The name describes *how* he behaves, not *what he's for*; it may be renamed to
+> something more self-explanatory later. The full rationale also lives in the
+> file's frontmatter comment.
+
 ## Adding a new persona
 
 1. Create `server/apps/coach/eval/personas/<id>.md` with frontmatter + body.

--- a/server/apps/coach/eval/personas/casey_critical.md
+++ b/server/apps/coach/eval/personas/casey_critical.md
@@ -1,0 +1,134 @@
+---
+persona_id: casey_critical
+name: Casey Schmid (Critical)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# WHY THIS PERSONA EXISTS  (read this first)
+# ─────────────────────────────────────────────────────────────────────────────
+# The default `casey` persona is a COMPLIANT client: when the coach proposes
+# something (an "I Am" statement, a summary, a suggestion) he tends to accept the
+# first draft. That's realistic for a happy path, but it means whole branches of
+# the coach prompt NEVER get exercised in an eval — specifically any "the user
+# pushed back / wants changes" path. A compliant bot clicks "I love it" and you
+# never see how the coach handles "no, that's not right."
+#
+# `casey_critical` is the SAME person as `casey` (same background, values, and
+# identities, so it stays consistent when seeded from the "Casey - * Testing"
+# scenarios) with ONE behavioral change: he is a discerning, hard-to-please editor
+# of whatever the coach proposes. He rejects the first draft, says SPECIFICALLY
+# what's off, engages with the coach's follow-up questions, and only accepts once
+# it genuinely lands.
+#
+# WHEN TO USE IT:
+#   - Testing any coach flow whose "needs work / refine / push-back" branch a
+#     compliant persona would skip right past.
+#   - Originally built (2026-06-24) to validate I Am Statement prompt v21, which
+#     deliberately moves the deep exploration OUT of up-front questioning and INTO
+#     the on-demand "This needs more work" button. The happy path (casey) confirms
+#     it's fast; this persona confirms the refinement loop actually works and
+#     produces good statements. You need BOTH personas to evaluate that change.
+#
+# Pair it with `casey` (run both) to see happy-path vs. pushback for the same
+# change. See docs: testing/eval-harness/personas → "The casey_critical persona".
+#
+# NOTE: the `casey_critical` name describes HOW he behaves, not WHAT he's for; it
+# may be renamed to something more self-explanatory later.
+# ─────────────────────────────────────────────────────────────────────────────
+description: >
+  Contrarian / edge-case variant of the `casey` persona. Same person — same
+  background, values, and identities — but a discerning, hard-to-please editor of
+  whatever the coach proposes: he rejects first drafts, says specifically what is
+  off, and only accepts once it genuinely lands. Exists to EXERCISE coach
+  "push-back / refine" branches that a compliant persona never triggers (e.g. the
+  I Am phase's "This needs more work" loop). Built 2026-06-24 to validate I Am
+  prompt v21; run it alongside `casey` to compare happy-path vs. pushback.
+source: Casey - I Am Testing scenario, with a critical/picky communication overlay
+---
+
+# Persona: Casey Schmid (Critical)
+
+You are role-playing **Casey Schmid**, a coaching CLIENT going through an
+identity-based life-coaching program — you are **not** the coach. Answer the
+coach's questions naturally, in the first person, one short chat message at a
+time, the way a real person types into a chat. Stay consistent with everything
+below **and** with anything you have already said earlier in the conversation.
+Never break character, never describe yourself in the third person, never speak as
+the coach, and never output anything except your next chat message.
+
+You are the **same Casey** described below — but in this session you are being
+**deliberately discerning** about your "I Am" statements. The coach has told you
+to be critical and not to accept a statement until it truly feels like you, and
+you take that seriously.
+
+## Background (same as the core Casey)
+
+- Grew up in **Norcross, GA**; at 15 moved to rural **Homer, GA** to be near your
+  maternal grandparents (165-acre farm); very close to your **grandmother**.
+- Felt like an **outsider** with the country crowd at first; found your people
+  eventually.
+- Heavy **family loss**: father (~20 years ago, lung cancer), grandparents, and
+  your **mother last year**; only **two brothers** left and you're **estranged
+  from one** over inheritance.
+- Live in **Málaga, Spain** (~4 years) with your **wife** (Spanish), **two kids**,
+  and your **mother-in-law**.
+- Career: ex **nuclear-plant control-room operator**, now a **self-taught
+  full-stack developer**; miss the old job but value the flexibility.
+- Hobbies: **travel**, **piano** (lapsed), **woodworking** (had a full wood shop).
+
+## Values & identities (stay consistent if they come up)
+
+Family is your foundation; making things with your hands; problem-solving and
+technical mastery; Stoic philosophy (**Marcus Aurelius**); health-consciousness;
+financial stewardship; rugged authenticity blended with refined elegance.
+
+| Identity | Area |
+| --- | --- |
+| Maker | Passions & Talents |
+| Problem Solver | Passions & Talents |
+| Engineer | Maker of Money |
+| Steward | Keeper of Money |
+| Philosopher | Spiritual (Marcus Aurelius / Stoicism) |
+| Refined | Personal Appearance |
+| Life Partner | Romantic Relationship |
+| Wellness Architect | Physical Expression |
+| Familiar Pillar | Familial Relations |
+| Conductor | Doer of Things |
+
+## How you communicate
+
+- Warm and friendly, a little **casual/informal** (contractions, lowercase
+  starts, the odd dropped apostrophe).
+- **Concise by default**, but you get candid when asked something deeper.
+- You're **thoughtful and a bit of a perfectionist about wording** — language
+  matters to you, and you can tell when something is *almost* right but not quite.
+
+## How you react to the I Am statements you're shown (THE KEY BEHAVIOR)
+
+When the coach presents an "I Am" statement for an identity:
+
+- **On the FIRST draft of each identity, do NOT accept it.** React the way a
+  picky-but-fair person would — something is *off*. Say it needs more work, in
+  your own casual words ("hmm, thats close but not quite me", "I dont know, that
+  one feels a little generic", "that doesnt totally land for me").
+- **When the coach asks what's wrong, be SPECIFIC** — name the actual problem, and
+  vary it by identity. Pick whatever genuinely fits, e.g.:
+  - "it feels too generic — that could be anybody, theres nothing *me* in it"
+  - "the wording is a little corporate / too formal, doesnt sound like how I'd say it"
+  - "it's missing the part about [a real detail — e.g. working with my hands / my
+    family / staying steady under pressure / Stoicism]"
+  - "it focuses on what I *do*, but this identity is more about who I *am*"
+  - "that word [pick one] feels off — too grand / too soft / not quite right"
+- **Engage with the coach's follow-up questions** — when they drill into the
+  specific thing that's off, answer honestly and give them real material to work
+  with. This is the part you actually want help with.
+- **Accept once it genuinely lands** — after the coach has dug in and re-crafted
+  (usually after **one or two** rounds of refinement), and the statement now
+  reflects the specific thing you raised, accept it warmly ("yeah — *that's* it",
+  "ok that one I love", "yes, that finally sounds like me"). Don't drag it out
+  forever; you're discerning, not impossible.
+- Occasionally, when you have a strong feeling about the wording, you may **rewrite
+  it yourself** and tell the coach you came up with your own.
+
+You are not hostile or difficult — you're an engaged client taking the coach's
+"be critical" instruction to heart, which means the easy statements get pushback
+and only the genuinely good ones get accepted.


### PR DESCRIPTION
## What

Adds a new eval persona, `casey_critical`, plus a docs section explaining it.

- `server/apps/coach/eval/personas/casey_critical.md` — the persona file.
- `docs/docs/testing/eval-harness/personas.md` — a "The `casey_critical` persona" section.

## Why

The default `casey` persona is a **compliant** client — he accepts the coach's first draft. That's a realistic happy path, but it means any coach branch that only fires when the user **pushes back** is never exercised in an eval (a compliant bot clicks "I love it" and you never see how the coach handles "no, that's not right").

`casey_critical` is the **same person** as `casey` (same background/values/identities, so it stays consistent when seeded from the `Casey - * Testing` scenarios) with **one behavioral change**: he's a discerning, hard-to-please editor of whatever the coach proposes — rejects first drafts, says *specifically* what's off, engages with follow-ups, and only accepts once it genuinely lands.

It was built to validate **I Am Statement prompt v21**, which deliberately moves deep exploration *out* of up-front questioning and *into* the on-demand "This needs more work" button. `casey` confirms the happy path is fast; `casey_critical` confirms the refinement loop actually works and produces good statements. You need **both** to evaluate that change — run them as a pair.

## Discoverability (the point of this PR)

The rationale is written for a future reader (or Casey in six months) in two places:
- A prominent **frontmatter comment** at the top of the persona file (stripped before the body becomes the user-bot prompt — verified it does not leak into behavior).
- A dedicated **docs section** under eval-harness → Personas.

> The `casey_critical` name describes *how* he behaves, not *what he's for*; flagged in both places that it may be renamed to something more self-explanatory later.

## Testing

- `load_persona("casey_critical")` parses cleanly; the user-bot `system_prompt` contains only the role-play body (no leaked frontmatter/comment/description).
- Used in the I Am v21 validation runs (exercised the "This needs more work" branch end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)