### PR TITLE
feat(meditations): generation orchestration (prompts, Celery, admin API)

### DIFF
--- a/server/apps/api_urls.py
+++ b/server/apps/api_urls.py
@@ -24,6 +24,7 @@ from apps.identities.views import (
     IdentityImageChatViewSet,
     IdentityViewSet,
 )
+from apps.meditations.views import AdminMeditationViewSet
 from apps.prompts.views import PromptViewSet
 from apps.reference_images.views import ReferenceImageViewSet
 from apps.test_scenario.views import AdminTestScenarioViewSet
@@ -73,6 +74,9 @@ admin_router.register(
     basename="admin-identity-image-chat",
 )
 admin_router.register(r"test-user", AdminTestUserViewSet, basename="admin-test-user")
+admin_router.register(
+    r"meditations", AdminMeditationViewSet, basename="admin-meditations"
+)
 
 # JWT token URLs
 jwt_patterns = [

--- a/server/apps/meditations/serializers/__init__.py
+++ b/server/apps/meditations/serializers/__init__.py
@@ -1,0 +1,17 @@
+"""
+Meditation serializers.
+"""
+
+from apps.meditations.serializers.meditation_serializers import (
+    MeditationAssetSerializer,
+    MeditationDetailSerializer,
+    MeditationListSerializer,
+    MeditationSegmentSerializer,
+)
+
+__all__ = [
+    "MeditationAssetSerializer",
+    "MeditationDetailSerializer",
+    "MeditationListSerializer",
+    "MeditationSegmentSerializer",
+]

--- a/server/apps/meditations/serializers/meditation_serializers.py
+++ b/server/apps/meditations/serializers/meditation_serializers.py
@@ -1,0 +1,85 @@
+"""
+Serializers for the meditations admin API.
+"""
+
+from django.core.files.storage import default_storage
+from rest_framework import serializers
+
+from apps.meditations.models import Meditation, MeditationAsset, MeditationSegment
+
+
+class MeditationAssetSerializer(serializers.ModelSerializer):
+    url = serializers.SerializerMethodField()
+
+    class Meta:
+        model = MeditationAsset
+        fields = (
+            "id",
+            "kind",
+            "version",
+            "status",
+            "is_active",
+            "s3_key",
+            "url",
+            "prompt_snapshot",
+            "error_code",
+            "created_at",
+            "updated_at",
+        )
+
+    def get_url(self, obj):
+        if not obj.s3_key:
+            return None
+        return default_storage.url(obj.s3_key)
+
+
+class MeditationSegmentSerializer(serializers.ModelSerializer):
+    assets = MeditationAssetSerializer(many=True, read_only=True)
+    identity_name = serializers.CharField(source="identity.name", read_only=True)
+
+    class Meta:
+        model = MeditationSegment
+        fields = (
+            "id",
+            "identity",
+            "identity_name",
+            "order",
+            "current_video_prompt",
+            "current_audio_script",
+            "assets",
+        )
+
+
+class MeditationDetailSerializer(serializers.ModelSerializer):
+    segments = MeditationSegmentSerializer(many=True, read_only=True)
+    user_email = serializers.EmailField(source="user.email", read_only=True)
+
+    class Meta:
+        model = Meditation
+        fields = (
+            "id",
+            "user",
+            "user_email",
+            "status",
+            "final_video_s3_key",
+            "segments",
+            "created_at",
+            "updated_at",
+        )
+
+
+class MeditationListSerializer(serializers.ModelSerializer):
+    user_email = serializers.EmailField(source="user.email", read_only=True)
+    segment_count = serializers.IntegerField(source="segments.count", read_only=True)
+
+    class Meta:
+        model = Meditation
+        fields = (
+            "id",
+            "user",
+            "user_email",
+            "status",
+            "segment_count",
+            "created_at",
+            "updated_at",
+        )

--- a/server/apps/meditations/services/__init__.py
+++ b/server/apps/meditations/services/__init__.py
@@ -1,0 +1,18 @@
+"""
+Meditation services — orchestration logic for creating meditations and
+generating their parts.
+"""
+
+from apps.meditations.services.create_meditation import (
+    create_meditation_for_user,
+    get_eligible_identities,
+)
+from apps.meditations.services.generate_part import generate_segment_part
+from apps.meditations.services.set_active_asset import set_active_asset
+
+__all__ = [
+    "create_meditation_for_user",
+    "get_eligible_identities",
+    "generate_segment_part",
+    "set_active_asset",
+]

--- a/server/apps/meditations/services/create_meditation.py
+++ b/server/apps/meditations/services/create_meditation.py
@@ -1,0 +1,55 @@
+"""
+create_meditation_for_user — build a pending meditation and its empty segments.
+
+A segment is created for every identity that has BOTH a saved image and an
+i_am_statement, ordered by identity order. Each segment is seeded with the
+current editable video prompt (from the VIDEO_GENERATION prompt template) and
+audio script (the identity's I Am statement). No parts are generated here.
+"""
+
+from apps.identities.models import Identity
+from apps.meditations.models import Meditation, MeditationSegment
+from apps.users.models import User
+from services.logger import configure_logging
+from services.prompt_manager.manager import PromptManager
+
+log = configure_logging(__name__, log_level="INFO")
+
+
+def get_eligible_identities(user: User):
+    """Identities with both a saved image and an i_am_statement, in order."""
+    return list(
+        Identity.objects.filter(user=user)
+        .exclude(image="")
+        .exclude(image__isnull=True)
+        .exclude(i_am_statement__isnull=True)
+        .exclude(i_am_statement="")
+        .order_by("order", "created_at")
+    )
+
+
+def create_meditation_for_user(user: User) -> Meditation:
+    """
+    Create a pending Meditation for *user* with one empty segment per eligible
+    identity. Returns the created Meditation.
+    """
+    identities = get_eligible_identities(user)
+    log.info(
+        f"Creating meditation for {user.email} with {len(identities)} eligible identities"
+    )
+
+    meditation = Meditation.objects.create(user=user)
+    prompt_manager = PromptManager()
+
+    for index, identity in enumerate(identities):
+        MeditationSegment.objects.create(
+            meditation=meditation,
+            identity=identity,
+            order=index,
+            current_video_prompt=prompt_manager.create_video_generation_prompt(
+                identity
+            ),
+            current_audio_script=identity.i_am_statement or "",
+        )
+
+    return meditation

--- a/server/apps/meditations/services/generate_part.py
+++ b/server/apps/meditations/services/generate_part.py
@@ -1,0 +1,137 @@
+"""
+generate_segment_part — generate one video or audio part for a segment.
+
+Creates a new versioned MeditationAsset, calls the appropriate media provider,
+uploads the result to S3, and promotes the new asset to active (demoting the
+prior active in a transaction). On provider failure the asset is marked FAILED
+with an error code. This is the synchronous core; the Celery task wraps it.
+"""
+
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+from django.db import transaction
+from django.db.models import Max
+
+from apps.meditations.models import (
+    Meditation,
+    MeditationAsset,
+    MeditationSegment,
+)
+from enums.meditation import (
+    MeditationAssetKind,
+    MeditationAssetStatus,
+    MeditationStatus,
+)
+from services.logger import configure_logging
+from services.media import MediaGenerationError, MediaProviderFactory
+
+log = configure_logging(__name__, log_level="INFO")
+
+_EXTENSIONS = {
+    MeditationAssetKind.VIDEO: "mp4",
+    MeditationAssetKind.AUDIO: "wav",
+}
+
+
+def _next_version(segment: MeditationSegment, kind: str) -> int:
+    current_max = MeditationAsset.objects.filter(segment=segment, kind=kind).aggregate(
+        Max("version")
+    )["version__max"]
+    return (current_max or 0) + 1
+
+
+def _asset_key(segment: MeditationSegment, kind: str, version: int, ext: str) -> str:
+    return (
+        f"meditations/{segment.meditation_id}/{segment.id}/"
+        f"{kind.lower()}_v{version}.{ext}"
+    )
+
+
+def generate_segment_part(segment_id: str, kind: str) -> MeditationAsset:
+    """
+    Generate one part (``kind`` = VIDEO or AUDIO) for the given segment.
+
+    Returns the created MeditationAsset (READY on success, FAILED on a provider
+    error). Raises ValueError for an unknown kind or missing inputs.
+    """
+    kind = MeditationAssetKind(kind)
+    segment = MeditationSegment.objects.select_related("identity", "meditation").get(
+        id=segment_id
+    )
+
+    if kind == MeditationAssetKind.VIDEO:
+        prompt_snapshot = segment.current_video_prompt
+    else:
+        prompt_snapshot = segment.current_audio_script
+
+    version = _next_version(segment, kind)
+    asset = MeditationAsset.objects.create(
+        segment=segment,
+        kind=kind,
+        version=version,
+        prompt_snapshot=prompt_snapshot,
+        status=MeditationAssetStatus.GENERATING,
+    )
+
+    # Mark the meditation as actively generating parts.
+    Meditation.objects.filter(
+        id=segment.meditation_id, status=MeditationStatus.PENDING
+    ).update(status=MeditationStatus.GENERATING_PARTS)
+
+    try:
+        result = _run_provider(segment, kind)
+        ext = _EXTENSIONS[kind]
+        saved_key = default_storage.save(
+            _asset_key(segment, kind, version, ext), ContentFile(result.data)
+        )
+        with transaction.atomic():
+            MeditationAsset.objects.filter(
+                segment=segment, kind=kind, is_active=True
+            ).update(is_active=False)
+            asset.s3_key = saved_key
+            asset.status = MeditationAssetStatus.READY
+            asset.is_active = True
+            asset.error_code = ""
+            asset.save(
+                update_fields=[
+                    "s3_key",
+                    "status",
+                    "is_active",
+                    "error_code",
+                    "updated_at",
+                ]
+            )
+        log.info(f"Generated {kind} v{version} for segment {segment_id}: {saved_key}")
+    except MediaGenerationError as e:
+        log.warning(f"Generation failed for segment {segment_id} ({kind}): {e}")
+        asset.status = MeditationAssetStatus.FAILED
+        asset.error_code = e.error_code
+        asset.save(update_fields=["status", "error_code", "updated_at"])
+
+    return asset
+
+
+def _run_provider(segment: MeditationSegment, kind: str):
+    """Call the right media provider and return its MediaResult."""
+    if kind == MeditationAssetKind.VIDEO:
+        first_frame = _read_identity_image(segment.identity)
+        provider = MediaProviderFactory.create_video_provider()
+        return provider.generate(
+            prompt=segment.current_video_prompt, first_frame=first_frame
+        )
+
+    provider = MediaProviderFactory.create_audio_provider()
+    return provider.generate(script=segment.current_audio_script)
+
+
+def _read_identity_image(identity) -> bytes:
+    if not identity.image:
+        raise MediaGenerationError(
+            "Identity has no image to use as the first frame.",
+            MediaGenerationError.EMPTY_RESPONSE,
+        )
+    identity.image.open("rb")
+    try:
+        return identity.image.read()
+    finally:
+        identity.image.close()

--- a/server/apps/meditations/services/set_active_asset.py
+++ b/server/apps/meditations/services/set_active_asset.py
@@ -1,0 +1,24 @@
+"""
+set_active_asset — make one asset the active version for its (segment, kind).
+
+Demotes the currently-active sibling and promotes the target in a single
+transaction so the "at most one active per (segment, kind)" constraint is never
+violated.
+"""
+
+from django.db import transaction
+
+from apps.meditations.models import MeditationAsset
+
+
+def set_active_asset(asset: MeditationAsset) -> MeditationAsset:
+    """Promote *asset* to active, demoting any other active asset of the same
+    (segment, kind)."""
+    with transaction.atomic():
+        MeditationAsset.objects.filter(
+            segment_id=asset.segment_id, kind=asset.kind, is_active=True
+        ).exclude(pk=asset.pk).update(is_active=False)
+        if not asset.is_active:
+            asset.is_active = True
+            asset.save(update_fields=["is_active", "updated_at"])
+    return asset

--- a/server/apps/meditations/tasks/__init__.py
+++ b/server/apps/meditations/tasks/__init__.py
@@ -1,0 +1,7 @@
+"""
+Meditation Celery tasks.
+"""
+
+from apps.meditations.tasks.generate_segment_part import generate_segment_part_task
+
+__all__ = ["generate_segment_part_task"]

--- a/server/apps/meditations/tasks/generate_segment_part.py
+++ b/server/apps/meditations/tasks/generate_segment_part.py
@@ -1,0 +1,16 @@
+"""
+Celery task wrapping the segment-part generation service.
+
+Generation is slow (Veo is a long-poll, ~minutes) so the admin enqueues it and
+polls asset status. Runs serialized on the existing worker.
+"""
+
+from celery import shared_task
+
+from apps.meditations.services import generate_segment_part
+
+
+@shared_task
+def generate_segment_part_task(segment_id: str, kind: str) -> None:
+    """Generate one part (VIDEO or AUDIO) for *segment_id* asynchronously."""
+    generate_segment_part(segment_id, kind)

--- a/server/apps/meditations/tests/test_admin_meditation_endpoints.py
+++ b/server/apps/meditations/tests/test_admin_meditation_endpoints.py
@@ -1,0 +1,138 @@
+"""
+Tests for the AdminMeditationViewSet endpoints under /api/v1/admin/meditations.
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.meditations.models import Meditation, MeditationAsset, MeditationSegment
+from conftest import create_test_identity, create_test_user
+from enums.meditation import MeditationAssetKind
+
+
+class AdminMeditationEndpointTests(TestCase):
+    def setUp(self):
+        self.admin = create_test_user(email="admin@example.com", is_staff=True)
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.admin)
+        self.target = create_test_user(email="target@example.com")
+        self.identity = create_test_identity(
+            self.target,
+            name="Creator",
+            i_am_statement="I am bold.",
+            image="identities/c.png",
+        )
+
+    def test_requires_admin(self):
+        non_admin = create_test_user(email="plain@example.com")
+        client = APIClient()
+        client.force_authenticate(user=non_admin)
+        response = client.get("/api/v1/admin/meditations")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_create_for_user(self):
+        response = self.client.post(
+            "/api/v1/admin/meditations/create-for-user",
+            {"user_id": str(self.target.id)},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(len(response.data["segments"]), 1)
+        self.assertEqual(Meditation.objects.count(), 1)
+
+    def test_create_for_user_requires_user_id(self):
+        response = self.client.post(
+            "/api/v1/admin/meditations/create-for-user", {}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_list_and_retrieve(self):
+        med = Meditation.objects.create(user=self.target)
+        list_resp = self.client.get("/api/v1/admin/meditations")
+        self.assertEqual(list_resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(list_resp.data), 1)
+
+        detail_resp = self.client.get(f"/api/v1/admin/meditations/{med.id}")
+        self.assertEqual(detail_resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(detail_resp.data["id"], str(med.id))
+
+    def test_list_filters_by_status(self):
+        Meditation.objects.create(user=self.target, status="PENDING")
+        Meditation.objects.create(user=self.target, status="COMPLETE")
+        resp = self.client.get("/api/v1/admin/meditations?status=COMPLETE")
+        self.assertEqual(len(resp.data), 1)
+        self.assertEqual(resp.data[0]["status"], "COMPLETE")
+
+    @patch(
+        "apps.meditations.views.admin_meditation_view_set.generate_segment_part_task"
+    )
+    def test_generate_part_enqueues_task(self, mock_task):
+        med = Meditation.objects.create(user=self.target)
+        segment = MeditationSegment.objects.create(
+            meditation=med, identity=self.identity, order=0
+        )
+        response = self.client.post(
+            "/api/v1/admin/meditations/generate-part",
+            {"segment_id": str(segment.id), "kind": MeditationAssetKind.VIDEO},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        mock_task.delay_on_commit.assert_called_once_with(
+            str(segment.id), MeditationAssetKind.VIDEO
+        )
+
+    def test_generate_part_rejects_bad_kind(self):
+        med = Meditation.objects.create(user=self.target)
+        segment = MeditationSegment.objects.create(
+            meditation=med, identity=self.identity, order=0
+        )
+        response = self.client.post(
+            "/api/v1/admin/meditations/generate-part",
+            {"segment_id": str(segment.id), "kind": "GIF"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_set_active(self):
+        med = Meditation.objects.create(user=self.target)
+        segment = MeditationSegment.objects.create(
+            meditation=med, identity=self.identity, order=0
+        )
+        a1 = MeditationAsset.objects.create(
+            segment=segment, kind=MeditationAssetKind.VIDEO, version=1, is_active=True
+        )
+        a2 = MeditationAsset.objects.create(
+            segment=segment, kind=MeditationAssetKind.VIDEO, version=2, is_active=False
+        )
+        response = self.client.post(
+            "/api/v1/admin/meditations/set-active",
+            {"asset_id": str(a2.id)},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        a1.refresh_from_db()
+        a2.refresh_from_db()
+        self.assertFalse(a1.is_active)
+        self.assertTrue(a2.is_active)
+
+    def test_update_segment(self):
+        med = Meditation.objects.create(user=self.target)
+        segment = MeditationSegment.objects.create(
+            meditation=med, identity=self.identity, order=0
+        )
+        response = self.client.patch(
+            "/api/v1/admin/meditations/update-segment",
+            {
+                "segment_id": str(segment.id),
+                "video_prompt": "new prompt",
+                "audio_script": "I am new.",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        segment.refresh_from_db()
+        self.assertEqual(segment.current_video_prompt, "new prompt")
+        self.assertEqual(segment.current_audio_script, "I am new.")

--- a/server/apps/meditations/tests/test_create_meditation.py
+++ b/server/apps/meditations/tests/test_create_meditation.py
@@ -1,0 +1,69 @@
+"""
+Tests for create_meditation_for_user: eligible-identity selection, ordering,
+and per-segment prompt/script seeding.
+
+Relies on the seeded VIDEO_GENERATION prompt (migration
+prompts/0020_seed_video_generation_prompt).
+"""
+
+from django.test import TestCase
+
+from apps.meditations.models import Meditation
+from apps.meditations.services import create_meditation_for_user
+from conftest import create_test_identity, create_test_user
+
+
+class CreateMeditationTests(TestCase):
+    def setUp(self):
+        self.user = create_test_user(email="med-create@example.com")
+
+    def _eligible(self, name, order, i_am="I am whole."):
+        return create_test_identity(
+            self.user,
+            name=name,
+            order=order,
+            i_am_statement=i_am,
+            image=f"identities/{name}.png",
+        )
+
+    def test_includes_only_eligible_identities(self):
+        self._eligible("Creator", order=1)
+        # No image → excluded.
+        create_test_identity(
+            self.user, name="NoImage", order=2, i_am_statement="I am here."
+        )
+        # No i_am_statement → excluded.
+        create_test_identity(
+            self.user, name="NoStatement", order=3, image="identities/x.png"
+        )
+
+        meditation = create_meditation_for_user(self.user)
+
+        self.assertEqual(meditation.segments.count(), 1)
+        self.assertEqual(meditation.segments.first().identity.name, "Creator")
+
+    def test_segments_ordered_by_identity_order(self):
+        self._eligible("Third", order=30)
+        self._eligible("First", order=10)
+        self._eligible("Second", order=20)
+
+        meditation = create_meditation_for_user(self.user)
+        names = [s.identity.name for s in meditation.segments.all()]
+        self.assertEqual(names, ["First", "Second", "Third"])
+
+    def test_segment_seeded_with_script_and_prompt(self):
+        self._eligible("Creator", order=1, i_am="I am unstoppable.")
+        meditation = create_meditation_for_user(self.user)
+        seg = meditation.segments.first()
+
+        self.assertEqual(seg.current_audio_script, "I am unstoppable.")
+        # The video prompt is the formatted template — non-empty and contains
+        # the identity context.
+        self.assertTrue(seg.current_video_prompt)
+        self.assertIn("Creator", seg.current_video_prompt)
+
+    def test_creates_pending_meditation(self):
+        self._eligible("Creator", order=1)
+        meditation = create_meditation_for_user(self.user)
+        self.assertEqual(Meditation.objects.count(), 1)
+        self.assertEqual(meditation.status, "PENDING")

--- a/server/apps/meditations/tests/test_generate_part.py
+++ b/server/apps/meditations/tests/test_generate_part.py
@@ -1,0 +1,103 @@
+"""
+Tests for generate_segment_part: versioned asset creation, S3 upload, active
+promotion/demotion, and failure handling. The provider call and storage are
+mocked (the providers themselves are covered in services/media tests).
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from apps.meditations.models import Meditation, MeditationAsset, MeditationSegment
+from apps.meditations.services import generate_segment_part
+from conftest import create_test_identity, create_test_user
+from enums.meditation import (
+    MeditationAssetKind,
+    MeditationAssetStatus,
+    MeditationStatus,
+)
+from services.media import MediaGenerationError, MediaResult
+
+
+def _result(kind="video"):
+    return MediaResult(
+        data=b"BYTES",
+        mime_type="video/mp4" if kind == "video" else "audio/wav",
+        provider="GOOGLE_VEO" if kind == "video" else "GEMINI_TTS",
+        model="test-model",
+    )
+
+
+class GenerateSegmentPartTests(TestCase):
+    def setUp(self):
+        self.user = create_test_user(email="gen@example.com")
+        self.identity = create_test_identity(
+            self.user, name="Creator", i_am_statement="I am calm.", image="x.png"
+        )
+        self.med = Meditation.objects.create(user=self.user)
+        self.segment = MeditationSegment.objects.create(
+            meditation=self.med,
+            identity=self.identity,
+            order=0,
+            current_video_prompt="serene push-in",
+            current_audio_script="I am calm.",
+        )
+
+    @patch("apps.meditations.services.generate_part.default_storage")
+    @patch("apps.meditations.services.generate_part._run_provider")
+    def test_video_success(self, mock_run, mock_storage):
+        mock_run.return_value = _result("video")
+        mock_storage.save.return_value = "meditations/k/video_v1.mp4"
+
+        asset = generate_segment_part(str(self.segment.id), MeditationAssetKind.VIDEO)
+
+        self.assertEqual(asset.status, MeditationAssetStatus.READY)
+        self.assertEqual(asset.s3_key, "meditations/k/video_v1.mp4")
+        self.assertTrue(asset.is_active)
+        self.assertEqual(asset.version, 1)
+        self.assertEqual(asset.prompt_snapshot, "serene push-in")
+        self.med.refresh_from_db()
+        self.assertEqual(self.med.status, MeditationStatus.GENERATING_PARTS)
+
+    @patch("apps.meditations.services.generate_part.default_storage")
+    @patch("apps.meditations.services.generate_part._run_provider")
+    def test_audio_uses_script_snapshot(self, mock_run, mock_storage):
+        mock_run.return_value = _result("audio")
+        mock_storage.save.return_value = "meditations/k/audio_v1.wav"
+
+        asset = generate_segment_part(str(self.segment.id), MeditationAssetKind.AUDIO)
+        self.assertEqual(asset.prompt_snapshot, "I am calm.")
+        self.assertEqual(asset.kind, MeditationAssetKind.AUDIO)
+
+    @patch("apps.meditations.services.generate_part.default_storage")
+    @patch("apps.meditations.services.generate_part._run_provider")
+    def test_new_version_demotes_prior_active(self, mock_run, mock_storage):
+        mock_run.return_value = _result("video")
+        mock_storage.save.side_effect = ["k/v1.mp4", "k/v2.mp4"]
+
+        first = generate_segment_part(str(self.segment.id), MeditationAssetKind.VIDEO)
+        second = generate_segment_part(str(self.segment.id), MeditationAssetKind.VIDEO)
+
+        first.refresh_from_db()
+        self.assertFalse(first.is_active)
+        self.assertTrue(second.is_active)
+        self.assertEqual(second.version, 2)
+        # Exactly one active video asset.
+        active = MeditationAsset.objects.filter(
+            segment=self.segment, kind=MeditationAssetKind.VIDEO, is_active=True
+        )
+        self.assertEqual(active.count(), 1)
+
+    @patch("apps.meditations.services.generate_part.default_storage")
+    @patch("apps.meditations.services.generate_part._run_provider")
+    def test_provider_failure_marks_asset_failed(self, mock_run, mock_storage):
+        mock_run.side_effect = MediaGenerationError(
+            "blocked", MediaGenerationError.SAFETY_BLOCK
+        )
+
+        asset = generate_segment_part(str(self.segment.id), MeditationAssetKind.VIDEO)
+
+        self.assertEqual(asset.status, MeditationAssetStatus.FAILED)
+        self.assertEqual(asset.error_code, MediaGenerationError.SAFETY_BLOCK)
+        self.assertFalse(asset.is_active)
+        mock_storage.save.assert_not_called()

--- a/server/apps/meditations/views/__init__.py
+++ b/server/apps/meditations/views/__init__.py
@@ -1,0 +1,7 @@
+"""
+Meditation viewsets.
+"""
+
+from apps.meditations.views.admin_meditation_view_set import AdminMeditationViewSet
+
+__all__ = ["AdminMeditationViewSet"]

--- a/server/apps/meditations/views/admin_meditation_view_set.py
+++ b/server/apps/meditations/views/admin_meditation_view_set.py
@@ -1,0 +1,124 @@
+"""
+Admin Meditation ViewSet
+
+Admin-only endpoints driving the meditations QC pipeline:
+- GET  /api/v1/admin/meditations                 → list (optional ?status=)
+- GET  /api/v1/admin/meditations/{id}            → detail (segments + assets)
+- POST /api/v1/admin/meditations/create-for-user → build a meditation for a user
+- POST /api/v1/admin/meditations/generate-part   → enqueue video/audio gen
+- POST /api/v1/admin/meditations/set-active      → choose an asset version
+- PATCH /api/v1/admin/meditations/update-segment → edit a segment prompt/script
+"""
+
+from django.shortcuts import get_object_or_404
+from rest_framework import mixins, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+from apps.meditations.models import Meditation, MeditationAsset, MeditationSegment
+from apps.meditations.serializers import (
+    MeditationDetailSerializer,
+    MeditationListSerializer,
+)
+from apps.meditations.services import create_meditation_for_user, set_active_asset
+from apps.meditations.tasks import generate_segment_part_task
+from apps.users.models import User
+from enums.meditation import MeditationAssetKind
+from permissions import IsAdminUser
+from services.logger import configure_logging
+
+log = configure_logging(__name__, log_level="INFO")
+
+
+class AdminMeditationViewSet(
+    mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet
+):
+    permission_classes = [IsAdminUser]
+    serializer_class = MeditationDetailSerializer
+
+    def get_queryset(self):
+        qs = Meditation.objects.select_related("user").prefetch_related(
+            "segments__identity", "segments__assets"
+        )
+        status_filter = self.request.query_params.get("status")
+        if status_filter:
+            qs = qs.filter(status=status_filter)
+        return qs.order_by("-created_at")
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return MeditationListSerializer
+        return MeditationDetailSerializer
+
+    @action(detail=False, methods=["post"], url_path="create-for-user")
+    def create_for_user(self, request):
+        user_id = request.data.get("user_id")
+        if not user_id:
+            return Response(
+                {"detail": "user_id is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        user = get_object_or_404(User, id=user_id)
+        meditation = create_meditation_for_user(user)
+        return Response(
+            MeditationDetailSerializer(meditation).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+    @action(detail=False, methods=["post"], url_path="generate-part")
+    def generate_part(self, request):
+        segment_id = request.data.get("segment_id")
+        kind = request.data.get("kind")
+        if not segment_id or not kind:
+            return Response(
+                {"detail": "segment_id and kind are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if kind not in MeditationAssetKind.values:
+            return Response(
+                {"detail": f"kind must be one of {MeditationAssetKind.values}."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        # Validate the segment exists (404 otherwise).
+        get_object_or_404(MeditationSegment, id=segment_id)
+        generate_segment_part_task.delay_on_commit(str(segment_id), kind)
+        return Response(
+            {"status": "queued", "segment_id": str(segment_id), "kind": kind},
+            status=status.HTTP_202_ACCEPTED,
+        )
+
+    @action(detail=False, methods=["post"], url_path="set-active")
+    def set_active(self, request):
+        asset_id = request.data.get("asset_id")
+        if not asset_id:
+            return Response(
+                {"detail": "asset_id is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        asset = get_object_or_404(MeditationAsset, id=asset_id)
+        set_active_asset(asset)
+        meditation = asset.segment.meditation
+        return Response(MeditationDetailSerializer(meditation).data)
+
+    @action(detail=False, methods=["patch"], url_path="update-segment")
+    def update_segment(self, request):
+        segment_id = request.data.get("segment_id")
+        if not segment_id:
+            return Response(
+                {"detail": "segment_id is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        segment = get_object_or_404(MeditationSegment, id=segment_id)
+
+        update_fields = []
+        if "video_prompt" in request.data:
+            segment.current_video_prompt = request.data["video_prompt"]
+            update_fields.append("current_video_prompt")
+        if "audio_script" in request.data:
+            segment.current_audio_script = request.data["audio_script"]
+            update_fields.append("current_audio_script")
+        if update_fields:
+            update_fields.append("updated_at")
+            segment.save(update_fields=update_fields)
+
+        return Response(MeditationDetailSerializer(segment.meditation).data)

--- a/server/apps/prompts/migrations/0020_seed_video_generation_prompt.py
+++ b/server/apps/prompts/migrations/0020_seed_video_generation_prompt.py
@@ -1,0 +1,62 @@
+"""
+Seed an initial active VIDEO_GENERATION prompt.
+
+The meditations feature builds a per-segment video prompt by formatting the
+latest active VIDEO_GENERATION prompt with identity + scene context. This
+migration seeds version 1 so the feature works on a fresh database; the wording
+can be refined later via the prompts admin (a new version supersedes this one).
+"""
+
+from django.db import migrations
+
+VIDEO_GENERATION_PROMPT_BODY = """\
+You are generating a short, cinematic motion video clip for a personal \
+meditation. The clip gently animates a still portrait of a person embodying a \
+specific identity.
+
+Keep the motion subtle, calm, and serene: soft natural breathing, a slow, \
+steady camera push-in, gentle ambient light. The subject's appearance, \
+clothing, and setting must stay consistent with the reference image (the first \
+frame). No abrupt movements, no scene changes, no text or captions.
+
+IDENTITY:
+{identity_context}
+
+SCENE:
+{scene_context}
+
+ADDITIONAL DIRECTION:
+{additional_prompt}
+"""
+
+
+def seed_prompt(apps, schema_editor):
+    Prompt = apps.get_model("prompts", "Prompt")
+    Prompt.objects.get_or_create(
+        prompt_type="video_generation",
+        coaching_phase=None,
+        version=1,
+        defaults={
+            "name": "Video Generation v1",
+            "description": "Initial meditations video-generation prompt (Veo).",
+            "body": VIDEO_GENERATION_PROMPT_BODY,
+            "is_active": True,
+        },
+    )
+
+
+def unseed_prompt(apps, schema_editor):
+    Prompt = apps.get_model("prompts", "Prompt")
+    Prompt.objects.filter(
+        prompt_type="video_generation", coaching_phase=None, version=1
+    ).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("prompts", "0019_alter_prompt_unique_together"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_prompt, unseed_prompt),
+    ]

--- a/server/apps/prompts/migrations/0021_alter_prompt_prompt_type.py
+++ b/server/apps/prompts/migrations/0021_alter_prompt_prompt_type.py
@@ -1,0 +1,30 @@
+"""
+Add the VIDEO_GENERATION choice to Prompt.prompt_type (choices-only change).
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("prompts", "0020_seed_video_generation_prompt"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="prompt",
+            name="prompt_type",
+            field=models.CharField(
+                choices=[
+                    ("coach", "Coach"),
+                    ("sentinel", "Sentinel"),
+                    ("system", "System"),
+                    ("image_generation", "Image Generation"),
+                    ("video_generation", "Video Generation"),
+                ],
+                default="coach",
+                help_text="Type of prompt (coach, sentinel, system, etc.)",
+                max_length=32,
+            ),
+        ),
+    ]

--- a/server/enums/prompt_type.py
+++ b/server/enums/prompt_type.py
@@ -11,6 +11,7 @@ class PromptType(models.TextChoices):
     SENTINEL = "sentinel", "Sentinel"
     SYSTEM = "system", "System"
     IMAGE_GENERATION = "image_generation", "Image Generation"
+    VIDEO_GENERATION = "video_generation", "Video Generation"
 
     def get_all_actions() -> list:
         """Get all action types as a list."""

--- a/server/services/prompt_manager/manager.py
+++ b/server/services/prompt_manager/manager.py
@@ -203,3 +203,58 @@ class PromptManager:
         log.debug(f"Formatted image generation prompt: {formatted_prompt}")
 
         return formatted_prompt
+
+    def create_video_generation_prompt(
+        self,
+        identity: Identity,
+        additional_prompt: str = "",
+    ) -> str:
+        """
+        Create a prompt for identity video generation (Veo first-frame
+        image-to-video).
+
+        Mirrors create_image_generation_prompt: fetches the latest active
+        VIDEO_GENERATION prompt and formats it with the identity + scene
+        context. The identity's saved image is the first frame (passed
+        separately to the video provider), so this prompt describes the motion
+        and mood rather than the appearance.
+
+        Args:
+            identity: The Identity to generate a video for
+            additional_prompt: Optional extra direction from admin
+
+        Returns:
+            Formatted prompt string for the video provider
+        """
+        from services.prompt_manager.utils.context.func import (
+            get_identity_context_for_image,
+            get_scene_context,
+        )
+
+        prompt = (
+            Prompt.objects.filter(
+                prompt_type=PromptType.VIDEO_GENERATION,
+                is_active=True,
+            )
+            .order_by("-version")
+            .first()
+        )
+
+        if not prompt:
+            raise ValueError("No active video generation prompt found in the database.")
+
+        log.info(f"Using Video Generation Prompt version: {prompt.version}")
+
+        identity_context = get_identity_context_for_image(identity)
+        scene_context = get_scene_context(identity)
+
+        # The prompt body should have placeholders: {identity_context},
+        # {scene_context}, and {additional_prompt}
+        formatted_prompt = prompt.body.format(
+            identity_context=identity_context,
+            scene_context=scene_context or "None provided",
+            additional_prompt=additional_prompt or "None provided",
+        )
+        log.debug(f"Formatted video generation prompt: {formatted_prompt}")
+
+        return formatted_prompt


### PR DESCRIPTION
## Summary

PR-03 of the **meditations** feature: the backend generation pipeline. Builds a per-segment video prompt + audio script, creates a meditation (empty segments), generates individual video/audio parts via Celery using the PR-01 media providers, persists results to S3 as versioned assets, and exposes the admin API the QC UI (PR-04) will drive. Still admin-only and behind the `MEDITATIONS_ENABLED` flag's surface; nothing is wired into the user-facing flow.

### What changed

**Prompts**
- `PromptType.VIDEO_GENERATION` + `PromptManager.create_video_generation_prompt()` (mirrors `create_image_generation_prompt`: formats the latest active template with identity + scene context; the identity image is the first frame, so the prompt describes motion/mood).
- Migration `0020` seeds an initial active v1 video prompt (refinable later via the prompts admin); `0021` adds the enum choice.

**Services (`apps/meditations/services/`)**
- `create_meditation_for_user` — PENDING meditation + one segment per identity that has BOTH a saved image and an `i_am_statement`, ordered; seeds `current_video_prompt` (from the template) and `current_audio_script` (the I-Am statement).
- `generate_segment_part` — creates the next versioned `MeditationAsset` (GENERATING), calls the right provider, uploads bytes to S3 via `default_storage`, then promotes the new asset to active while **demoting the prior active in a transaction** (honoring the one-active-per-(segment,kind) constraint), snapshotting the prompt/script. On `MediaGenerationError` the asset is marked FAILED with the error code.
- `set_active_asset` — transactional active swap.

**Celery**
- `generate_segment_part_task` (`@shared_task`) — wraps the service; the admin enqueues it and polls asset status (Veo is a multi-minute long-poll; runs serialized on the existing worker).

**Admin API (`/api/v1/admin/meditations`, `IsAdminUser`)**
- `GET /` list (optional `?status=`), `GET /{id}` detail (segments + assets, with derived S3 URLs).
- `POST /create-for-user`, `POST /generate-part` (enqueues), `POST /set-active`, `PATCH /update-segment`.
- Detail/list/asset serializers.

### Testing
- New tests: create-meditation (eligibility/ordering/seeding), generate-part (versioning, S3 upload, active promote/demote, failure → FAILED+error_code), and all admin endpoints (auth, create, list/retrieve/filter, generate-part enqueue, set-active, update-segment). Providers + storage mocked.
- **Full regression 340/340** (prompts, identities, coach, core, prompt_manager, media, meditations). `manage.py check` clean. isort / black / flake8 clean.

### Discovery (out of scope, left untouched)
`makemigrations` wants to alter `Prompt.allowed_actions` — a **pre-existing** `ActionType` choices drift (the coaching-videos session-video/break actions were added without a migration). Unrelated to meditations, so this PR deliberately does not include it; worth a small standalone migration PR.

No runtime behavior change for existing flows — all new, admin-only, additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)