### PR TITLE
Meditations admin QC page + instant-pending part generation

### DIFF
--- a/client/src/api/__tests__/adminMeditations.test.ts
+++ b/client/src/api/__tests__/adminMeditations.test.ts
@@ -1,0 +1,93 @@
+import {
+	createMeditationForUser,
+	fetchMeditations,
+	generatePart,
+	setActiveAsset,
+	updateSegment,
+} from "@/api/adminMeditations";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utils/authFetch", () => ({
+	authFetch: vi.fn(),
+}));
+
+vi.mock("@/constants/api", () => ({
+	COACH_BASE_URL: "http://localhost:8000/api/v1",
+}));
+
+import { authFetch } from "@/utils/authFetch";
+
+const BASE = "http://localhost:8000/api/v1/admin/meditations";
+
+function ok(data: unknown) {
+	return { ok: true, json: () => Promise.resolve(data) } as Response;
+}
+
+describe("adminMeditations API", () => {
+	beforeEach(() => vi.mocked(authFetch).mockReset());
+
+	it("fetchMeditations appends the status filter", async () => {
+		vi.mocked(authFetch).mockResolvedValue(ok([]));
+		await fetchMeditations("COMPLETE");
+		expect(authFetch).toHaveBeenCalledWith(`${BASE}?status=COMPLETE`);
+	});
+
+	it("fetchMeditations omits the query when no status", async () => {
+		vi.mocked(authFetch).mockResolvedValue(ok([]));
+		await fetchMeditations();
+		expect(authFetch).toHaveBeenCalledWith(BASE);
+	});
+
+	it("createMeditationForUser posts the user_id", async () => {
+		vi.mocked(authFetch).mockResolvedValue(ok({ id: "m1" }));
+		await createMeditationForUser("u1");
+		expect(authFetch).toHaveBeenCalledWith(
+			`${BASE}/create-for-user`,
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({ user_id: "u1" }),
+			}),
+		);
+	});
+
+	it("generatePart posts segment_id + kind", async () => {
+		vi.mocked(authFetch).mockResolvedValue(ok({}));
+		await generatePart("s1", "VIDEO");
+		expect(authFetch).toHaveBeenCalledWith(
+			`${BASE}/generate-part`,
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({ segment_id: "s1", kind: "VIDEO" }),
+			}),
+		);
+	});
+
+	it("setActiveAsset posts asset_id", async () => {
+		vi.mocked(authFetch).mockResolvedValue(ok({ id: "m1" }));
+		await setActiveAsset("a1");
+		expect(authFetch).toHaveBeenCalledWith(
+			`${BASE}/set-active`,
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({ asset_id: "a1" }),
+			}),
+		);
+	});
+
+	it("updateSegment patches the given fields", async () => {
+		vi.mocked(authFetch).mockResolvedValue(ok({ id: "m1" }));
+		await updateSegment("s1", { video_prompt: "new" });
+		expect(authFetch).toHaveBeenCalledWith(
+			`${BASE}/update-segment`,
+			expect.objectContaining({
+				method: "PATCH",
+				body: JSON.stringify({ segment_id: "s1", video_prompt: "new" }),
+			}),
+		);
+	});
+
+	it("throws on a non-ok response", async () => {
+		vi.mocked(authFetch).mockResolvedValue({ ok: false } as Response);
+		await expect(fetchMeditations()).rejects.toThrow();
+	});
+});

--- a/client/src/api/adminMeditations.ts
+++ b/client/src/api/adminMeditations.ts
@@ -1,0 +1,132 @@
+import { COACH_BASE_URL } from "@/constants/api";
+import { authFetch } from "@/utils/authFetch";
+
+/**
+ * Admin Meditations API
+ * ---------------------
+ * Admin-only endpoints driving the meditations QC pipeline.
+ * Base: /api/v1/admin/meditations  (Permission: IsAdminUser)
+ */
+
+export type MeditationAssetKind = "VIDEO" | "AUDIO";
+
+export type MeditationAssetStatus =
+	| "QUEUED"
+	| "GENERATING"
+	| "READY"
+	| "FAILED";
+
+export type MeditationStatus =
+	| "PENDING"
+	| "GENERATING_PARTS"
+	| "READY_FOR_QC"
+	| "ASSEMBLING"
+	| "COMPLETE"
+	| "FAILED";
+
+export interface MeditationAsset {
+	id: string;
+	kind: MeditationAssetKind;
+	version: number;
+	status: MeditationAssetStatus;
+	is_active: boolean;
+	s3_key: string;
+	url: string | null;
+	prompt_snapshot: string;
+	error_code: string;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface MeditationSegment {
+	id: string;
+	identity: string;
+	identity_name: string | null;
+	order: number;
+	current_video_prompt: string;
+	current_audio_script: string;
+	assets: MeditationAsset[];
+}
+
+export interface MeditationDetail {
+	id: string;
+	user: string;
+	user_email: string;
+	status: MeditationStatus;
+	final_video_s3_key: string;
+	segments: MeditationSegment[];
+	created_at: string;
+	updated_at: string;
+}
+
+export interface MeditationListItem {
+	id: string;
+	user: string;
+	user_email: string;
+	status: MeditationStatus;
+	segment_count: number;
+	created_at: string;
+	updated_at: string;
+}
+
+const BASE = `${COACH_BASE_URL}/admin/meditations`;
+
+export async function fetchMeditations(
+	status?: string,
+): Promise<MeditationListItem[]> {
+	const query = status ? `?status=${encodeURIComponent(status)}` : "";
+	const response = await authFetch(`${BASE}${query}`);
+	if (!response.ok) throw new Error("Failed to fetch meditations");
+	return response.json();
+}
+
+export async function fetchMeditation(id: string): Promise<MeditationDetail> {
+	const response = await authFetch(`${BASE}/${id}`);
+	if (!response.ok) throw new Error("Failed to fetch meditation");
+	return response.json();
+}
+
+export async function createMeditationForUser(
+	userId: string,
+): Promise<MeditationDetail> {
+	const response = await authFetch(`${BASE}/create-for-user`, {
+		method: "POST",
+		body: JSON.stringify({ user_id: userId }),
+	});
+	if (!response.ok) throw new Error("Failed to create meditation");
+	return response.json();
+}
+
+export async function generatePart(
+	segmentId: string,
+	kind: MeditationAssetKind,
+): Promise<void> {
+	const response = await authFetch(`${BASE}/generate-part`, {
+		method: "POST",
+		body: JSON.stringify({ segment_id: segmentId, kind }),
+	});
+	if (!response.ok) throw new Error("Failed to start generation");
+}
+
+export async function setActiveAsset(
+	assetId: string,
+): Promise<MeditationDetail> {
+	const response = await authFetch(`${BASE}/set-active`, {
+		method: "POST",
+		body: JSON.stringify({ asset_id: assetId }),
+	});
+	if (!response.ok) throw new Error("Failed to set active version");
+	return response.json();
+}
+
+export async function updateSegment(
+	segmentId: string,
+	fields: { video_prompt?: string; audio_script?: string },
+): Promise<MeditationDetail> {
+	const response = await authFetch(`${BASE}/update-segment`, {
+		method: "PATCH",
+		body: JSON.stringify({ segment_id: segmentId, ...fields }),
+	});
+	if (!response.ok) throw new Error("Failed to update segment");
+	return response.json();
+}

--- a/client/src/hooks/use-admin-meditations.ts
+++ b/client/src/hooks/use-admin-meditations.ts
@@ -1,0 +1,83 @@
+import {
+	type MeditationAssetKind,
+	type MeditationDetail,
+	type MeditationListItem,
+	createMeditationForUser,
+	fetchMeditation,
+	fetchMeditations,
+	generatePart,
+	setActiveAsset,
+	updateSegment,
+} from "@/api/adminMeditations";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+const LIST_KEY = ["admin", "meditations"];
+const detailKey = (id: string) => ["admin", "meditation", id];
+
+/** True if any asset is still queued/generating — used to drive polling. */
+function hasPendingParts(detail: MeditationDetail | undefined): boolean {
+	if (!detail) return false;
+	return detail.segments.some((segment) =>
+		segment.assets.some(
+			(asset) => asset.status === "QUEUED" || asset.status === "GENERATING",
+		),
+	);
+}
+
+export function useMeditationsList(status?: string) {
+	return useQuery<MeditationListItem[]>({
+		queryKey: [...LIST_KEY, status ?? "all"],
+		queryFn: () => fetchMeditations(status),
+		staleTime: 1000 * 30,
+	});
+}
+
+export function useMeditationDetail(id: string | null) {
+	return useQuery<MeditationDetail>({
+		queryKey: id ? detailKey(id) : ["admin", "meditation", "none"],
+		queryFn: () => fetchMeditation(id as string),
+		enabled: !!id,
+		// Poll while any part is generating so the QC view updates live.
+		refetchInterval: (query) =>
+			hasPendingParts(query.state.data as MeditationDetail | undefined)
+				? 5000
+				: false,
+	});
+}
+
+export function useCreateMeditation() {
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: (userId: string) => createMeditationForUser(userId),
+		onSuccess: () => qc.invalidateQueries({ queryKey: LIST_KEY }),
+	});
+}
+
+export function useGeneratePart(meditationId: string) {
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: (vars: { segmentId: string; kind: MeditationAssetKind }) =>
+			generatePart(vars.segmentId, vars.kind),
+		onSuccess: () =>
+			qc.invalidateQueries({ queryKey: detailKey(meditationId) }),
+	});
+}
+
+export function useSetActive(meditationId: string) {
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: (assetId: string) => setActiveAsset(assetId),
+		onSuccess: (data) => qc.setQueryData(detailKey(meditationId), data),
+	});
+}
+
+export function useUpdateSegment(meditationId: string) {
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: (vars: {
+			segmentId: string;
+			fields: { video_prompt?: string; audio_script?: string };
+		}) => updateSegment(vars.segmentId, vars.fields),
+		onSuccess: (data) => qc.setQueryData(detailKey(meditationId), data),
+	});
+}

--- a/client/src/layout/AuthLayout.tsx
+++ b/client/src/layout/AuthLayout.tsx
@@ -2,12 +2,20 @@ import { ImpersonationBanner } from "@/components/ImpersonationBanner";
 import MobileAuthFooter from "@/components/mobile/MobileAuthFooter";
 import MobileAuthHeader from "@/components/mobile/MobileAuthHeader";
 import { useCoachState } from "@/hooks/use-coach-state";
+import { useMeditations } from "@/hooks/use-meditations";
 import { useProfile } from "@/hooks/use-profile";
 import { STUDIO_LOCKED_MESSAGE, isStudioLocked } from "@/lib/studio-lock";
 import type { NavItem } from "@/types/navItem";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
-import { FlaskConical, Lock, ScrollText, Shield, Users } from "lucide-react";
+import {
+	Clapperboard,
+	FlaskConical,
+	Lock,
+	ScrollText,
+	Shield,
+	Users,
+} from "lucide-react";
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -63,6 +71,17 @@ function SidebarContent({
 	bottomItems,
 	isAdmin,
 }: SidebarContentProps) {
+	const { enabled: meditationsEnabled } = useMeditations();
+	const visibleAdminItems = meditationsEnabled
+		? [
+				...adminNavItems,
+				{
+					to: "/admin/meditations",
+					label: "Meditations",
+					Icon: Clapperboard,
+				},
+			]
+		: adminNavItems;
 	return (
 		<div className="flex flex-col h-full justify-between py-6">
 			<div className="px-3 flex flex-col gap-3 pb-4">
@@ -166,7 +185,7 @@ function SidebarContent({
 							)}
 						</AnimatePresence>
 					</div>
-					{adminNavItems.map(({ to, label, Icon }) => {
+					{visibleAdminItems.map(({ to, label, Icon }) => {
 						const isActive = pathname === to || pathname.startsWith(`${to}/`);
 						return (
 							<button

--- a/client/src/pages/admin-meditations/AdminMeditations.tsx
+++ b/client/src/pages/admin-meditations/AdminMeditations.tsx
@@ -1,0 +1,199 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	useCreateMeditation,
+	useMeditationsList,
+} from "@/hooks/use-admin-meditations";
+import { useAdminUsers } from "@/hooks/use-admin-users";
+import { Loader2, Plus } from "lucide-react";
+import { useState } from "react";
+import MeditationDetailView from "./MeditationDetailView";
+import {
+	MEDITATION_STATUSES,
+	formatStatus,
+	statusVariant,
+} from "./meditation-helpers";
+
+/**
+ * AdminMeditations page
+ *
+ * Status-filterable table of meditations. Selecting one opens the QC detail
+ * view (per-segment video/audio parts). Route: /admin/meditations (admin-only,
+ * gated behind the MEDITATIONS_ENABLED backend flag).
+ */
+export default function AdminMeditations() {
+	const [selectedId, setSelectedId] = useState<string | null>(null);
+	const [status, setStatus] = useState<string>("all");
+	const { data: meditations, isLoading } = useMeditationsList(
+		status === "all" ? undefined : status,
+	);
+
+	if (selectedId) {
+		return (
+			<MeditationDetailView
+				meditationId={selectedId}
+				onBack={() => setSelectedId(null)}
+			/>
+		);
+	}
+
+	return (
+		<div className="max-w-5xl mx-auto">
+			<div className="flex items-center justify-between mb-6">
+				<div>
+					<h1 className="text-2xl font-bold">Meditations</h1>
+					<p className="text-sm text-muted-foreground mt-1">
+						{meditations?.length ?? 0} meditations
+					</p>
+				</div>
+				<CreateMeditationDialog onCreated={(id) => setSelectedId(id)} />
+			</div>
+
+			<div className="mb-4 w-56">
+				<Select value={status} onValueChange={setStatus}>
+					<SelectTrigger>
+						<SelectValue placeholder="Filter by status" />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value="all">All statuses</SelectItem>
+						{MEDITATION_STATUSES.map((s) => (
+							<SelectItem key={s} value={s}>
+								{formatStatus(s)}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</div>
+
+			{isLoading ? (
+				<div className="flex items-center justify-center h-64">
+					<Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+				</div>
+			) : (
+				<div className="rounded-lg border border-border overflow-hidden">
+					<table className="w-full text-sm">
+						<thead>
+							<tr className="bg-muted/50 border-b border-border">
+								<th className="text-left font-medium px-4 py-3">User</th>
+								<th className="text-left font-medium px-4 py-3">Status</th>
+								<th className="text-left font-medium px-4 py-3 hidden md:table-cell">
+									Segments
+								</th>
+								<th className="text-left font-medium px-4 py-3 hidden md:table-cell">
+									Created
+								</th>
+							</tr>
+						</thead>
+						<tbody className="divide-y divide-border">
+							{(meditations ?? []).map((m) => (
+								<tr
+									key={m.id}
+									onClick={() => setSelectedId(m.id)}
+									className="hover:bg-muted/30 transition-colors cursor-pointer"
+								>
+									<td className="px-4 py-3 font-medium">{m.user_email}</td>
+									<td className="px-4 py-3">
+										<Badge variant={statusVariant(m.status)}>
+											{formatStatus(m.status)}
+										</Badge>
+									</td>
+									<td className="px-4 py-3 hidden md:table-cell">
+										{m.segment_count}
+									</td>
+									<td className="px-4 py-3 hidden md:table-cell text-muted-foreground">
+										{new Date(m.created_at).toLocaleDateString()}
+									</td>
+								</tr>
+							))}
+							{(meditations ?? []).length === 0 && (
+								<tr>
+									<td
+										colSpan={4}
+										className="px-4 py-8 text-center text-muted-foreground"
+									>
+										No meditations yet.
+									</td>
+								</tr>
+							)}
+						</tbody>
+					</table>
+				</div>
+			)}
+		</div>
+	);
+}
+
+function CreateMeditationDialog({
+	onCreated,
+}: {
+	onCreated: (id: string) => void;
+}) {
+	const [open, setOpen] = useState(false);
+	const [userId, setUserId] = useState<string>("");
+	const { data: users } = useAdminUsers();
+	const createMeditation = useCreateMeditation();
+
+	const handleCreate = () => {
+		if (!userId) return;
+		createMeditation.mutate(userId, {
+			onSuccess: (meditation) => {
+				setOpen(false);
+				setUserId("");
+				onCreated(meditation.id);
+			},
+		});
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>
+				<Button size="sm" className="gap-1.5">
+					<Plus className="w-4 h-4" />
+					New meditation
+				</Button>
+			</DialogTrigger>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Create a meditation</DialogTitle>
+				</DialogHeader>
+				<div className="py-2">
+					<Select value={userId} onValueChange={setUserId}>
+						<SelectTrigger>
+							<SelectValue placeholder="Select a user" />
+						</SelectTrigger>
+						<SelectContent>
+							{(users ?? []).map((u) => (
+								<SelectItem key={u.id} value={u.id}>
+									{u.email}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+				<DialogFooter>
+					<Button
+						onClick={handleCreate}
+						disabled={!userId || createMeditation.isPending}
+					>
+						{createMeditation.isPending ? "Creating…" : "Create"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/client/src/pages/admin-meditations/MeditationDetailView.tsx
+++ b/client/src/pages/admin-meditations/MeditationDetailView.tsx
@@ -1,0 +1,271 @@
+import type {
+	MeditationAsset,
+	MeditationAssetKind,
+	MeditationSegment,
+} from "@/api/adminMeditations";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
+import {
+	useGeneratePart,
+	useMeditationDetail,
+	useSetActive,
+	useUpdateSegment,
+} from "@/hooks/use-admin-meditations";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import {
+	assetsOfKind,
+	formatStatus,
+	statusVariant,
+} from "./meditation-helpers";
+
+interface Props {
+	meditationId: string;
+	onBack: () => void;
+}
+
+export default function MeditationDetailView({ meditationId, onBack }: Props) {
+	const {
+		data: meditation,
+		isLoading,
+		isError,
+	} = useMeditationDetail(meditationId);
+
+	if (isLoading) {
+		return (
+			<div className="flex items-center justify-center h-64">
+				<Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+			</div>
+		);
+	}
+
+	if (isError || !meditation) {
+		return (
+			<div className="flex flex-col items-center gap-4 py-12">
+				<p className="text-destructive">Failed to load meditation.</p>
+				<Button variant="outline" onClick={onBack}>
+					Back
+				</Button>
+			</div>
+		);
+	}
+
+	return (
+		<div className="max-w-4xl mx-auto">
+			<div className="flex items-center justify-between mb-6">
+				<div className="flex items-center gap-3">
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={onBack}
+						className="gap-1.5"
+					>
+						<ArrowLeft className="w-4 h-4" />
+						Back
+					</Button>
+					<div>
+						<h1 className="text-xl font-bold">{meditation.user_email}</h1>
+						<p className="text-xs text-muted-foreground">
+							{meditation.segments.length} segments
+						</p>
+					</div>
+				</div>
+				<Badge variant={statusVariant(meditation.status)}>
+					{formatStatus(meditation.status)}
+				</Badge>
+			</div>
+
+			<div className="flex flex-col gap-4">
+				{meditation.segments.map((segment) => (
+					<SegmentCard
+						key={segment.id}
+						segment={segment}
+						meditationId={meditationId}
+					/>
+				))}
+				{meditation.segments.length === 0 && (
+					<p className="text-center text-muted-foreground py-8">
+						No segments — this user had no identities with both an image and an
+						I Am statement.
+					</p>
+				)}
+			</div>
+		</div>
+	);
+}
+
+function SegmentCard({
+	segment,
+	meditationId,
+}: {
+	segment: MeditationSegment;
+	meditationId: string;
+}) {
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle className="text-base">
+					{segment.order + 1}. {segment.identity_name ?? "Identity"}
+				</CardTitle>
+			</CardHeader>
+			<CardContent className="grid gap-6 md:grid-cols-2">
+				<AssetPanel
+					segment={segment}
+					meditationId={meditationId}
+					kind="VIDEO"
+				/>
+				<AssetPanel
+					segment={segment}
+					meditationId={meditationId}
+					kind="AUDIO"
+				/>
+			</CardContent>
+		</Card>
+	);
+}
+
+function AssetPanel({
+	segment,
+	meditationId,
+	kind,
+}: {
+	segment: MeditationSegment;
+	meditationId: string;
+	kind: MeditationAssetKind;
+}) {
+	const isVideo = kind === "VIDEO";
+	const generate = useGeneratePart(meditationId);
+	const setActive = useSetActive(meditationId);
+	const updateSegment = useUpdateSegment(meditationId);
+
+	const initialScript = isVideo
+		? segment.current_video_prompt
+		: segment.current_audio_script;
+	const [script, setScript] = useState(initialScript);
+	useEffect(() => setScript(initialScript), [initialScript]);
+
+	const versions = assetsOfKind(segment.assets, kind);
+	const latest = versions[0];
+	const active = versions.find((a) => a.is_active);
+	const pending =
+		latest && (latest.status === "QUEUED" || latest.status === "GENERATING");
+	const failed = latest?.status === "FAILED";
+
+	const onGenerate = () => generate.mutate({ segmentId: segment.id, kind });
+	const onSave = () =>
+		updateSegment.mutate({
+			segmentId: segment.id,
+			fields: isVideo ? { video_prompt: script } : { audio_script: script },
+		});
+
+	return (
+		<div className="flex flex-col gap-3">
+			<div className="flex items-center justify-between">
+				<span className="text-sm font-medium">
+					{isVideo ? "Video" : "Audio"}
+				</span>
+				<Button
+					size="sm"
+					variant="outline"
+					onClick={onGenerate}
+					disabled={pending || generate.isPending}
+				>
+					{pending ? (
+						<>
+							<Loader2 className="w-3.5 h-3.5 animate-spin" /> Generating…
+						</>
+					) : versions.length ? (
+						"Regenerate"
+					) : (
+						"Generate"
+					)}
+				</Button>
+			</div>
+
+			{failed && (
+				<p className="text-xs text-destructive">
+					Generation failed{latest?.error_code ? `: ${latest.error_code}` : ""}.
+					Try again.
+				</p>
+			)}
+
+			{active?.url ? (
+				<AssetPlayer url={active.url} isVideo={isVideo} />
+			) : (
+				!pending && (
+					<p className="text-xs text-muted-foreground">No version yet.</p>
+				)
+			)}
+
+			{versions.length > 1 && (
+				<div className="flex gap-2">
+					{versions.slice(0, 2).map((asset) => (
+						<VersionChip
+							key={asset.id}
+							asset={asset}
+							onUse={() => setActive.mutate(asset.id)}
+							disabled={asset.is_active || setActive.isPending}
+						/>
+					))}
+				</div>
+			)}
+
+			<div className="flex flex-col gap-1.5">
+				<label className="text-xs text-muted-foreground">
+					{isVideo ? "Video prompt" : "Audio script"}
+				</label>
+				<Textarea
+					value={script}
+					onChange={(e) => setScript(e.target.value)}
+					rows={4}
+					className="text-xs"
+				/>
+				<Button
+					size="sm"
+					variant="ghost"
+					onClick={onSave}
+					disabled={script === initialScript || updateSegment.isPending}
+					className="self-end"
+				>
+					Save
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+function AssetPlayer({ url, isVideo }: { url: string; isVideo: boolean }) {
+	// Streams directly from S3; never proxied through the backend.
+	return isVideo ? (
+		// biome-ignore lint/a11y/useMediaCaption: QC preview of generated clip
+		<video key={url} src={url} controls className="w-full rounded-md border" />
+	) : (
+		// biome-ignore lint/a11y/useMediaCaption: QC preview of generated narration
+		<audio key={url} src={url} controls className="w-full" />
+	);
+}
+
+function VersionChip({
+	asset,
+	onUse,
+	disabled,
+}: {
+	asset: MeditationAsset;
+	onUse: () => void;
+	disabled: boolean;
+}) {
+	return (
+		<Button
+			size="sm"
+			variant={asset.is_active ? "default" : "outline"}
+			onClick={onUse}
+			disabled={disabled}
+			className="text-xs"
+		>
+			v{asset.version}
+			{asset.is_active ? " (active)" : " · Use"}
+		</Button>
+	);
+}

--- a/client/src/pages/admin-meditations/meditation-helpers.ts
+++ b/client/src/pages/admin-meditations/meditation-helpers.ts
@@ -1,0 +1,41 @@
+import type {
+	MeditationAsset,
+	MeditationAssetKind,
+} from "@/api/adminMeditations";
+
+/** Human-friendly label from an ENUM_VALUE. */
+export function formatStatus(value: string): string {
+	return value
+		.toLowerCase()
+		.replace(/_/g, " ")
+		.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Badge variant for a meditation/asset status. */
+export function statusVariant(
+	status: string,
+): "default" | "secondary" | "outline" | "destructive" {
+	if (status === "FAILED") return "destructive";
+	if (status === "COMPLETE" || status === "READY") return "default";
+	if (status === "READY_FOR_QC") return "secondary";
+	return "outline";
+}
+
+/** Assets of one kind, newest version first. */
+export function assetsOfKind(
+	assets: MeditationAsset[],
+	kind: MeditationAssetKind,
+): MeditationAsset[] {
+	return assets
+		.filter((a) => a.kind === kind)
+		.sort((a, b) => b.version - a.version);
+}
+
+export const MEDITATION_STATUSES = [
+	"PENDING",
+	"GENERATING_PARTS",
+	"READY_FOR_QC",
+	"ASSEMBLING",
+	"COMPLETE",
+	"FAILED",
+] as const;

--- a/client/src/routeTree.gen.ts
+++ b/client/src/routeTree.gen.ts
@@ -33,6 +33,7 @@ import { Route as AuthenticatedIdentitiesIdentityIdRouteImport } from './routes/
 import { Route as AuthenticatedAdminUsersRouteImport } from './routes/_authenticated/admin/users'
 import { Route as AuthenticatedAdminTestRouteImport } from './routes/_authenticated/admin/test'
 import { Route as AuthenticatedAdminPromptsRouteImport } from './routes/_authenticated/admin/prompts'
+import { Route as AuthenticatedAdminMeditationsRouteImport } from './routes/_authenticated/admin/meditations'
 
 const PublicRouteRoute = PublicRouteRouteImport.update({
   id: '/_public',
@@ -160,6 +161,12 @@ const AuthenticatedAdminPromptsRoute =
     path: '/prompts',
     getParentRoute: () => AuthenticatedAdminRouteRoute,
   } as any)
+const AuthenticatedAdminMeditationsRoute =
+  AuthenticatedAdminMeditationsRouteImport.update({
+    id: '/meditations',
+    path: '/meditations',
+    getParentRoute: () => AuthenticatedAdminRouteRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -171,6 +178,7 @@ export interface FileRoutesByFullPath {
   '/reset-password': typeof ResetPasswordIndexRoute
   '/signup': typeof SignupIndexRoute
   '/verify-email': typeof VerifyEmailIndexRoute
+  '/admin/meditations': typeof AuthenticatedAdminMeditationsRoute
   '/admin/prompts': typeof AuthenticatedAdminPromptsRoute
   '/admin/test': typeof AuthenticatedAdminTestRoute
   '/admin/users': typeof AuthenticatedAdminUsersRoute
@@ -195,6 +203,7 @@ export interface FileRoutesByTo {
   '/reset-password': typeof ResetPasswordIndexRoute
   '/signup': typeof SignupIndexRoute
   '/verify-email': typeof VerifyEmailIndexRoute
+  '/admin/meditations': typeof AuthenticatedAdminMeditationsRoute
   '/admin/prompts': typeof AuthenticatedAdminPromptsRoute
   '/admin/test': typeof AuthenticatedAdminTestRoute
   '/admin/users': typeof AuthenticatedAdminUsersRoute
@@ -222,6 +231,7 @@ export interface FileRoutesById {
   '/reset-password/': typeof ResetPasswordIndexRoute
   '/signup/': typeof SignupIndexRoute
   '/verify-email/': typeof VerifyEmailIndexRoute
+  '/_authenticated/admin/meditations': typeof AuthenticatedAdminMeditationsRoute
   '/_authenticated/admin/prompts': typeof AuthenticatedAdminPromptsRoute
   '/_authenticated/admin/test': typeof AuthenticatedAdminTestRoute
   '/_authenticated/admin/users': typeof AuthenticatedAdminUsersRoute
@@ -248,6 +258,7 @@ export interface FileRouteTypes {
     | '/reset-password'
     | '/signup'
     | '/verify-email'
+    | '/admin/meditations'
     | '/admin/prompts'
     | '/admin/test'
     | '/admin/users'
@@ -272,6 +283,7 @@ export interface FileRouteTypes {
     | '/reset-password'
     | '/signup'
     | '/verify-email'
+    | '/admin/meditations'
     | '/admin/prompts'
     | '/admin/test'
     | '/admin/users'
@@ -298,6 +310,7 @@ export interface FileRouteTypes {
     | '/reset-password/'
     | '/signup/'
     | '/verify-email/'
+    | '/_authenticated/admin/meditations'
     | '/_authenticated/admin/prompts'
     | '/_authenticated/admin/test'
     | '/_authenticated/admin/users'
@@ -496,10 +509,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAdminPromptsRouteImport
       parentRoute: typeof AuthenticatedAdminRouteRoute
     }
+    '/_authenticated/admin/meditations': {
+      id: '/_authenticated/admin/meditations'
+      path: '/meditations'
+      fullPath: '/admin/meditations'
+      preLoaderRoute: typeof AuthenticatedAdminMeditationsRouteImport
+      parentRoute: typeof AuthenticatedAdminRouteRoute
+    }
   }
 }
 
 interface AuthenticatedAdminRouteRouteChildren {
+  AuthenticatedAdminMeditationsRoute: typeof AuthenticatedAdminMeditationsRoute
   AuthenticatedAdminPromptsRoute: typeof AuthenticatedAdminPromptsRoute
   AuthenticatedAdminTestRoute: typeof AuthenticatedAdminTestRoute
   AuthenticatedAdminUsersRoute: typeof AuthenticatedAdminUsersRoute
@@ -507,6 +528,7 @@ interface AuthenticatedAdminRouteRouteChildren {
 
 const AuthenticatedAdminRouteRouteChildren: AuthenticatedAdminRouteRouteChildren =
   {
+    AuthenticatedAdminMeditationsRoute: AuthenticatedAdminMeditationsRoute,
     AuthenticatedAdminPromptsRoute: AuthenticatedAdminPromptsRoute,
     AuthenticatedAdminTestRoute: AuthenticatedAdminTestRoute,
     AuthenticatedAdminUsersRoute: AuthenticatedAdminUsersRoute,

--- a/client/src/routes/_authenticated/admin/meditations.tsx
+++ b/client/src/routes/_authenticated/admin/meditations.tsx
@@ -1,0 +1,27 @@
+import { useMeditations } from "@/hooks/use-meditations";
+import AdminMeditations from "@/pages/admin-meditations/AdminMeditations";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+/**
+ * /admin/meditations — gated behind the MEDITATIONS_ENABLED backend flag.
+ *
+ * The parent /admin route already restricts to admins; this additionally
+ * hides the feature until the backend flag is on. When the flag is off the
+ * route redirects to /chat so the half-built feature is invisible in prod.
+ */
+export const Route = createFileRoute("/_authenticated/admin/meditations")({
+	component: MeditationsRoute,
+});
+
+function MeditationsRoute() {
+	const { enabled, isLoading } = useMeditations();
+	const navigate = useNavigate();
+
+	useEffect(() => {
+		if (!isLoading && !enabled) navigate({ to: "/chat" });
+	}, [enabled, isLoading, navigate]);
+
+	if (isLoading || !enabled) return null;
+	return <AdminMeditations />;
+}

--- a/server/apps/meditations/services/__init__.py
+++ b/server/apps/meditations/services/__init__.py
@@ -7,12 +7,16 @@ from apps.meditations.services.create_meditation import (
     create_meditation_for_user,
     get_eligible_identities,
 )
-from apps.meditations.services.generate_part import generate_segment_part
+from apps.meditations.services.generate_part import (
+    create_pending_asset,
+    generate_asset,
+)
 from apps.meditations.services.set_active_asset import set_active_asset
 
 __all__ = [
     "create_meditation_for_user",
     "get_eligible_identities",
-    "generate_segment_part",
+    "create_pending_asset",
+    "generate_asset",
     "set_active_asset",
 ]

--- a/server/apps/meditations/services/generate_part.py
+++ b/server/apps/meditations/services/generate_part.py
@@ -1,10 +1,16 @@
 """
-generate_segment_part — generate one video or audio part for a segment.
+Segment-part generation.
 
-Creates a new versioned MeditationAsset, calls the appropriate media provider,
-uploads the result to S3, and promotes the new asset to active (demoting the
-prior active in a transaction). On provider failure the asset is marked FAILED
-with an error code. This is the synchronous core; the Celery task wraps it.
+Two steps so the admin UI gets immediate feedback:
+
+1. ``create_pending_asset`` — synchronous, called from the request. Creates the
+   next versioned MeditationAsset in QUEUED state (snapshotting the current
+   prompt/script) so the QC screen sees a pending part the instant Generate is
+   clicked and starts polling.
+2. ``generate_asset`` — the Celery task body. Loads that asset, flips it to
+   GENERATING, calls the media provider, uploads to S3, and promotes it to
+   active (demoting the prior active in a transaction). On provider failure the
+   asset is marked FAILED with an error code.
 """
 
 from django.core.files.base import ContentFile
@@ -12,11 +18,7 @@ from django.core.files.storage import default_storage
 from django.db import transaction
 from django.db.models import Max
 
-from apps.meditations.models import (
-    Meditation,
-    MeditationAsset,
-    MeditationSegment,
-)
+from apps.meditations.models import Meditation, MeditationAsset, MeditationSegment
 from enums.meditation import (
     MeditationAssetKind,
     MeditationAssetStatus,
@@ -47,47 +49,56 @@ def _asset_key(segment: MeditationSegment, kind: str, version: int, ext: str) ->
     )
 
 
-def generate_segment_part(segment_id: str, kind: str) -> MeditationAsset:
+def create_pending_asset(segment: MeditationSegment, kind: str) -> MeditationAsset:
     """
-    Generate one part (``kind`` = VIDEO or AUDIO) for the given segment.
-
-    Returns the created MeditationAsset (READY on success, FAILED on a provider
-    error). Raises ValueError for an unknown kind or missing inputs.
+    Create a QUEUED asset for the next version of (segment, kind), snapshotting
+    the current prompt/script. Returns it immediately so the UI can show and
+    poll it. Marks the meditation as generating.
     """
     kind = MeditationAssetKind(kind)
-    segment = MeditationSegment.objects.select_related("identity", "meditation").get(
-        id=segment_id
+    prompt_snapshot = (
+        segment.current_video_prompt
+        if kind == MeditationAssetKind.VIDEO
+        else segment.current_audio_script
     )
-
-    if kind == MeditationAssetKind.VIDEO:
-        prompt_snapshot = segment.current_video_prompt
-    else:
-        prompt_snapshot = segment.current_audio_script
-
-    version = _next_version(segment, kind)
     asset = MeditationAsset.objects.create(
         segment=segment,
         kind=kind,
-        version=version,
+        version=_next_version(segment, kind),
         prompt_snapshot=prompt_snapshot,
-        status=MeditationAssetStatus.GENERATING,
+        status=MeditationAssetStatus.QUEUED,
     )
-
-    # Mark the meditation as actively generating parts.
     Meditation.objects.filter(
         id=segment.meditation_id, status=MeditationStatus.PENDING
     ).update(status=MeditationStatus.GENERATING_PARTS)
+    return asset
+
+
+def generate_asset(asset_id: str) -> MeditationAsset:
+    """
+    Run generation for an existing QUEUED asset: provider → S3 → READY (active),
+    or FAILED with an error code. Idempotent inputs come from the asset itself
+    (its snapshotted prompt) and its segment's identity.
+    """
+    asset = MeditationAsset.objects.select_related(
+        "segment__identity", "segment__meditation"
+    ).get(id=asset_id)
+    segment = asset.segment
+    kind = MeditationAssetKind(asset.kind)
+
+    asset.status = MeditationAssetStatus.GENERATING
+    asset.save(update_fields=["status", "updated_at"])
 
     try:
-        result = _run_provider(segment, kind)
+        result = _run_provider(segment, kind, asset.prompt_snapshot)
         ext = _EXTENSIONS[kind]
         saved_key = default_storage.save(
-            _asset_key(segment, kind, version, ext), ContentFile(result.data)
+            _asset_key(segment, kind, asset.version, ext), ContentFile(result.data)
         )
         with transaction.atomic():
             MeditationAsset.objects.filter(
                 segment=segment, kind=kind, is_active=True
-            ).update(is_active=False)
+            ).exclude(pk=asset.pk).update(is_active=False)
             asset.s3_key = saved_key
             asset.status = MeditationAssetStatus.READY
             asset.is_active = True
@@ -101,9 +112,11 @@ def generate_segment_part(segment_id: str, kind: str) -> MeditationAsset:
                     "updated_at",
                 ]
             )
-        log.info(f"Generated {kind} v{version} for segment {segment_id}: {saved_key}")
+        log.info(
+            f"Generated {kind} v{asset.version} for segment {segment.id}: {saved_key}"
+        )
     except MediaGenerationError as e:
-        log.warning(f"Generation failed for segment {segment_id} ({kind}): {e}")
+        log.warning(f"Generation failed for asset {asset_id} ({kind}): {e}")
         asset.status = MeditationAssetStatus.FAILED
         asset.error_code = e.error_code
         asset.save(update_fields=["status", "error_code", "updated_at"])
@@ -111,17 +124,15 @@ def generate_segment_part(segment_id: str, kind: str) -> MeditationAsset:
     return asset
 
 
-def _run_provider(segment: MeditationSegment, kind: str):
-    """Call the right media provider and return its MediaResult."""
+def _run_provider(segment: MeditationSegment, kind: str, prompt: str):
+    """Call the right media provider with the snapshotted prompt/script."""
     if kind == MeditationAssetKind.VIDEO:
         first_frame = _read_identity_image(segment.identity)
         provider = MediaProviderFactory.create_video_provider()
-        return provider.generate(
-            prompt=segment.current_video_prompt, first_frame=first_frame
-        )
+        return provider.generate(prompt=prompt, first_frame=first_frame)
 
     provider = MediaProviderFactory.create_audio_provider()
-    return provider.generate(script=segment.current_audio_script)
+    return provider.generate(script=prompt)
 
 
 def _read_identity_image(identity) -> bytes:

--- a/server/apps/meditations/tasks/generate_segment_part.py
+++ b/server/apps/meditations/tasks/generate_segment_part.py
@@ -1,16 +1,17 @@
 """
-Celery task wrapping the segment-part generation service.
+Celery task that runs generation for a pending meditation asset.
 
-Generation is slow (Veo is a long-poll, ~minutes) so the admin enqueues it and
-polls asset status. Runs serialized on the existing worker.
+The asset is created (QUEUED) synchronously in the request so the UI sees it
+immediately; this task fills it in. Generation is slow (Veo is a long-poll,
+~minutes); runs serialized on the existing worker.
 """
 
 from celery import shared_task
 
-from apps.meditations.services import generate_segment_part
+from apps.meditations.services import generate_asset
 
 
 @shared_task
-def generate_segment_part_task(segment_id: str, kind: str) -> None:
-    """Generate one part (VIDEO or AUDIO) for *segment_id* asynchronously."""
-    generate_segment_part(segment_id, kind)
+def generate_segment_part_task(asset_id: str) -> None:
+    """Generate the media for a pending MeditationAsset asynchronously."""
+    generate_asset(asset_id)

--- a/server/apps/meditations/tests/test_admin_meditation_endpoints.py
+++ b/server/apps/meditations/tests/test_admin_meditation_endpoints.py
@@ -69,7 +69,7 @@ class AdminMeditationEndpointTests(TestCase):
     @patch(
         "apps.meditations.views.admin_meditation_view_set.generate_segment_part_task"
     )
-    def test_generate_part_enqueues_task(self, mock_task):
+    def test_generate_part_creates_queued_asset_and_enqueues(self, mock_task):
         med = Meditation.objects.create(user=self.target)
         segment = MeditationSegment.objects.create(
             meditation=med, identity=self.identity, order=0
@@ -80,9 +80,12 @@ class AdminMeditationEndpointTests(TestCase):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
-        mock_task.delay_on_commit.assert_called_once_with(
-            str(segment.id), MeditationAssetKind.VIDEO
-        )
+        # A QUEUED asset is created synchronously and returned.
+        self.assertEqual(response.data["status"], "QUEUED")
+        asset = MeditationAsset.objects.get(segment=segment)
+        self.assertEqual(str(asset.id), response.data["id"])
+        # The task is enqueued by the new asset's id.
+        mock_task.delay_on_commit.assert_called_once_with(str(asset.id))
 
     def test_generate_part_rejects_bad_kind(self):
         med = Meditation.objects.create(user=self.target)

--- a/server/apps/meditations/tests/test_generate_part.py
+++ b/server/apps/meditations/tests/test_generate_part.py
@@ -1,7 +1,8 @@
 """
-Tests for generate_segment_part: versioned asset creation, S3 upload, active
-promotion/demotion, and failure handling. The provider call and storage are
-mocked (the providers themselves are covered in services/media tests).
+Tests for the two-step generation flow: create_pending_asset (synchronous,
+QUEUED) and generate_asset (the task body — provider → S3 → READY/FAILED). The
+provider call and storage are mocked (providers are covered in services/media
+tests).
 """
 
 from unittest.mock import patch
@@ -9,7 +10,7 @@ from unittest.mock import patch
 from django.test import TestCase
 
 from apps.meditations.models import Meditation, MeditationAsset, MeditationSegment
-from apps.meditations.services import generate_segment_part
+from apps.meditations.services import create_pending_asset, generate_asset
 from conftest import create_test_identity, create_test_user
 from enums.meditation import (
     MeditationAssetKind,
@@ -28,7 +29,7 @@ def _result(kind="video"):
     )
 
 
-class GenerateSegmentPartTests(TestCase):
+class GenerationFlowTests(TestCase):
     def setUp(self):
         self.user = create_test_user(email="gen@example.com")
         self.identity = create_test_identity(
@@ -43,31 +44,33 @@ class GenerateSegmentPartTests(TestCase):
             current_audio_script="I am calm.",
         )
 
+    def test_create_pending_asset(self):
+        asset = create_pending_asset(self.segment, MeditationAssetKind.VIDEO)
+        self.assertEqual(asset.status, MeditationAssetStatus.QUEUED)
+        self.assertEqual(asset.version, 1)
+        self.assertEqual(asset.prompt_snapshot, "serene push-in")
+        self.assertFalse(asset.is_active)
+        self.med.refresh_from_db()
+        self.assertEqual(self.med.status, MeditationStatus.GENERATING_PARTS)
+
+    def test_create_pending_audio_uses_script(self):
+        asset = create_pending_asset(self.segment, MeditationAssetKind.AUDIO)
+        self.assertEqual(asset.prompt_snapshot, "I am calm.")
+
     @patch("apps.meditations.services.generate_part.default_storage")
     @patch("apps.meditations.services.generate_part._run_provider")
-    def test_video_success(self, mock_run, mock_storage):
+    def test_generate_asset_success(self, mock_run, mock_storage):
         mock_run.return_value = _result("video")
         mock_storage.save.return_value = "meditations/k/video_v1.mp4"
+        pending = create_pending_asset(self.segment, MeditationAssetKind.VIDEO)
 
-        asset = generate_segment_part(str(self.segment.id), MeditationAssetKind.VIDEO)
+        asset = generate_asset(str(pending.id))
 
         self.assertEqual(asset.status, MeditationAssetStatus.READY)
         self.assertEqual(asset.s3_key, "meditations/k/video_v1.mp4")
         self.assertTrue(asset.is_active)
-        self.assertEqual(asset.version, 1)
-        self.assertEqual(asset.prompt_snapshot, "serene push-in")
-        self.med.refresh_from_db()
-        self.assertEqual(self.med.status, MeditationStatus.GENERATING_PARTS)
-
-    @patch("apps.meditations.services.generate_part.default_storage")
-    @patch("apps.meditations.services.generate_part._run_provider")
-    def test_audio_uses_script_snapshot(self, mock_run, mock_storage):
-        mock_run.return_value = _result("audio")
-        mock_storage.save.return_value = "meditations/k/audio_v1.wav"
-
-        asset = generate_segment_part(str(self.segment.id), MeditationAssetKind.AUDIO)
-        self.assertEqual(asset.prompt_snapshot, "I am calm.")
-        self.assertEqual(asset.kind, MeditationAssetKind.AUDIO)
+        # The provider is called with the snapshotted prompt.
+        self.assertEqual(mock_run.call_args.args[2], "serene push-in")
 
     @patch("apps.meditations.services.generate_part.default_storage")
     @patch("apps.meditations.services.generate_part._run_provider")
@@ -75,14 +78,17 @@ class GenerateSegmentPartTests(TestCase):
         mock_run.return_value = _result("video")
         mock_storage.save.side_effect = ["k/v1.mp4", "k/v2.mp4"]
 
-        first = generate_segment_part(str(self.segment.id), MeditationAssetKind.VIDEO)
-        second = generate_segment_part(str(self.segment.id), MeditationAssetKind.VIDEO)
+        first = generate_asset(
+            str(create_pending_asset(self.segment, MeditationAssetKind.VIDEO).id)
+        )
+        second = generate_asset(
+            str(create_pending_asset(self.segment, MeditationAssetKind.VIDEO).id)
+        )
 
         first.refresh_from_db()
         self.assertFalse(first.is_active)
         self.assertTrue(second.is_active)
         self.assertEqual(second.version, 2)
-        # Exactly one active video asset.
         active = MeditationAsset.objects.filter(
             segment=self.segment, kind=MeditationAssetKind.VIDEO, is_active=True
         )
@@ -90,12 +96,13 @@ class GenerateSegmentPartTests(TestCase):
 
     @patch("apps.meditations.services.generate_part.default_storage")
     @patch("apps.meditations.services.generate_part._run_provider")
-    def test_provider_failure_marks_asset_failed(self, mock_run, mock_storage):
+    def test_provider_failure_marks_failed(self, mock_run, mock_storage):
         mock_run.side_effect = MediaGenerationError(
             "blocked", MediaGenerationError.SAFETY_BLOCK
         )
+        pending = create_pending_asset(self.segment, MeditationAssetKind.VIDEO)
 
-        asset = generate_segment_part(str(self.segment.id), MeditationAssetKind.VIDEO)
+        asset = generate_asset(str(pending.id))
 
         self.assertEqual(asset.status, MeditationAssetStatus.FAILED)
         self.assertEqual(asset.error_code, MediaGenerationError.SAFETY_BLOCK)

--- a/server/apps/meditations/views/admin_meditation_view_set.py
+++ b/server/apps/meditations/views/admin_meditation_view_set.py
@@ -17,10 +17,15 @@ from rest_framework.response import Response
 
 from apps.meditations.models import Meditation, MeditationAsset, MeditationSegment
 from apps.meditations.serializers import (
+    MeditationAssetSerializer,
     MeditationDetailSerializer,
     MeditationListSerializer,
 )
-from apps.meditations.services import create_meditation_for_user, set_active_asset
+from apps.meditations.services import (
+    create_meditation_for_user,
+    create_pending_asset,
+    set_active_asset,
+)
 from apps.meditations.tasks import generate_segment_part_task
 from apps.users.models import User
 from enums.meditation import MeditationAssetKind
@@ -79,11 +84,13 @@ class AdminMeditationViewSet(
                 {"detail": f"kind must be one of {MeditationAssetKind.values}."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        # Validate the segment exists (404 otherwise).
-        get_object_or_404(MeditationSegment, id=segment_id)
-        generate_segment_part_task.delay_on_commit(str(segment_id), kind)
+        segment = get_object_or_404(MeditationSegment, id=segment_id)
+        # Create the QUEUED asset now so the UI sees it and starts polling
+        # immediately; the task fills it in.
+        asset = create_pending_asset(segment, kind)
+        generate_segment_part_task.delay_on_commit(str(asset.id))
         return Response(
-            {"status": "queued", "segment_id": str(segment_id), "kind": kind},
+            MeditationAssetSerializer(asset).data,
             status=status.HTTP_202_ACCEPTED,
         )
 


### PR DESCRIPTION
## What & why

The admin-facing **QC surface** for Meditations, plus a generation-flow change so the screen feels responsive. Builds on the merged backend (#147). **Flag-gated and ships OFF by default** — see below.

### Frontend — admin QC surface
- **API client + hooks** — `adminMeditations.ts` + `use-admin-meditations.ts` (React Query) for the admin meditations endpoints.
- **QC page** — `AdminMeditations.tsx` (list/table) + `MeditationDetailView.tsx` (per-segment video/audio cards) at flag-gated route `/admin/meditations`.
- **Nav** — flag-gated "Meditations" item in the admin sidebar.
- **Tests** — cover the API client.

### Backend — two-step part generation
Split `generate_segment_part` into:
1. `create_pending_asset` — synchronous, called from the request. Creates the next versioned `MeditationAsset` in **QUEUED** state (with a prompt snapshot) and marks the meditation `GENERATING_PARTS`.
2. `generate_asset` — the Celery task body: flips to GENERATING, runs the provider off the snapshot, uploads to S3, promotes to active (or marks FAILED).

The generate-part endpoint now creates the QUEUED asset up front and returns the serialized asset (202), so the QC screen renders and polls the pending part the instant **Generate** is clicked instead of waiting on the long-running Veo call. The task is enqueued by asset id.

## Feature flag — ships OFF
`MEDITATIONS_ENABLED = env.bool("MEDITATIONS_ENABLED", default=False)`. The whole surface (route, nav, config endpoint) gates on this flag, which **defaults to False**. `server/.env` is gitignored, and this branch touches no settings/`.env`, so nothing here turns it on — it only activates if the service env var is explicitly set.

## Testing
- Backend: `apps.meditations` + core meditations endpoint/get tests — 35 pass.
- Frontend: admin meditations API tests 7 pass; `tsc --noEmit` clean; biome clean (2 pre-existing a11y warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)