### PR TITLE
feat(meditations): media provider abstraction + Veo & Gemini-TTS providers

### DIFF
--- a/server/enums/media.py
+++ b/server/enums/media.py
@@ -1,0 +1,51 @@
+from django.db import models
+
+
+class VideoProvider(models.TextChoices):
+    """
+    Enum of supported video-generation providers for meditations.
+
+    Used to select which concrete video provider the media factory builds.
+    As new providers are added, add them here and wire a branch into
+    ``MediaProviderFactory.create_video_provider``.
+    """
+
+    GOOGLE_VEO = "GOOGLE_VEO", "Google Veo"
+
+    @classmethod
+    def from_string(cls, provider_name: str) -> "VideoProvider":
+        """Convert a string representation to a VideoProvider enum value."""
+        name_map = {
+            "google_veo": cls.GOOGLE_VEO,
+            "veo": cls.GOOGLE_VEO,
+            "google": cls.GOOGLE_VEO,
+        }
+        normalized = provider_name.strip().lower()
+        if normalized not in name_map:
+            raise ValueError(f"Unknown video provider: {provider_name}")
+        return name_map[normalized]
+
+
+class AudioProvider(models.TextChoices):
+    """
+    Enum of supported audio-generation (text-to-speech) providers for
+    meditations.
+
+    Used to select which concrete audio provider the media factory builds.
+    """
+
+    GEMINI_TTS = "GEMINI_TTS", "Google Gemini TTS"
+
+    @classmethod
+    def from_string(cls, provider_name: str) -> "AudioProvider":
+        """Convert a string representation to an AudioProvider enum value."""
+        name_map = {
+            "gemini_tts": cls.GEMINI_TTS,
+            "gemini": cls.GEMINI_TTS,
+            "google": cls.GEMINI_TTS,
+            "tts": cls.GEMINI_TTS,
+        }
+        normalized = provider_name.strip().lower()
+        if normalized not in name_map:
+            raise ValueError(f"Unknown audio provider: {provider_name}")
+        return name_map[normalized]

--- a/server/services/media/__init__.py
+++ b/server/services/media/__init__.py
@@ -1,0 +1,28 @@
+"""
+Media generation layer for the meditations feature.
+
+Provider-agnostic interfaces for generating video and audio, with concrete
+implementations resolved by ``MediaProviderFactory``. Callers depend only on
+the base interfaces + the standard ``MediaResult`` / ``MediaGenerationError``
+types, never on a concrete vendor.
+"""
+
+from services.media.base import (
+    BaseAudioProvider,
+    BaseVideoProvider,
+    MediaGenerationError,
+    MediaResult,
+)
+from services.media.factory import MediaProviderFactory
+from services.media.gemini_tts_provider import GeminiTTSProvider
+from services.media.veo_video_provider import VeoVideoProvider
+
+__all__ = [
+    "BaseAudioProvider",
+    "BaseVideoProvider",
+    "MediaGenerationError",
+    "MediaResult",
+    "MediaProviderFactory",
+    "GeminiTTSProvider",
+    "VeoVideoProvider",
+]

--- a/server/services/media/base.py
+++ b/server/services/media/base.py
@@ -1,0 +1,158 @@
+"""
+Media Generation Base Module
+
+Defines the contracts the meditations feature uses to generate media, plus the
+standard result/error types. Callers (orchestration, Celery tasks) interact
+exclusively with these interfaces; the concrete provider is resolved by
+``MediaProviderFactory`` and is an implementation detail.
+
+Two capability families:
+    BaseVideoProvider  — image-to-video (first frame -> short clip)
+    BaseAudioProvider  — text-to-speech (script -> narration)
+
+Concrete implementations live alongside this module:
+    VeoVideoProvider     (services/media/veo_video_provider.py)
+    GeminiTTSProvider    (services/media/gemini_tts_provider.py)
+
+To add a new provider, create a class inheriting the relevant base, implement
+its abstract methods, register it in the factory, and add a value to the
+matching enum in ``enums/media.py``.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Optional
+
+from enums.media import AudioProvider, VideoProvider
+
+
+@dataclass
+class MediaResult:
+    """
+    Standard output of any media provider.
+
+    ``data`` is the raw bytes ready to upload to S3; the remaining fields are
+    metadata callers persist alongside the asset. Dimensions are video-only and
+    left ``None`` for audio.
+    """
+
+    data: bytes
+    mime_type: str
+    provider: str
+    model: str
+    duration_seconds: Optional[float] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
+    extra: dict = field(default_factory=dict)
+
+
+class MediaGenerationError(Exception):
+    """
+    Custom exception for media generation failures with a machine-readable
+    error code, mirroring ``ImageGenerationError`` so callers can surface a
+    consistent retry UX across image, video, and audio generation.
+    """
+
+    BLOCKED_PROMPT = "BLOCKED_PROMPT"
+    SAFETY_BLOCK = "SAFETY_BLOCK"
+    RATE_LIMITED = "RATE_LIMITED"
+    MODEL_OVERLOADED = "MODEL_OVERLOADED"
+    TIMEOUT = "TIMEOUT"
+    EMPTY_RESPONSE = "EMPTY_RESPONSE"
+    UNKNOWN = "UNKNOWN"
+
+    def __init__(
+        self, message: str, error_code: str = "UNKNOWN", details: Optional[str] = None
+    ):
+        self.message = message
+        self.error_code = error_code
+        self.details = details
+        super().__init__(self.message)
+
+    def to_dict(self) -> dict:
+        return {
+            "message": self.message,
+            "error_code": self.error_code,
+            "details": self.details,
+        }
+
+    @classmethod
+    def from_exception(cls, e: Exception) -> "MediaGenerationError":
+        """
+        Convert a generic provider/SDK exception into a MediaGenerationError,
+        parsing common error patterns for a specific error code.
+        """
+        if isinstance(e, cls):
+            return e
+
+        error_str = str(e).lower()
+
+        if "503" in str(e) or "unavailable" in error_str or "overloaded" in error_str:
+            return cls(
+                message="The media model is currently overloaded. Please wait a moment and try again.",
+                error_code=cls.MODEL_OVERLOADED,
+                details=str(e),
+            )
+
+        if "429" in str(e) or "rate limit" in error_str or "quota" in error_str:
+            return cls(
+                message="Too many requests. Please wait a moment before trying again.",
+                error_code=cls.RATE_LIMITED,
+                details=str(e),
+            )
+
+        if "safety" in error_str or "blocked" in error_str:
+            return cls(
+                message="The request was blocked by safety filters. Please modify the prompt and try again.",
+                error_code=cls.SAFETY_BLOCK,
+                details=str(e),
+            )
+
+        return cls(
+            message=f"Media generation failed: {str(e)}",
+            error_code=cls.UNKNOWN,
+            details=str(e),
+        )
+
+
+class BaseVideoProvider(ABC):
+    """Contract for image-to-video providers."""
+
+    @abstractmethod
+    def generate(
+        self,
+        *,
+        prompt: str,
+        first_frame: bytes,
+        first_frame_mime: str = "image/png",
+        aspect_ratio: str = "16:9",
+        resolution: str = "1080p",
+        duration_seconds: int = 8,
+    ) -> MediaResult:
+        """
+        Generate a short video clip from a text prompt and a first-frame image.
+
+        Returns a MediaResult with the encoded video bytes and metadata.
+        Raises MediaGenerationError on failure.
+        """
+
+    @abstractmethod
+    def provider_name(self) -> VideoProvider:
+        """Return the VideoProvider enum value for this implementation."""
+
+
+class BaseAudioProvider(ABC):
+    """Contract for text-to-speech providers."""
+
+    @abstractmethod
+    def generate(self, *, script: str, voice: Optional[str] = None) -> MediaResult:
+        """
+        Generate narration audio from a text script.
+
+        Returns a MediaResult with the encoded audio bytes and metadata.
+        Raises MediaGenerationError on failure.
+        """
+
+    @abstractmethod
+    def provider_name(self) -> AudioProvider:
+        """Return the AudioProvider enum value for this implementation."""

--- a/server/services/media/factory.py
+++ b/server/services/media/factory.py
@@ -1,0 +1,95 @@
+"""
+Media Provider Factory
+
+Single entry point for creating media provider instances. Resolves the correct
+concrete implementation for video and audio generation based on an explicit
+provider, an environment override, or the default.
+
+To add a new provider:
+  1. Create a class in services/media/ that inherits BaseVideoProvider or
+     BaseAudioProvider.
+  2. Add a value to the matching enum in enums/media.py.
+  3. Add the provider's branch below.
+
+Environment overrides:
+  MEDITATIONS_VIDEO_PROVIDER  (default: GOOGLE_VEO)
+  MEDITATIONS_AUDIO_PROVIDER  (default: GEMINI_TTS)
+"""
+
+import os
+from pathlib import Path
+from typing import Optional, Union
+
+from dotenv import load_dotenv
+
+from enums.media import AudioProvider, VideoProvider
+from services.logger import configure_logging
+from services.media.base import BaseAudioProvider, BaseVideoProvider
+from services.media.gemini_tts_provider import GeminiTTSProvider
+from services.media.veo_video_provider import VeoVideoProvider
+
+# Load .env so the factory works in standalone scripts; in the running app
+# Django has already populated the environment.
+load_dotenv(Path(__file__).resolve().parents[2] / ".env")
+
+log = configure_logging(__name__, log_level="INFO")
+
+
+class MediaProviderFactory:
+    """Factory for creating media provider instances."""
+
+    @staticmethod
+    def create_video_provider(
+        provider: Optional[Union[VideoProvider, str]] = None, **kwargs
+    ) -> BaseVideoProvider:
+        """
+        Return a concrete BaseVideoProvider. Extra kwargs are forwarded to the
+        provider constructor (e.g. api_key, model).
+        """
+        resolved = _resolve(
+            provider,
+            VideoProvider,
+            env_var="MEDITATIONS_VIDEO_PROVIDER",
+            default=VideoProvider.GOOGLE_VEO,
+        )
+        log.debug(f"Creating video provider: {resolved}")
+
+        if resolved == VideoProvider.GOOGLE_VEO:
+            return VeoVideoProvider(**kwargs)
+
+        raise NotImplementedError(f"Video provider not implemented: {resolved}")
+
+    @staticmethod
+    def create_audio_provider(
+        provider: Optional[Union[AudioProvider, str]] = None, **kwargs
+    ) -> BaseAudioProvider:
+        """
+        Return a concrete BaseAudioProvider. Extra kwargs are forwarded to the
+        provider constructor (e.g. api_key, model, voice).
+        """
+        resolved = _resolve(
+            provider,
+            AudioProvider,
+            env_var="MEDITATIONS_AUDIO_PROVIDER",
+            default=AudioProvider.GEMINI_TTS,
+        )
+        log.debug(f"Creating audio provider: {resolved}")
+
+        if resolved == AudioProvider.GEMINI_TTS:
+            return GeminiTTSProvider(**kwargs)
+
+        raise NotImplementedError(f"Audio provider not implemented: {resolved}")
+
+
+def _resolve(provider, enum_cls, *, env_var: str, default):
+    """
+    Resolve a provider selection from an explicit value, an env override, or
+    the default. Accepts the enum, a string, or None.
+    """
+    if provider is None:
+        provider = os.getenv(env_var)
+    if provider is None:
+        return default
+    if isinstance(provider, enum_cls):
+        return provider
+    return enum_cls.from_string(str(provider))

--- a/server/services/media/gemini_tts_provider.py
+++ b/server/services/media/gemini_tts_provider.py
@@ -1,0 +1,127 @@
+"""
+Gemini TTS audio provider.
+
+Concrete BaseAudioProvider backed by Google's Gemini text-to-speech models via
+the google-genai SDK, reusing the same ``GEMINI_API_KEY`` as the rest of the
+Google integration. It narrates a script (the identity's "I Am" statement, or
+an admin-edited version) in a single fixed brand voice.
+
+Gemini TTS returns raw 24kHz, 16-bit, mono PCM; this provider wraps it in a WAV
+container so callers get a self-describing, playable file to store in S3.
+"""
+
+import io
+import os
+import wave
+from pathlib import Path
+from typing import Optional
+
+from dotenv import load_dotenv
+from google import genai
+from google.genai import types
+
+from enums.media import AudioProvider
+from services.logger import configure_logging
+from services.media.base import BaseAudioProvider, MediaGenerationError, MediaResult
+
+# Load .env so the provider works in standalone scripts; in the running app
+# Django has already populated the environment.
+load_dotenv(Path(__file__).resolve().parents[2] / ".env")
+
+log = configure_logging(__name__, log_level="INFO")
+
+
+class GeminiTTSProvider(BaseAudioProvider):
+    """Generate narration audio with Google Gemini TTS."""
+
+    DEFAULT_MODEL = "gemini-2.5-flash-preview-tts"
+    DEFAULT_VOICE = "Kore"
+
+    # Gemini TTS PCM characteristics (24kHz, 16-bit, mono).
+    SAMPLE_RATE = 24000
+    SAMPLE_WIDTH = 2
+    CHANNELS = 1
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        voice: Optional[str] = None,
+    ):
+        self.api_key = api_key or os.getenv("GEMINI_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "GEMINI_API_KEY is required. Set it in .env or pass to constructor."
+            )
+        self.model = model or os.getenv("MEDITATIONS_TTS_MODEL") or self.DEFAULT_MODEL
+        self.voice = voice or os.getenv("MEDITATIONS_TTS_VOICE") or self.DEFAULT_VOICE
+        self.client = genai.Client(api_key=self.api_key)
+        log.info(
+            f"GeminiTTSProvider initialized (model={self.model}, voice={self.voice})"
+        )
+
+    def provider_name(self) -> AudioProvider:
+        return AudioProvider.GEMINI_TTS
+
+    def generate(self, *, script: str, voice: Optional[str] = None) -> MediaResult:
+        voice_name = voice or self.voice
+        config = types.GenerateContentConfig(
+            response_modalities=["AUDIO"],
+            speech_config=types.SpeechConfig(
+                voice_config=types.VoiceConfig(
+                    prebuilt_voice_config=types.PrebuiltVoiceConfig(
+                        voice_name=voice_name
+                    )
+                )
+            ),
+        )
+
+        log.info(f"Generating TTS audio: model={self.model}, voice={voice_name}")
+
+        try:
+            response = self.client.models.generate_content(
+                model=self.model, contents=script, config=config
+            )
+        except Exception as e:
+            log.error(f"Gemini TTS failed: {e}", exc_info=True)
+            raise MediaGenerationError.from_exception(e)
+
+        pcm = self._extract_pcm(response)
+        wav_bytes = self._pcm_to_wav(pcm)
+        duration = len(pcm) / float(
+            self.SAMPLE_RATE * self.SAMPLE_WIDTH * self.CHANNELS
+        )
+
+        log.info(f"TTS audio generated: {len(wav_bytes)} bytes, {duration:.2f}s")
+        return MediaResult(
+            data=wav_bytes,
+            mime_type="audio/wav",
+            provider=AudioProvider.GEMINI_TTS.value,
+            model=self.model,
+            duration_seconds=round(duration, 3),
+        )
+
+    def _extract_pcm(self, response) -> bytes:
+        """Pull the raw PCM bytes out of a Gemini TTS response."""
+        candidates = getattr(response, "candidates", None) or []
+        for candidate in candidates:
+            content = getattr(candidate, "content", None)
+            parts = getattr(content, "parts", None) if content else None
+            for part in parts or []:
+                inline = getattr(part, "inline_data", None)
+                data = getattr(inline, "data", None) if inline else None
+                if data:
+                    return data
+        raise MediaGenerationError(
+            "Gemini TTS returned no audio.", MediaGenerationError.EMPTY_RESPONSE
+        )
+
+    def _pcm_to_wav(self, pcm: bytes) -> bytes:
+        """Wrap raw PCM in a WAV container."""
+        buffer = io.BytesIO()
+        with wave.open(buffer, "wb") as wav_file:
+            wav_file.setnchannels(self.CHANNELS)
+            wav_file.setsampwidth(self.SAMPLE_WIDTH)
+            wav_file.setframerate(self.SAMPLE_RATE)
+            wav_file.writeframes(pcm)
+        return buffer.getvalue()

--- a/server/services/media/tests/test_media.py
+++ b/server/services/media/tests/test_media.py
@@ -1,0 +1,268 @@
+"""
+Tests for the media generation layer (services/media/).
+
+Covers the provider enums, the standard error type, the Veo video provider and
+Gemini TTS provider (with the google-genai client mocked), and the factory.
+No network calls are made.
+"""
+
+from unittest.mock import MagicMock
+
+from django.test import SimpleTestCase
+
+from enums.media import AudioProvider, VideoProvider
+from services.media.base import MediaGenerationError, MediaResult
+from services.media.factory import MediaProviderFactory
+from services.media.gemini_tts_provider import GeminiTTSProvider
+from services.media.veo_video_provider import VeoVideoProvider
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class TestProviderEnums(SimpleTestCase):
+    def test_video_provider_from_string(self):
+        self.assertEqual(VideoProvider.from_string("veo"), VideoProvider.GOOGLE_VEO)
+        self.assertEqual(
+            VideoProvider.from_string("GOOGLE_VEO"), VideoProvider.GOOGLE_VEO
+        )
+
+    def test_video_provider_from_string_unknown(self):
+        with self.assertRaises(ValueError):
+            VideoProvider.from_string("runway")
+
+    def test_audio_provider_from_string(self):
+        self.assertEqual(AudioProvider.from_string("gemini"), AudioProvider.GEMINI_TTS)
+        self.assertEqual(AudioProvider.from_string("TTS"), AudioProvider.GEMINI_TTS)
+
+    def test_audio_provider_from_string_unknown(self):
+        with self.assertRaises(ValueError):
+            AudioProvider.from_string("elevenlabs")
+
+
+# ---------------------------------------------------------------------------
+# MediaGenerationError
+# ---------------------------------------------------------------------------
+
+
+class TestMediaGenerationError(SimpleTestCase):
+    def test_from_exception_rate_limited(self):
+        err = MediaGenerationError.from_exception(Exception("429 quota exceeded"))
+        self.assertEqual(err.error_code, MediaGenerationError.RATE_LIMITED)
+
+    def test_from_exception_overloaded(self):
+        err = MediaGenerationError.from_exception(Exception("503 UNAVAILABLE"))
+        self.assertEqual(err.error_code, MediaGenerationError.MODEL_OVERLOADED)
+
+    def test_from_exception_safety(self):
+        err = MediaGenerationError.from_exception(
+            Exception("request blocked by safety")
+        )
+        self.assertEqual(err.error_code, MediaGenerationError.SAFETY_BLOCK)
+
+    def test_from_exception_unknown(self):
+        err = MediaGenerationError.from_exception(Exception("something odd"))
+        self.assertEqual(err.error_code, MediaGenerationError.UNKNOWN)
+
+    def test_from_exception_passthrough(self):
+        original = MediaGenerationError("boom", MediaGenerationError.TIMEOUT)
+        self.assertIs(MediaGenerationError.from_exception(original), original)
+
+
+# ---------------------------------------------------------------------------
+# VeoVideoProvider
+# ---------------------------------------------------------------------------
+
+
+def _make_veo_provider(**kwargs):
+    provider = VeoVideoProvider(api_key="test-key", **kwargs)
+    provider.client = MagicMock()
+    return provider
+
+
+def _mock_done_operation(video_bytes=b"VIDEOBYTES", mime_type="video/mp4"):
+    video = MagicMock()
+    video.video_bytes = video_bytes
+    video.mime_type = mime_type
+    generated = MagicMock()
+    generated.video = video
+    op = MagicMock()
+    op.done = True
+    op.error = None
+    op.response.generated_videos = [generated]
+    return op
+
+
+class TestVeoVideoProvider(SimpleTestCase):
+    def test_provider_name(self):
+        self.assertEqual(_make_veo_provider().provider_name(), VideoProvider.GOOGLE_VEO)
+
+    def test_generate_success(self):
+        provider = _make_veo_provider()
+        provider.client.models.generate_videos.return_value = _mock_done_operation()
+
+        result = provider.generate(prompt="serene portrait", first_frame=b"img")
+
+        self.assertIsInstance(result, MediaResult)
+        self.assertEqual(result.data, b"VIDEOBYTES")
+        self.assertEqual(result.mime_type, "video/mp4")
+        self.assertEqual(result.provider, VideoProvider.GOOGLE_VEO.value)
+        self.assertEqual(result.width, 1920)
+        self.assertEqual(result.height, 1080)
+        self.assertEqual(result.duration_seconds, 8.0)
+        provider.client.files.download.assert_called_once()
+
+    def test_generate_forces_8s_at_1080p(self):
+        provider = _make_veo_provider()
+        provider.client.models.generate_videos.return_value = _mock_done_operation()
+
+        provider.generate(
+            prompt="p", first_frame=b"img", resolution="1080p", duration_seconds=4
+        )
+
+        config = provider.client.models.generate_videos.call_args.kwargs["config"]
+        self.assertEqual(config.duration_seconds, 8)
+
+    def test_generate_allows_4s_at_720p(self):
+        provider = _make_veo_provider()
+        provider.client.models.generate_videos.return_value = _mock_done_operation()
+
+        provider.generate(
+            prompt="p", first_frame=b"img", resolution="720p", duration_seconds=4
+        )
+
+        config = provider.client.models.generate_videos.call_args.kwargs["config"]
+        self.assertEqual(config.duration_seconds, 4)
+
+    def test_generate_timeout(self):
+        provider = _make_veo_provider(poll_interval=0, timeout=0)
+        op = MagicMock()
+        op.done = False
+        provider.client.models.generate_videos.return_value = op
+
+        with self.assertRaises(MediaGenerationError) as ctx:
+            provider.generate(prompt="p", first_frame=b"img")
+        self.assertEqual(ctx.exception.error_code, MediaGenerationError.TIMEOUT)
+
+    def test_generate_operation_error(self):
+        provider = _make_veo_provider()
+        op = MagicMock()
+        op.done = True
+        op.error = "safety violation"
+        provider.client.models.generate_videos.return_value = op
+
+        with self.assertRaises(MediaGenerationError):
+            provider.generate(prompt="p", first_frame=b"img")
+
+    def test_generate_empty_response(self):
+        provider = _make_veo_provider()
+        op = MagicMock()
+        op.done = True
+        op.error = None
+        op.response.generated_videos = []
+        provider.client.models.generate_videos.return_value = op
+
+        with self.assertRaises(MediaGenerationError) as ctx:
+            provider.generate(prompt="p", first_frame=b"img")
+        self.assertEqual(ctx.exception.error_code, MediaGenerationError.EMPTY_RESPONSE)
+
+    def test_generate_wraps_submit_exception(self):
+        provider = _make_veo_provider()
+        provider.client.models.generate_videos.side_effect = Exception("429 quota")
+
+        with self.assertRaises(MediaGenerationError) as ctx:
+            provider.generate(prompt="p", first_frame=b"img")
+        self.assertEqual(ctx.exception.error_code, MediaGenerationError.RATE_LIMITED)
+
+
+# ---------------------------------------------------------------------------
+# GeminiTTSProvider
+# ---------------------------------------------------------------------------
+
+
+def _make_tts_provider(**kwargs):
+    provider = GeminiTTSProvider(api_key="test-key", **kwargs)
+    provider.client = MagicMock()
+    return provider
+
+
+def _mock_tts_response(pcm=b"\x00\x01" * 12000):
+    part = MagicMock()
+    part.inline_data.data = pcm
+    response = MagicMock()
+    response.candidates = [MagicMock()]
+    response.candidates[0].content.parts = [part]
+    return response
+
+
+class TestGeminiTTSProvider(SimpleTestCase):
+    def test_provider_name(self):
+        self.assertEqual(_make_tts_provider().provider_name(), AudioProvider.GEMINI_TTS)
+
+    def test_generate_success_wraps_wav(self):
+        provider = _make_tts_provider()
+        provider.client.models.generate_content.return_value = _mock_tts_response()
+
+        result = provider.generate(script="I am calm. I am focused.")
+
+        self.assertIsInstance(result, MediaResult)
+        self.assertEqual(result.mime_type, "audio/wav")
+        self.assertEqual(result.provider, AudioProvider.GEMINI_TTS.value)
+        # WAV container magic bytes.
+        self.assertTrue(result.data.startswith(b"RIFF"))
+        self.assertIn(b"WAVE", result.data[:12])
+        self.assertGreater(result.duration_seconds, 0)
+
+    def test_generate_no_audio_raises(self):
+        provider = _make_tts_provider()
+        response = MagicMock()
+        response.candidates = []
+        provider.client.models.generate_content.return_value = response
+
+        with self.assertRaises(MediaGenerationError) as ctx:
+            provider.generate(script="hello")
+        self.assertEqual(ctx.exception.error_code, MediaGenerationError.EMPTY_RESPONSE)
+
+    def test_generate_wraps_api_exception(self):
+        provider = _make_tts_provider()
+        provider.client.models.generate_content.side_effect = Exception(
+            "503 overloaded"
+        )
+
+        with self.assertRaises(MediaGenerationError) as ctx:
+            provider.generate(script="hello")
+        self.assertEqual(
+            ctx.exception.error_code, MediaGenerationError.MODEL_OVERLOADED
+        )
+
+
+# ---------------------------------------------------------------------------
+# MediaProviderFactory
+# ---------------------------------------------------------------------------
+
+
+class TestMediaProviderFactory(SimpleTestCase):
+    def test_create_video_provider_default(self):
+        provider = MediaProviderFactory.create_video_provider(api_key="test-key")
+        self.assertIsInstance(provider, VeoVideoProvider)
+
+    def test_create_video_provider_by_string(self):
+        provider = MediaProviderFactory.create_video_provider("veo", api_key="test-key")
+        self.assertIsInstance(provider, VeoVideoProvider)
+
+    def test_create_video_provider_by_enum(self):
+        provider = MediaProviderFactory.create_video_provider(
+            VideoProvider.GOOGLE_VEO, api_key="test-key"
+        )
+        self.assertIsInstance(provider, VeoVideoProvider)
+
+    def test_create_audio_provider_default(self):
+        provider = MediaProviderFactory.create_audio_provider(api_key="test-key")
+        self.assertIsInstance(provider, GeminiTTSProvider)
+
+    def test_create_audio_provider_by_string(self):
+        provider = MediaProviderFactory.create_audio_provider(
+            "gemini", api_key="test-key"
+        )
+        self.assertIsInstance(provider, GeminiTTSProvider)

--- a/server/services/media/veo_video_provider.py
+++ b/server/services/media/veo_video_provider.py
@@ -1,0 +1,176 @@
+"""
+Veo video provider.
+
+Concrete BaseVideoProvider backed by Google's Veo models via the google-genai
+SDK, reusing the same ``GEMINI_API_KEY`` as the identity image service. This is
+a "dumb" provider: it takes a prompt + first-frame image and returns encoded
+video bytes. Prompt construction and persistence belong to callers.
+
+Verified facts (see the meditations braindump's "Veo spike findings"):
+  - Veo generation is a long-running async operation: submit -> poll
+    ``operations.get`` until ``done`` -> download.
+  - Default model ``veo-3.1-fast-generate-preview`` (3.0/2.0 are deprecated).
+  - 1080p / 4k force an 8s duration; 720p allows 4/6/8s. Output is H.264 + AAC
+    mp4 at 24fps; Veo's always-on audio track is ignored by callers.
+  - Image-to-video of a person requires ``person_generation="allow_adult"``.
+"""
+
+import os
+import time
+from pathlib import Path
+from typing import Optional
+
+from dotenv import load_dotenv
+from google import genai
+from google.genai import types
+
+from enums.media import VideoProvider
+from services.logger import configure_logging
+from services.media.base import BaseVideoProvider, MediaGenerationError, MediaResult
+
+# Load .env so the provider works in standalone scripts; in the running app
+# Django has already populated the environment.
+load_dotenv(Path(__file__).resolve().parents[2] / ".env")
+
+log = configure_logging(__name__, log_level="INFO")
+
+# Pixel dimensions per resolution label, used to stamp asset metadata.
+RESOLUTION_DIMENSIONS = {
+    "720p": (1280, 720),
+    "1080p": (1920, 1080),
+    "4k": (3840, 2160),
+}
+
+
+class VeoVideoProvider(BaseVideoProvider):
+    """Generate short video clips with Google Veo (image-to-video)."""
+
+    DEFAULT_MODEL = "veo-3.1-fast-generate-preview"
+    PERSON_GENERATION = "allow_adult"
+    POLL_INTERVAL_SECONDS = 10
+    TIMEOUT_SECONDS = 600
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        *,
+        poll_interval: Optional[int] = None,
+        timeout: Optional[int] = None,
+    ):
+        self.api_key = api_key or os.getenv("GEMINI_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "GEMINI_API_KEY is required. Set it in .env or pass to constructor."
+            )
+        self.model = model or os.getenv("MEDITATIONS_VEO_MODEL") or self.DEFAULT_MODEL
+        self.poll_interval = (
+            poll_interval if poll_interval is not None else self.POLL_INTERVAL_SECONDS
+        )
+        self.timeout = timeout if timeout is not None else self.TIMEOUT_SECONDS
+        self.client = genai.Client(api_key=self.api_key)
+        log.info(f"VeoVideoProvider initialized (model={self.model})")
+
+    def provider_name(self) -> VideoProvider:
+        return VideoProvider.GOOGLE_VEO
+
+    def generate(
+        self,
+        *,
+        prompt: str,
+        first_frame: bytes,
+        first_frame_mime: str = "image/png",
+        aspect_ratio: str = "16:9",
+        resolution: str = "1080p",
+        duration_seconds: int = 8,
+    ) -> MediaResult:
+        # 1080p and 4k only support an 8s duration; coerce and warn rather than
+        # let the API reject the request.
+        if resolution.lower() != "720p" and duration_seconds != 8:
+            log.warning(
+                f"Veo {resolution} only supports 8s; overriding "
+                f"duration_seconds={duration_seconds} -> 8"
+            )
+            duration_seconds = 8
+
+        config = types.GenerateVideosConfig(
+            aspect_ratio=aspect_ratio,
+            resolution=resolution,
+            number_of_videos=1,
+            person_generation=self.PERSON_GENERATION,
+            duration_seconds=duration_seconds,
+        )
+
+        log.info(
+            f"Generating video: model={self.model}, resolution={resolution}, "
+            f"aspect_ratio={aspect_ratio}, duration={duration_seconds}s"
+        )
+
+        try:
+            operation = self.client.models.generate_videos(
+                model=self.model,
+                prompt=prompt,
+                image=types.Image(image_bytes=first_frame, mime_type=first_frame_mime),
+                config=config,
+            )
+        except Exception as e:
+            log.error(f"Veo submit failed: {e}", exc_info=True)
+            raise MediaGenerationError.from_exception(e)
+
+        operation = self._poll(operation)
+
+        if operation.error:
+            raise MediaGenerationError(
+                message="Veo reported an error while generating the video.",
+                error_code=MediaGenerationError.UNKNOWN,
+                details=str(operation.error),
+            )
+
+        videos = (
+            getattr(operation.response, "generated_videos", None)
+            if operation.response
+            else None
+        ) or []
+        if not videos:
+            raise MediaGenerationError(
+                "Veo returned no video.", MediaGenerationError.EMPTY_RESPONSE
+            )
+
+        video = videos[0].video
+        try:
+            self.client.files.download(file=video)
+        except Exception as e:
+            log.error(f"Veo download failed: {e}", exc_info=True)
+            raise MediaGenerationError.from_exception(e)
+
+        data = getattr(video, "video_bytes", None)
+        if not data:
+            raise MediaGenerationError(
+                "Veo video contained no bytes.", MediaGenerationError.EMPTY_RESPONSE
+            )
+
+        width, height = RESOLUTION_DIMENSIONS.get(resolution.lower(), (None, None))
+        log.info(f"Veo video generated: {len(data)} bytes")
+        return MediaResult(
+            data=data,
+            mime_type=getattr(video, "mime_type", None) or "video/mp4",
+            provider=VideoProvider.GOOGLE_VEO.value,
+            model=self.model,
+            duration_seconds=float(duration_seconds),
+            width=width,
+            height=height,
+        )
+
+    def _poll(self, operation):
+        """Poll the long-running operation until done or timed out."""
+        elapsed = 0
+        while not operation.done:
+            if elapsed >= self.timeout:
+                raise MediaGenerationError(
+                    f"Veo generation timed out after {self.timeout}s.",
+                    MediaGenerationError.TIMEOUT,
+                )
+            time.sleep(self.poll_interval)
+            elapsed += self.poll_interval
+            operation = self.client.operations.get(operation)
+        return operation


### PR DESCRIPTION
## Summary

PR-01 of the **meditations** feature: a provider-agnostic media-generation layer under `server/services/media/`. It mirrors the existing text-AI factory pattern (`enums/ai.py` `AIProvider` + `services/ai/ai_service_factory.py`) so video and audio providers are swappable behind a stable interface. Purely additive — no existing code paths touched, and the identity image generation is intentionally left alone.

This is the foundation the rest of the feature builds on (orchestration → admin QC). Nothing here is wired into the app yet.

### What changed
- **`enums/media.py`** — `VideoProvider` (`GOOGLE_VEO`) and `AudioProvider` (`GEMINI_TTS`) enums with `from_string`, mirroring `AIProvider`.
- **`services/media/base.py`** — `BaseVideoProvider` / `BaseAudioProvider` interfaces, a standard `MediaResult` dataclass (bytes + metadata), and `MediaGenerationError` with the same error-code taxonomy as `ImageGenerationError` (rate-limited / overloaded / safety / timeout / empty / unknown).
- **`services/media/veo_video_provider.py`** — `VeoVideoProvider`: image-to-video via Google Veo. Default model `veo-3.1-fast-generate-preview` (3.0/2.0 are deprecated), 1080p / 16:9 / 8s, first frame passed as the image input, async submit→poll→download, a guard that coerces 1080p/4k to the API-required 8s, and a poll timeout.
- **`services/media/gemini_tts_provider.py`** — `GeminiTTSProvider`: text→speech via Gemini TTS, wrapping the returned 24kHz/16-bit/mono PCM into a WAV container.
- **`services/media/factory.py` + `__init__.py`** — `MediaProviderFactory` resolving a provider from an explicit enum/string, an env override (`MEDITATIONS_VIDEO_PROVIDER` / `MEDITATIONS_AUDIO_PROVIDER`), or the default.

All providers reuse the existing `GEMINI_API_KEY`; no new dependency (`google-genai==1.56.0` already present).

### Testing
- `pytest services/media/tests/test_media.py` (under `settings.test`) — **26/26 pass**, google-genai client mocked, no network calls.
- isort / black / flake8 — clean.
- **Live smoke** against the real API to validate the actual contracts: Veo (verified earlier — 720p/1080p, 8s, h264+aac mp4) and Gemini TTS (313KB WAV, 6.5s, valid RIFF header, model `gemini-2.5-flash-preview-tts`).

No runtime behavior change — the layer is not yet called by anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)