### PR TITLE
Chat UX polish: smooth message flow, single dots→reply bubble, canned-choice choreography

### DIFF
--- a/client/src/hooks/use-chat-messages.ts
+++ b/client/src/hooks/use-chat-messages.ts
@@ -122,12 +122,13 @@ export function useChatMessages() {
 			// `message: null` is a programmatic-only dispatch (e.g. the video
 			// Continue button); the backend saves no user ChatMessage, so neither
 			// do we.
+			const now = Date.now();
 			if (request.message !== null) {
 				const optimisticUser: Message = {
 					id: nextClientMessageId(),
 					role: "user",
 					content: request.message,
-					timestamp: new Date().toISOString(),
+					timestamp: new Date(now).toISOString(),
 				};
 				queryClient.setQueryData<Message[] | undefined>(
 					chatMessagesKey,
@@ -135,7 +136,27 @@ export function useChatMessages() {
 				);
 			}
 
-			return { previousMessages, previousComponentConfig };
+			// Append a PENDING coach placeholder — this is the loading-dots bubble.
+			// onSuccess finalizes this exact message in place (same id), so the dots
+			// crossfade into the response within one bubble rather than a separate
+			// loading bubble unmounting. Timestamp is nudged +1ms so it always sorts
+			// after the user message it answers.
+			const pendingCoachId = nextClientMessageId();
+			queryClient.setQueryData<Message[] | undefined>(
+				chatMessagesKey,
+				(old) => [
+					...(old ?? []),
+					{
+						id: pendingCoachId,
+						role: "coach",
+						content: "",
+						timestamp: new Date(now + 1).toISOString(),
+						pending: true,
+					},
+				],
+			);
+
+			return { previousMessages, previousComponentConfig, pendingCoachId };
 		},
 		onError: (_error, _variables, context) => {
 			// Roll the optimistic writes back to the pre-mutation snapshot so a
@@ -149,47 +170,47 @@ export function useChatMessages() {
 				);
 			}
 		},
-		onSuccess: (response: CoachResponse, variables) => {
+		onSuccess: (response: CoachResponse, _variables, context) => {
 			queryClient.cancelQueries({ queryKey: chatMessagesKey });
 
 			queryClient.setQueryData<Message[] | undefined>(
 				chatMessagesKey,
 				(old) => {
 					const current = old ?? [];
-					// PR 17: when `message: null` (programmatic-only dispatch from
-					// the video modal's Continue button), the backend skips saving a
-					// user ChatMessage. Mirror that here — no optimistic user bubble.
-					const userMsg: Message | null =
-						variables.message === null
-							? null
-							: {
-									id: nextClientMessageId(),
-									role: "user",
-									content: variables.message,
-									timestamp: new Date().toISOString(),
-								};
-					const coachMsg: Message | null = response.message
-						? {
-								id: nextClientMessageId(),
-								role: "coach",
-								content: response.message,
-								timestamp: new Date().toISOString(),
-							}
-						: null;
+					const pendingId = context?.pendingCoachId;
+					const hasText = !!response.message;
+					// The component (if any) renders via `componentConfigKey` below,
+					// so a component-only turn still has visible coach output.
+					const hasComponent = !!response.component;
 
-					const last = current[current.length - 1];
-					const hasUserAlready =
-						!!last &&
-						userMsg !== null &&
-						last.role === "user" &&
-						last.content === userMsg.content;
+					// Finalize the pending coach placeholder IN PLACE (same id → same
+					// React key) so the dots crossfade into the response within one
+					// bubble. No new coach row is appended, nothing unmounts.
+					if (pendingId) {
+						if (!hasText && !hasComponent) {
+							// No coach output this turn (e.g. the Identity Visualization
+							// no-op phase) — drop the placeholder so there's no empty bubble.
+							return current.filter((m) => m.id !== pendingId);
+						}
+						return current.map((m) =>
+							m.id === pendingId
+								? { ...m, content: response.message ?? "", pending: false }
+								: m,
+						);
+					}
 
-					const next: Message[] =
-						hasUserAlready || userMsg === null
-							? [...current]
-							: [...current, userMsg];
-
-					return coachMsg ? [...next, coachMsg] : next;
+					// Fallback (no placeholder in context — shouldn't happen): append a
+					// finalized coach message if there's output, otherwise leave as-is.
+					if (!hasText && !hasComponent) return current;
+					return [
+						...current,
+						{
+							id: nextClientMessageId(),
+							role: "coach",
+							content: response.message ?? "",
+							timestamp: new Date().toISOString(),
+						},
+					];
 				},
 			);
 

--- a/client/src/hooks/use-chat-messages.ts
+++ b/client/src/hooks/use-chat-messages.ts
@@ -34,6 +34,15 @@ const MIN_THINKING_MS = 900;
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
+ * Delay before the pending coach "dots" bubble appears after the user's
+ * message. Lets the user's message land and settle first, so the coach's reply
+ * reads as a turn-taking beat rather than everything popping in at once. Must
+ * stay below MIN_THINKING_MS so the placeholder always exists before onSuccess
+ * finalizes it.
+ */
+const DOTS_DELAY_MS = 400;
+
+/**
  * useChatMessages hook
  * Handles fetching and updating chat messages using TanStack Query.
  *
@@ -150,39 +159,53 @@ export function useChatMessages() {
 				);
 			}
 
-			// Append a PENDING coach placeholder — this is the loading-dots bubble.
-			// onSuccess finalizes this exact message in place (same id), so the dots
-			// crossfade into the response within one bubble rather than a separate
-			// loading bubble unmounting. Timestamp is nudged +1ms so it always sorts
-			// after the user message it answers.
+			// Append the PENDING coach placeholder — the loading-dots bubble —
+			// after a short beat, so the dots arrive once the user's message has
+			// landed instead of in the same instant. onSuccess finalizes this exact
+			// message in place (same id), so the dots crossfade into the response
+			// within one bubble. The timer is cleared on error/settle so a failed
+			// turn never strands a dots bubble.
 			const pendingCoachId = nextClientMessageId();
-			queryClient.setQueryData<Message[] | undefined>(
-				chatMessagesKey,
-				(old) => [
-					...(old ?? []),
-					{
-						id: pendingCoachId,
-						role: "coach",
-						content: "",
-						timestamp: new Date(now + 1).toISOString(),
-						pending: true,
-					},
-				],
-			);
+			const dotsTimer = setTimeout(() => {
+				queryClient.setQueryData<Message[] | undefined>(
+					chatMessagesKey,
+					(old) => [
+						...(old ?? []),
+						{
+							id: pendingCoachId,
+							role: "coach",
+							content: "",
+							timestamp: new Date(now + DOTS_DELAY_MS).toISOString(),
+							pending: true,
+						},
+					],
+				);
+			}, DOTS_DELAY_MS);
 
-			return { previousMessages, previousComponentConfig, pendingCoachId };
+			return {
+				previousMessages,
+				previousComponentConfig,
+				pendingCoachId,
+				dotsTimer,
+			};
 		},
 		onError: (_error, _variables, context) => {
 			// Roll the optimistic writes back to the pre-mutation snapshot so a
 			// failed send doesn't leave a stranded user bubble or a prematurely
 			// frozen (display-only) card.
 			if (context) {
+				clearTimeout(context.dotsTimer);
 				queryClient.setQueryData(chatMessagesKey, context.previousMessages);
 				queryClient.setQueryData(
 					componentConfigKey,
 					context.previousComponentConfig,
 				);
 			}
+		},
+		onSettled: (_data, _error, _variables, context) => {
+			// Safety net: ensure the deferred dots timer can never fire after the
+			// turn has resolved (it normally fires well before onSuccess).
+			if (context) clearTimeout(context.dotsTimer);
 		},
 		onSuccess: (response: CoachResponse, _variables, context) => {
 			queryClient.cancelQueries({ queryKey: chatMessagesKey });

--- a/client/src/hooks/use-chat-messages.ts
+++ b/client/src/hooks/use-chat-messages.ts
@@ -152,6 +152,9 @@ export function useChatMessages() {
 					role: "user",
 					content: request.message,
 					timestamp: new Date(now).toISOString(),
+					// Choice clicks always carry `actions`; typed sends never do. Only
+					// choices get the slide-over entrance in ChatMessages.
+					fromChoice: request.actions !== undefined,
 				};
 				queryClient.setQueryData<Message[] | undefined>(
 					chatMessagesKey,

--- a/client/src/hooks/use-chat-messages.ts
+++ b/client/src/hooks/use-chat-messages.ts
@@ -24,6 +24,16 @@ const nextClientMessageId = () => {
 };
 
 /**
+ * Deliberate minimum "thinking" time before the coach's reply lands. The coach
+ * dots show during this beat. Without it, canned-response turns (which skip the
+ * LLM on the backend and return almost instantly) snap the reply in the same
+ * breath as the user's message and feel robotic. Padding only affects fast
+ * turns — slower LLM turns already exceed this.
+ */
+const MIN_THINKING_MS = 900;
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
  * useChatMessages hook
  * Handles fetching and updating chat messages using TanStack Query.
  *
@@ -67,13 +77,17 @@ export function useChatMessages() {
 	 */
 	const updateMutation = useMutation({
 		mutationFn: async (request: CoachRequest) => {
-			if (isImpersonating) {
-				return apiClient.sendTestScenarioMessage({
-					...request,
-					user_id: targetUserId!,
-				});
-			}
-			return apiClient.sendMessage(request);
+			const send = isImpersonating
+				? apiClient.sendTestScenarioMessage({
+						...request,
+						user_id: targetUserId!,
+					})
+				: apiClient.sendMessage(request);
+			// Hold a deliberate beat so the reply lands after the user's message,
+			// not in the same instant. Promise.all resolves on the SLOWER of the
+			// two, so this pads fast (canned) turns without delaying slow ones.
+			const [response] = await Promise.all([send, sleep(MIN_THINKING_MS)]);
+			return response;
 		},
 		onMutate: async (request: CoachRequest) => {
 			await queryClient.cancelQueries({ queryKey: chatMessagesKey });

--- a/client/src/hooks/use-chat-messages.ts
+++ b/client/src/hooks/use-chat-messages.ts
@@ -18,7 +18,10 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
  * Resetting on reload is fine — keys only need to be unique within the live list.
  */
 let clientMessageSeq = 0;
-const nextClientMessageId = () => `client-${(clientMessageSeq += 1)}`;
+const nextClientMessageId = () => {
+	clientMessageSeq += 1;
+	return `client-${clientMessageSeq}`;
+};
 
 /**
  * useChatMessages hook
@@ -191,7 +194,19 @@ export function useChatMessages() {
 			);
 
 			if (response.component) {
-				queryClient.invalidateQueries({ queryKey: chatMessagesKey });
+				// Mark stale WITHOUT an active refetch (`refetchType: "none"`). The
+				// component for this turn is already in `response.component` (the
+				// backend always returns it — see process_message), and we set it
+				// on `componentConfigKey` below, so the card renders without the
+				// round-trip. Actively refetching here replaced the whole message
+				// list with fresh server objects mid-turn, remounting every row
+				// (new keys) and flashing the just-rendered card. Server truth
+				// (DB ids, persisted component_config) reconciles on the next
+				// natural mount instead.
+				queryClient.invalidateQueries({
+					queryKey: chatMessagesKey,
+					refetchType: "none",
+				});
 			}
 
 			if (response.final_prompt !== undefined) {
@@ -206,7 +221,7 @@ export function useChatMessages() {
 			// Coaching Phase Videos (PR 15): mirror on_break from the coach
 			// response into the coachState cache immediately so the composer
 			// disables/enables this paint, not on the next refetch. The
-			// invalidation below still triggers a refetch as confirmation.
+			// coachState invalidation below refetches separately to confirm.
 			if (response.on_break !== undefined) {
 				queryClient.setQueryData<CoachState | undefined>(
 					[...queryKeyPrefix, "coachState"],

--- a/client/src/hooks/use-chat-messages.ts
+++ b/client/src/hooks/use-chat-messages.ts
@@ -11,6 +11,16 @@ import { makeComponentDisplayOnly } from "@/utils/componentConfig";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 /**
+ * Monotonic id for client-created (optimistic/synthetic) messages. Stable
+ * within a session and unique against server UUIDs, so a message row keeps the
+ * same React key from its optimistic render through commit and never remounts
+ * (a remount re-runs the row's entrance animation and makes the list flicker).
+ * Resetting on reload is fine — keys only need to be unique within the live list.
+ */
+let clientMessageSeq = 0;
+const nextClientMessageId = () => `client-${(clientMessageSeq += 1)}`;
+
+/**
  * useChatMessages hook
  * Handles fetching and updating chat messages using TanStack Query.
  *
@@ -62,11 +72,17 @@ export function useChatMessages() {
 			}
 			return apiClient.sendMessage(request);
 		},
-		onMutate: async () => {
+		onMutate: async (request: CoachRequest) => {
 			await queryClient.cancelQueries({ queryKey: chatMessagesKey });
 
-			const componentConfigFromCache =
+			// Snapshot the pre-mutation cache so onError can fully roll back the
+			// optimistic writes below (the user bubble and the display-only freeze).
+			const previousMessages =
+				queryClient.getQueryData<Message[]>(chatMessagesKey);
+			const previousComponentConfig =
 				queryClient.getQueryData<ComponentConfig | null>(componentConfigKey);
+
+			const componentConfigFromCache = previousComponentConfig;
 
 			if (componentConfigFromCache) {
 				queryClient.setQueryData<Message[] | undefined>(
@@ -96,6 +112,39 @@ export function useChatMessages() {
 				);
 				queryClient.setQueryData(componentConfigKey, null);
 			}
+
+			// Optimistically append the user's message with a STABLE client id, so
+			// the bubble keeps the same React key from this paint through commit
+			// (onSuccess keeps this same object — see `hasUserAlready` below).
+			// `message: null` is a programmatic-only dispatch (e.g. the video
+			// Continue button); the backend saves no user ChatMessage, so neither
+			// do we.
+			if (request.message !== null) {
+				const optimisticUser: Message = {
+					id: nextClientMessageId(),
+					role: "user",
+					content: request.message,
+					timestamp: new Date().toISOString(),
+				};
+				queryClient.setQueryData<Message[] | undefined>(
+					chatMessagesKey,
+					(old) => [...(old ?? []), optimisticUser],
+				);
+			}
+
+			return { previousMessages, previousComponentConfig };
+		},
+		onError: (_error, _variables, context) => {
+			// Roll the optimistic writes back to the pre-mutation snapshot so a
+			// failed send doesn't leave a stranded user bubble or a prematurely
+			// frozen (display-only) card.
+			if (context) {
+				queryClient.setQueryData(chatMessagesKey, context.previousMessages);
+				queryClient.setQueryData(
+					componentConfigKey,
+					context.previousComponentConfig,
+				);
+			}
 		},
 		onSuccess: (response: CoachResponse, variables) => {
 			queryClient.cancelQueries({ queryKey: chatMessagesKey });
@@ -111,12 +160,14 @@ export function useChatMessages() {
 						variables.message === null
 							? null
 							: {
+									id: nextClientMessageId(),
 									role: "user",
 									content: variables.message,
 									timestamp: new Date().toISOString(),
 								};
 					const coachMsg: Message | null = response.message
 						? {
+								id: nextClientMessageId(),
 								role: "coach",
 								content: response.message,
 								timestamp: new Date().toISOString(),

--- a/client/src/pages/chat/components/ChatInterface.tsx
+++ b/client/src/pages/chat/components/ChatInterface.tsx
@@ -101,8 +101,15 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({
 	// single instant pin is stable. `displayedMessages` already derives from
 	// `chatMessages`, so one effect covers both; `isProcessingMessage` re-pins
 	// when the loading bubble appears/disappears.
+	// Scroll the messages container fully to the bottom by setting scrollTop to
+	// scrollHeight directly. `scrollIntoView({ block: "end" })` would stop once
+	// the (zero-height) anchor was *barely* visible, leaving the last message
+	// partly cut off behind the composer. The anchor's parent IS the scroll
+	// container (the overflow-y-auto _ChatMessages div), so going to its
+	// scrollHeight always lands all the way down.
 	const scrollToBottom = useCallback(() => {
-		messagesEndRef.current?.scrollIntoView({ block: "end" });
+		const container = messagesEndRef.current?.parentElement;
+		if (container) container.scrollTop = container.scrollHeight;
 	}, []);
 
 	useEffect(() => {

--- a/client/src/pages/chat/components/ChatInterface.tsx
+++ b/client/src/pages/chat/components/ChatInterface.tsx
@@ -93,28 +93,45 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({
 			);
 	}, [chatMessages]);
 
-	// Keep the view pinned to the latest message. Use an INSTANT jump, not a
-	// smooth scroll: a single message turn fires several rapid updates
-	// (optimistic user message → loading bubble → the response, which can
-	// collapse a card and add a new one), and an animated scroll chasing a list
-	// whose height is changing under it is what made the chat feel jerky. A
-	// single instant pin is stable. `displayedMessages` already derives from
-	// `chatMessages`, so one effect covers both; `isProcessingMessage` re-pins
-	// when the loading bubble appears/disappears.
-	// Scroll the messages container fully to the bottom by setting scrollTop to
-	// scrollHeight directly. `scrollIntoView({ block: "end" })` would stop once
-	// the (zero-height) anchor was *barely* visible, leaving the last message
-	// partly cut off behind the composer. The anchor's parent IS the scroll
-	// container (the overflow-y-auto _ChatMessages div), so going to its
-	// scrollHeight always lands all the way down.
-	const scrollToBottom = useCallback(() => {
-		const container = messagesEndRef.current?.parentElement;
-		if (container) container.scrollTop = container.scrollHeight;
-	}, []);
-
+	// Keep the view pinned to the bottom as the list grows. A single scroll on
+	// each message change isn't enough: the list keeps changing height for up to
+	// ~1s afterward (the dots bubble appears on a delay, the dots→response
+	// crossfade mounts the reply a beat later, and the canned options fade and
+	// slide). A ResizeObserver on the content wrapper follows EVERY height change
+	// and re-pins to the very bottom (scrollTop = scrollHeight). We only auto-pin
+	// when the user is already near the bottom — tracked on scroll — so we never
+	// yank them while they're reading history.
 	useEffect(() => {
-		scrollToBottom();
-	}, [displayedMessages, updateStatus, scrollToBottom]);
+		if (isLoading || isError) return;
+		// messagesEndRef sits inside the content wrapper, whose parent is the
+		// scrollable _ChatMessages container.
+		const content = messagesEndRef.current?.parentElement;
+		const container = content?.parentElement;
+		if (!content || !container) return;
+
+		const STICK_THRESHOLD_PX = 80;
+		let stuckToBottom = true;
+
+		const onScroll = () => {
+			stuckToBottom =
+				container.scrollHeight - container.scrollTop - container.clientHeight <=
+				STICK_THRESHOLD_PX;
+		};
+		container.addEventListener("scroll", onScroll, { passive: true });
+
+		const observer = new ResizeObserver(() => {
+			if (stuckToBottom) container.scrollTop = container.scrollHeight;
+		});
+		observer.observe(content);
+
+		// Pin once on setup (e.g. when history first loads).
+		container.scrollTop = container.scrollHeight;
+
+		return () => {
+			container.removeEventListener("scroll", onScroll);
+			observer.disconnect();
+		};
+	}, [isLoading, isError]);
 
 	// Handler for sending a message.
 	//

--- a/client/src/pages/chat/components/ChatInterface.tsx
+++ b/client/src/pages/chat/components/ChatInterface.tsx
@@ -15,6 +15,7 @@ import { StudioUnlockAnimation } from "@/pages/chat/components/StudioUnlockAnima
 import { VisualizationChatGate } from "@/pages/chat/components/VisualizationChatGate";
 import { TestScenarioSessionFreezer } from "@/pages/test/components/TestScenarioSessionFreezer";
 import type { CoachRequest } from "@/types/coachRequest";
+import type { Message } from "@/types/message";
 import React, { useRef, useEffect, useCallback, useState } from "react";
 
 interface ChatInterfaceProps {
@@ -75,33 +76,22 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({
 		isError,
 		updateChatMessages,
 		updateStatus,
-		pendingMessage, // The message being sent (if any)
-		isPending, // Whether a message is being sent
 	} = useChatMessages();
 
-	// Compose the messages to display, including the pending message if any
-	// Always sort by timestamp to ensure correct order, as backend/hook may not guarantee order
-	const displayedMessages = React.useMemo(() => {
-		let messages: { role: string; content: string; timestamp: string }[] =
-			chatMessages || [];
-		if (isPending && pendingMessage?.message) {
-			messages = [
-				...messages,
-				{
-					role: "user",
-					content: pendingMessage.message,
-					timestamp: new Date().toISOString(), // Temporary timestamp
-				},
-			];
-		}
-		// Sort by timestamp ascending (oldest first)
-		return messages
+	// The optimistic user bubble is written into the query cache by
+	// useChatMessages' `onMutate` (with a stable client id), so `chatMessages`
+	// already includes it during a pending send — keeping a single source of
+	// truth means the bubble's React key never changes between optimistic render
+	// and commit, so it doesn't remount and flicker. We still sort defensively
+	// in case history arrives out of order.
+	const displayedMessages = React.useMemo<Message[]>(() => {
+		return ((chatMessages ?? []) as Message[])
 			.slice()
 			.sort(
 				(a, b) =>
 					new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
 			);
-	}, [chatMessages, isPending, pendingMessage]);
+	}, [chatMessages]);
 
 	// Keep the view pinned to the latest message. Use an INSTANT jump, not a
 	// smooth scroll: a single message turn fires several rapid updates

--- a/client/src/pages/chat/components/ChatMessages.tsx
+++ b/client/src/pages/chat/components/ChatMessages.tsx
@@ -57,7 +57,10 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
 	return (
 		<div className="_ChatMessages scrollbar not-last:flex-grow overflow-y-auto sm:p-6 bg-gold-50  dark:bg-[#333333]">
 			{messages.map((message: Message, index: number) => (
-				<motion.div key={`${message.timestamp}-${message.role}`} {...rowMotion}>
+				<motion.div
+					key={message.id ?? `${message.timestamp}-${message.role}`}
+					{...rowMotion}
+				>
 					{message.role === "coach" ? (
 						(() => {
 							const isLastCoachMessage = index === messages.length - 1;

--- a/client/src/pages/chat/components/ChatMessages.tsx
+++ b/client/src/pages/chat/components/ChatMessages.tsx
@@ -6,7 +6,7 @@ import type { CoachRequest } from "@/types/coachRequest";
 import type { ComponentConfig } from "@/types/componentConfig";
 import type { Message } from "@/types/message";
 import MarkdownRenderer from "@/utils/MarkdownRenderer";
-import { motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import type React from "react";
 
 /**
@@ -35,15 +35,17 @@ interface ChatMessagesProps {
 	onSendUserMessageToCoach: (request: CoachRequest) => void;
 }
 
-// New chat rows fade in on mount. Deliberately opacity-only and with NO
-// `layout` or exit animation: animating row positions/heights made the whole
-// list shove around to make room for incoming content and then snap back as
-// the loading bubble's space was reclaimed. A plain fade gives a calm,
-// predictable entrance with zero reflow thrash. Existing rows keep stable keys
-// so they never re-animate; the loading bubble simply unmounts when done.
+// New chat rows fade in on mount and fade out on unmount. Opacity-only by
+// design — animating row positions/heights made the whole list shove around.
+// The list is wrapped in <AnimatePresence mode="popLayout">: the only row that
+// routinely unmounts is the loading bubble, and popLayout pulls it out of the
+// layout flow as it fades so the incoming coach response can fade in over the
+// same spot — a calm crossfade instead of a hard dots→response cut. Existing
+// rows keep stable keys (see `key` below) so they never re-animate.
 const rowMotion = {
 	initial: { opacity: 0 },
 	animate: { opacity: 1 },
+	exit: { opacity: 0, transition: { duration: 0.15, ease: "easeIn" } },
 	transition: { duration: 0.25, ease: "easeOut" },
 } as const;
 
@@ -56,63 +58,65 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
 }) => {
 	return (
 		<div className="_ChatMessages scrollbar not-last:flex-grow overflow-y-auto sm:p-6 bg-gold-50  dark:bg-[#333333]">
-			{messages.map((message: Message, index: number) => (
-				<motion.div
-					key={message.id ?? `${message.timestamp}-${message.role}`}
-					{...rowMotion}
-				>
-					{message.role === "coach" ? (
-						(() => {
-							const isLastCoachMessage = index === messages.length - 1;
-							let componentToRender = null;
+			<AnimatePresence mode="popLayout" initial={false}>
+				{messages.map((message: Message, index: number) => (
+					<motion.div
+						key={message.id ?? `${message.timestamp}-${message.role}`}
+						{...rowMotion}
+					>
+						{message.role === "coach" ? (
+							(() => {
+								const isLastCoachMessage = index === messages.length - 1;
+								let componentToRender = null;
 
-							if (isLastCoachMessage) {
-								// Prefer the in-memory cache when not processing (freshest
-								// server response). Fall through to `message.component_config`
-								// for server-seeded cards (welcome SESSION_VIDEO,
-								// post-END_BREAK intros) — those represent persisted
-								// history and stay visible even during in-flight requests,
-								// so clicking Continue doesn't blink the card out while
-								// we wait for the response.
-								componentToRender =
-									(!isProcessingMessage && componentConfig) ||
-									message.component_config ||
-									null;
-							} else {
-								// For all other coach messages, ONLY check message.component_config
-								componentToRender = message.component_config || null;
-							}
+								if (isLastCoachMessage) {
+									// Prefer the in-memory cache when not processing (freshest
+									// server response). Fall through to `message.component_config`
+									// for server-seeded cards (welcome SESSION_VIDEO,
+									// post-END_BREAK intros) — those represent persisted
+									// history and stay visible even during in-flight requests,
+									// so clicking Continue doesn't blink the card out while
+									// we wait for the response.
+									componentToRender =
+										(!isProcessingMessage && componentConfig) ||
+										message.component_config ||
+										null;
+								} else {
+									// For all other coach messages, ONLY check message.component_config
+									componentToRender = message.component_config || null;
+								}
 
-							return componentToRender ? (
-								<CoachMessageWithComponent
-									componentConfig={componentToRender}
-									onSendUserMessageToCoach={onSendUserMessageToCoach}
-									disabled={isProcessingMessage}
-								>
-									<MarkdownRenderer content={message.content} />
-								</CoachMessageWithComponent>
-							) : (
-								<CoachMessage>
-									<MarkdownRenderer content={message.content} />
-								</CoachMessage>
-							);
-						})()
-					) : message.role === "user" ? (
-						<UserMessage>{message.content}</UserMessage>
-					) : (
-						<div className="mb-4 p-3.5 pr-4 pl-4 rounded-[18px] max-w-[85%] leading-[1.5] shadow-sm break-words mx-auto bg-red-500/70 text-center font-medium">
-							{message.content}
-						</div>
-					)}
-				</motion.div>
-			))}
-			{isProcessingMessage && (
-				<motion.div key="loading-bubbles" {...rowMotion}>
-					<CoachMessage>
-						<LoadingBubbles />
-					</CoachMessage>
-				</motion.div>
-			)}
+								return componentToRender ? (
+									<CoachMessageWithComponent
+										componentConfig={componentToRender}
+										onSendUserMessageToCoach={onSendUserMessageToCoach}
+										disabled={isProcessingMessage}
+									>
+										<MarkdownRenderer content={message.content} />
+									</CoachMessageWithComponent>
+								) : (
+									<CoachMessage>
+										<MarkdownRenderer content={message.content} />
+									</CoachMessage>
+								);
+							})()
+						) : message.role === "user" ? (
+							<UserMessage>{message.content}</UserMessage>
+						) : (
+							<div className="mb-4 p-3.5 pr-4 pl-4 rounded-[18px] max-w-[85%] leading-[1.5] shadow-sm break-words mx-auto bg-red-500/70 text-center font-medium">
+								{message.content}
+							</div>
+						)}
+					</motion.div>
+				))}
+				{isProcessingMessage && (
+					<motion.div key="loading-bubbles" {...rowMotion}>
+						<CoachMessage>
+							<LoadingBubbles />
+						</CoachMessage>
+					</motion.div>
+				)}
+			</AnimatePresence>
 			{/* Dummy div to scroll to bottom */}
 			<div ref={messagesEndRef} />
 		</div>

--- a/client/src/pages/chat/components/ChatMessages.tsx
+++ b/client/src/pages/chat/components/ChatMessages.tsx
@@ -34,6 +34,12 @@ interface ChatMessagesProps {
 // A soft ease-out that decelerates into place (easeOutExpo-ish).
 const SMOOTH_EASE = [0.22, 1, 0.36, 1] as const;
 
+// User-message slide-in (e.g. a chosen canned option sliding over to become the
+// user's message). Deliberately slow for now so the motion is easy to see —
+// tune these down once the feel is dialed in.
+const USER_SLIDE_DISTANCE = 80;
+const USER_SLIDE_DURATION = 2;
+
 // Each row fades in on mount and fades out on unmount — opacity only, NO
 // `layout` animation. (We tried `layout`: animating a bubble's size by scaling
 // it visibly distorts the text as it grows and, under popLayout, made the
@@ -86,10 +92,14 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
 					return (
 						<motion.div
 							key={message.id ?? `${message.timestamp}-${message.role}`}
-							initial={{ opacity: 0, x: isUser ? 28 : 0 }}
+							initial={{ opacity: 0, x: isUser ? USER_SLIDE_DISTANCE : 0 }}
 							animate={{ opacity: 1, x: 0 }}
 							exit={rowMotion.exit}
-							transition={rowMotion.transition}
+							transition={
+								isUser
+									? { duration: USER_SLIDE_DURATION, ease: SMOOTH_EASE }
+									: rowMotion.transition
+							}
 						>
 							{message.role === "coach" ? (
 								// One persistent bubble: the dots crossfade to the response

--- a/client/src/pages/chat/components/ChatMessages.tsx
+++ b/client/src/pages/chat/components/ChatMessages.tsx
@@ -77,82 +77,88 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
 
 	return (
 		<div className="_ChatMessages scrollbar not-last:flex-grow overflow-y-auto sm:p-6 bg-gold-50  dark:bg-[#333333]">
-			<AnimatePresence initial={false}>
-				{messages.map((message: Message, index: number) => {
-					// A chosen canned option already animated itself into the reply
-					// position (the option bubble slides there in ChoiceButtons), so the
-					// real user message that replaces it appears with NO entrance — it
-					// just takes over the spot. Everything else fades in normally.
-					const fromChoice =
-						message.role === "user" && message.fromChoice === true;
-					return (
-						<motion.div
-							key={message.id ?? `${message.timestamp}-${message.role}`}
-							initial={fromChoice ? false : rowMotion.initial}
-							animate={rowMotion.animate}
-							exit={rowMotion.exit}
-							transition={rowMotion.transition}
-						>
-							{message.role === "coach" ? (
-								// One persistent bubble: the dots crossfade to the response
-								// (mode="wait" → dots fully fade before content fades in).
-								<AnimatePresence mode="wait" initial={false}>
-									{message.pending ? (
-										<motion.div
-											key="dots"
-											initial={{ opacity: 0 }}
-											animate={{ opacity: 1 }}
-											exit={{ opacity: 0 }}
-											transition={{ duration: 0.2 }}
-										>
-											<CoachMessage>
-												<LoadingBubbles />
-											</CoachMessage>
-										</motion.div>
-									) : (
-										<motion.div
-											key="content"
-											initial={{ opacity: 0 }}
-											animate={{ opacity: 1 }}
-											transition={{ duration: 0.3, ease: SMOOTH_EASE }}
-										>
-											{(() => {
-												const isLastCoachMessage =
-													index === messages.length - 1;
-												const componentToRender = resolveCoachComponent(
-													message,
-													isLastCoachMessage,
-												);
-												return componentToRender ? (
-													<CoachMessageWithComponent
-														componentConfig={componentToRender}
-														onSendUserMessageToCoach={onSendUserMessageToCoach}
-														disabled={isProcessingMessage}
-													>
-														<MarkdownRenderer content={message.content} />
-													</CoachMessageWithComponent>
-												) : (
-													<CoachMessage>
-														<MarkdownRenderer content={message.content} />
-													</CoachMessage>
-												);
-											})()}
-										</motion.div>
-									)}
-								</AnimatePresence>
-							) : message.role === "user" ? (
-								<UserMessage>{message.content}</UserMessage>
-							) : (
-								<div className="mb-4 p-3.5 pr-4 pl-4 rounded-[18px] max-w-[85%] leading-[1.5] shadow-sm break-words mx-auto bg-red-500/70 text-center font-medium">
-									{message.content}
-								</div>
-							)}
-						</motion.div>
-					);
-				})}
-			</AnimatePresence>
-			{/* Dummy div to scroll to bottom */}
-			<div ref={messagesEndRef} />
+			{/* Single wrapper around all content so a ResizeObserver in
+			    ChatInterface can watch the list's height and keep it pinned. */}
+			<div className="_ChatMessagesContent">
+				<AnimatePresence initial={false}>
+					{messages.map((message: Message, index: number) => {
+						// A chosen canned option already animated itself into the reply
+						// position (the option bubble slides there in ChoiceButtons), so the
+						// real user message that replaces it appears with NO entrance — it
+						// just takes over the spot. Everything else fades in normally.
+						const fromChoice =
+							message.role === "user" && message.fromChoice === true;
+						return (
+							<motion.div
+								key={message.id ?? `${message.timestamp}-${message.role}`}
+								initial={fromChoice ? false : rowMotion.initial}
+								animate={rowMotion.animate}
+								exit={rowMotion.exit}
+								transition={rowMotion.transition}
+							>
+								{message.role === "coach" ? (
+									// One persistent bubble: the dots crossfade to the response
+									// (mode="wait" → dots fully fade before content fades in).
+									<AnimatePresence mode="wait" initial={false}>
+										{message.pending ? (
+											<motion.div
+												key="dots"
+												initial={{ opacity: 0 }}
+												animate={{ opacity: 1 }}
+												exit={{ opacity: 0 }}
+												transition={{ duration: 0.2 }}
+											>
+												<CoachMessage>
+													<LoadingBubbles />
+												</CoachMessage>
+											</motion.div>
+										) : (
+											<motion.div
+												key="content"
+												initial={{ opacity: 0 }}
+												animate={{ opacity: 1 }}
+												transition={{ duration: 0.3, ease: SMOOTH_EASE }}
+											>
+												{(() => {
+													const isLastCoachMessage =
+														index === messages.length - 1;
+													const componentToRender = resolveCoachComponent(
+														message,
+														isLastCoachMessage,
+													);
+													return componentToRender ? (
+														<CoachMessageWithComponent
+															componentConfig={componentToRender}
+															onSendUserMessageToCoach={
+																onSendUserMessageToCoach
+															}
+															disabled={isProcessingMessage}
+														>
+															<MarkdownRenderer content={message.content} />
+														</CoachMessageWithComponent>
+													) : (
+														<CoachMessage>
+															<MarkdownRenderer content={message.content} />
+														</CoachMessage>
+													);
+												})()}
+											</motion.div>
+										)}
+									</AnimatePresence>
+								) : message.role === "user" ? (
+									<UserMessage>{message.content}</UserMessage>
+								) : (
+									<div className="mb-4 p-3.5 pr-4 pl-4 rounded-[18px] max-w-[85%] leading-[1.5] shadow-sm break-words mx-auto bg-red-500/70 text-center font-medium">
+										{message.content}
+									</div>
+								)}
+							</motion.div>
+						);
+					})}
+				</AnimatePresence>
+				{/* Dummy div to scroll to bottom */}
+				<div ref={messagesEndRef} />
+			</div>
 		</div>
 	);
 };

--- a/client/src/pages/chat/components/ChatMessages.tsx
+++ b/client/src/pages/chat/components/ChatMessages.tsx
@@ -10,46 +10,40 @@ import { AnimatePresence, motion } from "framer-motion";
 import type React from "react";
 
 /**
- * ChatMessages component is used to render the chat messages in both the
+ * ChatMessages renders the conversation. See ChatInterface.tsx for the data
+ * flow; loading state is represented as a `pending` coach message (the dots
+ * bubble) rather than a separate element, so the dots and the eventual
+ * response are ONE bubble whose content swaps in place.
  *
- */
-
-/**
- * Props for ChatMessages
- * ---------------------
- * - messages: The full chat message history to render (array of Message objects)
- * - isProcessingMessage: Whether a message is being sent (shows loading bubbles)
- * - coachState: The current coach state (for proposed identity)
- * - handleIdentityChoice: Handler for when a user selects an identity
- * - messagesEndRef: Ref to scroll to the bottom of the messages
- *
- * Used by: ChatInterface.tsx
+ * Props:
+ * - messages: full chat history to render (includes the optimistic user
+ *   message and the pending coach placeholder during a send)
+ * - isProcessingMessage: whether a send is in flight (disables interactive cards)
+ * - messagesEndRef: scroll anchor pinned to the bottom
+ * - componentConfig: latest in-memory component for the newest coach message
+ * - onSendUserMessageToCoach: handler for component button selection
  */
 interface ChatMessagesProps {
 	messages: Message[];
 	isProcessingMessage: boolean;
 	messagesEndRef: React.RefObject<HTMLDivElement | null>;
-	/** Latest component config to render for the newest coach message (or null) */
 	componentConfig?: ComponentConfig | null;
-	/** Handler for component button selection (sends a CoachRequest) */
 	onSendUserMessageToCoach: (request: CoachRequest) => void;
 }
 
 // A soft ease-out that decelerates into place (easeOutExpo-ish) — used for
-// entrances and for the `layout` resize tweens below so size changes glide
-// instead of snapping.
+// entrances and for the `layout` resize tweens so size changes glide.
 const SMOOTH_EASE = [0.22, 1, 0.36, 1] as const;
 
 // Each row fades in on mount, fades out on unmount, and — via the `layout`
 // prop on the motion.div — smoothly tweens its own size/position changes
-// rather than popping. The classic example: when an interactive card (with
-// buttons, full width) becomes its display-only version (no buttons, narrower)
-// after the user answers, `layout` animates that resize. The list is wrapped
-// in <AnimatePresence mode="popLayout"> so the one row that routinely unmounts
-// — the loading bubble — gets pulled out of the layout flow as it fades, and
-// the incoming coach response fades in over the same spot (a calm crossfade,
-// not a hard dots→response cut). Stable keys (see `key` below) mean existing
-// rows never re-mount, so `layout` only ever animates real size changes.
+// rather than popping. Two places this matters: (1) an interactive card
+// collapsing to its display-only form after the user answers, and (2) the
+// pending coach bubble growing from the loading dots to the full response as
+// its inner content swaps. Stable keys mean existing rows never re-mount, so
+// `layout` only ever animates real size changes. AnimatePresence here uses the
+// default (in-flow) mode — NOT popLayout — so a rare exit fades in place
+// instead of being absolutely positioned and "falling" over the composer.
 const rowMotion = {
 	initial: { opacity: 0 },
 	animate: { opacity: 1 },
@@ -57,8 +51,6 @@ const rowMotion = {
 	transition: {
 		duration: 0.4,
 		ease: SMOOTH_EASE,
-		// Give the layout (resize) tween its own slightly springy timing so it
-		// reads as a deliberate glide.
 		layout: { duration: 0.4, ease: SMOOTH_EASE },
 	},
 } as const;
@@ -70,67 +62,107 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
 	componentConfig,
 	onSendUserMessageToCoach,
 }) => {
+	// Picks the component (if any) to render for a non-pending coach message.
+	const resolveCoachComponent = (
+		message: Message,
+		isLastCoachMessage: boolean,
+	): ComponentConfig | null => {
+		if (isLastCoachMessage) {
+			// Prefer the in-memory cache when not processing (freshest server
+			// response). Fall through to `message.component_config` for
+			// server-seeded cards (welcome SESSION_VIDEO, post-END_BREAK intros) —
+			// those represent persisted history and stay visible even during
+			// in-flight requests, so clicking Continue doesn't blink the card out.
+			return (
+				(!isProcessingMessage && componentConfig) ||
+				message.component_config ||
+				null
+			);
+		}
+		// All other coach messages: ONLY their own persisted component_config.
+		return message.component_config || null;
+	};
+
 	return (
 		<div className="_ChatMessages scrollbar not-last:flex-grow overflow-y-auto sm:p-6 bg-gold-50  dark:bg-[#333333]">
-			<AnimatePresence mode="popLayout" initial={false}>
-				{messages.map((message: Message, index: number) => (
-					<motion.div
-						layout
-						key={message.id ?? `${message.timestamp}-${message.role}`}
-						{...rowMotion}
-					>
-						{message.role === "coach" ? (
-							(() => {
-								const isLastCoachMessage = index === messages.length - 1;
-								let componentToRender = null;
+			<AnimatePresence initial={false}>
+				{messages.map((message: Message, index: number) => {
+					const isPendingCoach =
+						message.role === "coach" && message.pending === true;
 
-								if (isLastCoachMessage) {
-									// Prefer the in-memory cache when not processing (freshest
-									// server response). Fall through to `message.component_config`
-									// for server-seeded cards (welcome SESSION_VIDEO,
-									// post-END_BREAK intros) — those represent persisted
-									// history and stay visible even during in-flight requests,
-									// so clicking Continue doesn't blink the card out while
-									// we wait for the response.
-									componentToRender =
-										(!isProcessingMessage && componentConfig) ||
-										message.component_config ||
-										null;
-								} else {
-									// For all other coach messages, ONLY check message.component_config
-									componentToRender = message.component_config || null;
-								}
-
-								return componentToRender ? (
-									<CoachMessageWithComponent
-										componentConfig={componentToRender}
-										onSendUserMessageToCoach={onSendUserMessageToCoach}
-										disabled={isProcessingMessage}
-									>
-										<MarkdownRenderer content={message.content} />
-									</CoachMessageWithComponent>
-								) : (
-									<CoachMessage>
-										<MarkdownRenderer content={message.content} />
-									</CoachMessage>
-								);
-							})()
-						) : message.role === "user" ? (
-							<UserMessage>{message.content}</UserMessage>
-						) : (
-							<div className="mb-4 p-3.5 pr-4 pl-4 rounded-[18px] max-w-[85%] leading-[1.5] shadow-sm break-words mx-auto bg-red-500/70 text-center font-medium">
-								{message.content}
-							</div>
-						)}
-					</motion.div>
-				))}
-				{isProcessingMessage && (
-					<motion.div layout key="loading-bubbles" {...rowMotion}>
-						<CoachMessage>
-							<LoadingBubbles />
-						</CoachMessage>
-					</motion.div>
-				)}
+					return (
+						<motion.div
+							layout
+							key={message.id ?? `${message.timestamp}-${message.role}`}
+							initial={rowMotion.initial}
+							animate={rowMotion.animate}
+							exit={rowMotion.exit}
+							// Stagger the dots in slightly behind the user's message so the
+							// pair doesn't appear in the same jarring instant.
+							transition={
+								isPendingCoach
+									? { ...rowMotion.transition, delay: 0.15 }
+									: rowMotion.transition
+							}
+						>
+							{message.role === "coach" ? (
+								// One persistent bubble: the dots crossfade to the response
+								// (mode="wait" → dots fully fade before content fades in) while
+								// the row's `layout` animates the height growth.
+								<AnimatePresence mode="wait" initial={false}>
+									{message.pending ? (
+										<motion.div
+											key="dots"
+											initial={{ opacity: 0 }}
+											animate={{ opacity: 1 }}
+											exit={{ opacity: 0 }}
+											transition={{ duration: 0.2 }}
+										>
+											<CoachMessage>
+												<LoadingBubbles />
+											</CoachMessage>
+										</motion.div>
+									) : (
+										<motion.div
+											key="content"
+											initial={{ opacity: 0 }}
+											animate={{ opacity: 1 }}
+											transition={{ duration: 0.3, ease: SMOOTH_EASE }}
+										>
+											{(() => {
+												const isLastCoachMessage =
+													index === messages.length - 1;
+												const componentToRender = resolveCoachComponent(
+													message,
+													isLastCoachMessage,
+												);
+												return componentToRender ? (
+													<CoachMessageWithComponent
+														componentConfig={componentToRender}
+														onSendUserMessageToCoach={onSendUserMessageToCoach}
+														disabled={isProcessingMessage}
+													>
+														<MarkdownRenderer content={message.content} />
+													</CoachMessageWithComponent>
+												) : (
+													<CoachMessage>
+														<MarkdownRenderer content={message.content} />
+													</CoachMessage>
+												);
+											})()}
+										</motion.div>
+									)}
+								</AnimatePresence>
+							) : message.role === "user" ? (
+								<UserMessage>{message.content}</UserMessage>
+							) : (
+								<div className="mb-4 p-3.5 pr-4 pl-4 rounded-[18px] max-w-[85%] leading-[1.5] shadow-sm break-words mx-auto bg-red-500/70 text-center font-medium">
+									{message.content}
+								</div>
+							)}
+						</motion.div>
+					);
+				})}
 			</AnimatePresence>
 			{/* Dummy div to scroll to bottom */}
 			<div ref={messagesEndRef} />

--- a/client/src/pages/chat/components/ChatMessages.tsx
+++ b/client/src/pages/chat/components/ChatMessages.tsx
@@ -34,14 +34,6 @@ interface ChatMessagesProps {
 // A soft ease-out that decelerates into place (easeOutExpo-ish).
 const SMOOTH_EASE = [0.22, 1, 0.36, 1] as const;
 
-// Slide-over entrance for a chosen canned option becoming the user's message.
-// It starts to the LEFT of its final (right-aligned) spot and slides RIGHT into
-// place at a constant (linear) pace, so it never passes the target and slides
-// back. Deliberately slow (2s) for now so the motion is easy to see — tune down
-// once the feel is dialed in. Only choice messages use this (see `fromChoice`).
-const CHOICE_SLIDE_DISTANCE = 80;
-const CHOICE_SLIDE_DURATION = 2;
-
 // Each row fades in on mount and fades out on unmount — opacity only, NO
 // `layout` animation. (We tried `layout`: animating a bubble's size by scaling
 // it visibly distorts the text as it grows and, under popLayout, made the
@@ -87,22 +79,19 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
 		<div className="_ChatMessages scrollbar not-last:flex-grow overflow-y-auto sm:p-6 bg-gold-50  dark:bg-[#333333]">
 			<AnimatePresence initial={false}>
 				{messages.map((message: Message, index: number) => {
-					// Only a freshly-chosen canned option slides over to become the
-					// user's message; everything else (typed messages, coach messages)
-					// just fades in.
-					const slidesOver =
+					// A chosen canned option already animated itself into the reply
+					// position (the option bubble slides there in ChoiceButtons), so the
+					// real user message that replaces it appears with NO entrance — it
+					// just takes over the spot. Everything else fades in normally.
+					const fromChoice =
 						message.role === "user" && message.fromChoice === true;
 					return (
 						<motion.div
 							key={message.id ?? `${message.timestamp}-${message.role}`}
-							initial={{ opacity: 0, x: slidesOver ? -CHOICE_SLIDE_DISTANCE : 0 }}
-							animate={{ opacity: 1, x: 0 }}
+							initial={fromChoice ? false : rowMotion.initial}
+							animate={rowMotion.animate}
 							exit={rowMotion.exit}
-							transition={
-								slidesOver
-									? { duration: CHOICE_SLIDE_DURATION, ease: "linear" }
-									: rowMotion.transition
-							}
+							transition={rowMotion.transition}
 						>
 							{message.role === "coach" ? (
 								// One persistent bubble: the dots crossfade to the response

--- a/client/src/pages/chat/components/ChatMessages.tsx
+++ b/client/src/pages/chat/components/ChatMessages.tsx
@@ -6,7 +6,7 @@ import type { CoachRequest } from "@/types/coachRequest";
 import type { ComponentConfig } from "@/types/componentConfig";
 import type { Message } from "@/types/message";
 import MarkdownRenderer from "@/utils/MarkdownRenderer";
-import { AnimatePresence, MotionConfig, motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import type React from "react";
 
 /**
@@ -71,73 +71,69 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
 	onSendUserMessageToCoach,
 }) => {
 	return (
-		// reducedMotion="user" honors the OS "reduce motion" setting: Framer
-		// drops the transform-based layout/position tweens and keeps opacity.
-		<MotionConfig reducedMotion="user">
-			<div className="_ChatMessages scrollbar not-last:flex-grow overflow-y-auto sm:p-6 bg-gold-50  dark:bg-[#333333]">
-				<AnimatePresence mode="popLayout" initial={false}>
-					{messages.map((message: Message, index: number) => (
-						<motion.div
-							layout
-							key={message.id ?? `${message.timestamp}-${message.role}`}
-							{...rowMotion}
-						>
-							{message.role === "coach" ? (
-								(() => {
-									const isLastCoachMessage = index === messages.length - 1;
-									let componentToRender = null;
+		<div className="_ChatMessages scrollbar not-last:flex-grow overflow-y-auto sm:p-6 bg-gold-50  dark:bg-[#333333]">
+			<AnimatePresence mode="popLayout" initial={false}>
+				{messages.map((message: Message, index: number) => (
+					<motion.div
+						layout
+						key={message.id ?? `${message.timestamp}-${message.role}`}
+						{...rowMotion}
+					>
+						{message.role === "coach" ? (
+							(() => {
+								const isLastCoachMessage = index === messages.length - 1;
+								let componentToRender = null;
 
-									if (isLastCoachMessage) {
-										// Prefer the in-memory cache when not processing (freshest
-										// server response). Fall through to `message.component_config`
-										// for server-seeded cards (welcome SESSION_VIDEO,
-										// post-END_BREAK intros) — those represent persisted
-										// history and stay visible even during in-flight requests,
-										// so clicking Continue doesn't blink the card out while
-										// we wait for the response.
-										componentToRender =
-											(!isProcessingMessage && componentConfig) ||
-											message.component_config ||
-											null;
-									} else {
-										// For all other coach messages, ONLY check message.component_config
-										componentToRender = message.component_config || null;
-									}
+								if (isLastCoachMessage) {
+									// Prefer the in-memory cache when not processing (freshest
+									// server response). Fall through to `message.component_config`
+									// for server-seeded cards (welcome SESSION_VIDEO,
+									// post-END_BREAK intros) — those represent persisted
+									// history and stay visible even during in-flight requests,
+									// so clicking Continue doesn't blink the card out while
+									// we wait for the response.
+									componentToRender =
+										(!isProcessingMessage && componentConfig) ||
+										message.component_config ||
+										null;
+								} else {
+									// For all other coach messages, ONLY check message.component_config
+									componentToRender = message.component_config || null;
+								}
 
-									return componentToRender ? (
-										<CoachMessageWithComponent
-											componentConfig={componentToRender}
-											onSendUserMessageToCoach={onSendUserMessageToCoach}
-											disabled={isProcessingMessage}
-										>
-											<MarkdownRenderer content={message.content} />
-										</CoachMessageWithComponent>
-									) : (
-										<CoachMessage>
-											<MarkdownRenderer content={message.content} />
-										</CoachMessage>
-									);
-								})()
-							) : message.role === "user" ? (
-								<UserMessage>{message.content}</UserMessage>
-							) : (
-								<div className="mb-4 p-3.5 pr-4 pl-4 rounded-[18px] max-w-[85%] leading-[1.5] shadow-sm break-words mx-auto bg-red-500/70 text-center font-medium">
-									{message.content}
-								</div>
-							)}
-						</motion.div>
-					))}
-					{isProcessingMessage && (
-						<motion.div layout key="loading-bubbles" {...rowMotion}>
-							<CoachMessage>
-								<LoadingBubbles />
-							</CoachMessage>
-						</motion.div>
-					)}
-				</AnimatePresence>
-				{/* Dummy div to scroll to bottom */}
-				<div ref={messagesEndRef} />
-			</div>
-		</MotionConfig>
+								return componentToRender ? (
+									<CoachMessageWithComponent
+										componentConfig={componentToRender}
+										onSendUserMessageToCoach={onSendUserMessageToCoach}
+										disabled={isProcessingMessage}
+									>
+										<MarkdownRenderer content={message.content} />
+									</CoachMessageWithComponent>
+								) : (
+									<CoachMessage>
+										<MarkdownRenderer content={message.content} />
+									</CoachMessage>
+								);
+							})()
+						) : message.role === "user" ? (
+							<UserMessage>{message.content}</UserMessage>
+						) : (
+							<div className="mb-4 p-3.5 pr-4 pl-4 rounded-[18px] max-w-[85%] leading-[1.5] shadow-sm break-words mx-auto bg-red-500/70 text-center font-medium">
+								{message.content}
+							</div>
+						)}
+					</motion.div>
+				))}
+				{isProcessingMessage && (
+					<motion.div layout key="loading-bubbles" {...rowMotion}>
+						<CoachMessage>
+							<LoadingBubbles />
+						</CoachMessage>
+					</motion.div>
+				)}
+			</AnimatePresence>
+			{/* Dummy div to scroll to bottom */}
+			<div ref={messagesEndRef} />
+		</div>
 	);
 };

--- a/client/src/pages/chat/components/ChatMessages.tsx
+++ b/client/src/pages/chat/components/ChatMessages.tsx
@@ -79,10 +79,17 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
 		<div className="_ChatMessages scrollbar not-last:flex-grow overflow-y-auto sm:p-6 bg-gold-50  dark:bg-[#333333]">
 			<AnimatePresence initial={false}>
 				{messages.map((message: Message, index: number) => {
+					// User messages slide in from the right (the side they live on) so a
+					// freshly-chosen canned option reads as sliding over to become the
+					// user's message. Coach messages just fade.
+					const isUser = message.role === "user";
 					return (
 						<motion.div
 							key={message.id ?? `${message.timestamp}-${message.role}`}
-							{...rowMotion}
+							initial={{ opacity: 0, x: isUser ? 28 : 0 }}
+							animate={{ opacity: 1, x: 0 }}
+							exit={rowMotion.exit}
+							transition={rowMotion.transition}
 						>
 							{message.role === "coach" ? (
 								// One persistent bubble: the dots crossfade to the response

--- a/client/src/pages/chat/components/ChatMessages.tsx
+++ b/client/src/pages/chat/components/ChatMessages.tsx
@@ -34,11 +34,13 @@ interface ChatMessagesProps {
 // A soft ease-out that decelerates into place (easeOutExpo-ish).
 const SMOOTH_EASE = [0.22, 1, 0.36, 1] as const;
 
-// User-message slide-in (e.g. a chosen canned option sliding over to become the
-// user's message). Deliberately slow for now so the motion is easy to see —
-// tune these down once the feel is dialed in.
-const USER_SLIDE_DISTANCE = 80;
-const USER_SLIDE_DURATION = 2;
+// Slide-over entrance for a chosen canned option becoming the user's message.
+// It starts to the LEFT of its final (right-aligned) spot and slides RIGHT into
+// place at a constant (linear) pace, so it never passes the target and slides
+// back. Deliberately slow (2s) for now so the motion is easy to see — tune down
+// once the feel is dialed in. Only choice messages use this (see `fromChoice`).
+const CHOICE_SLIDE_DISTANCE = 80;
+const CHOICE_SLIDE_DURATION = 2;
 
 // Each row fades in on mount and fades out on unmount — opacity only, NO
 // `layout` animation. (We tried `layout`: animating a bubble's size by scaling
@@ -85,19 +87,20 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
 		<div className="_ChatMessages scrollbar not-last:flex-grow overflow-y-auto sm:p-6 bg-gold-50  dark:bg-[#333333]">
 			<AnimatePresence initial={false}>
 				{messages.map((message: Message, index: number) => {
-					// User messages slide in from the right (the side they live on) so a
-					// freshly-chosen canned option reads as sliding over to become the
-					// user's message. Coach messages just fade.
-					const isUser = message.role === "user";
+					// Only a freshly-chosen canned option slides over to become the
+					// user's message; everything else (typed messages, coach messages)
+					// just fades in.
+					const slidesOver =
+						message.role === "user" && message.fromChoice === true;
 					return (
 						<motion.div
 							key={message.id ?? `${message.timestamp}-${message.role}`}
-							initial={{ opacity: 0, x: isUser ? USER_SLIDE_DISTANCE : 0 }}
+							initial={{ opacity: 0, x: slidesOver ? -CHOICE_SLIDE_DISTANCE : 0 }}
 							animate={{ opacity: 1, x: 0 }}
 							exit={rowMotion.exit}
 							transition={
-								isUser
-									? { duration: USER_SLIDE_DURATION, ease: SMOOTH_EASE }
+								slidesOver
+									? { duration: CHOICE_SLIDE_DURATION, ease: "linear" }
 									: rowMotion.transition
 							}
 						>

--- a/client/src/pages/chat/components/ChatMessages.tsx
+++ b/client/src/pages/chat/components/ChatMessages.tsx
@@ -6,7 +6,7 @@ import type { CoachRequest } from "@/types/coachRequest";
 import type { ComponentConfig } from "@/types/componentConfig";
 import type { Message } from "@/types/message";
 import MarkdownRenderer from "@/utils/MarkdownRenderer";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, MotionConfig, motion } from "framer-motion";
 import type React from "react";
 
 /**
@@ -35,18 +35,32 @@ interface ChatMessagesProps {
 	onSendUserMessageToCoach: (request: CoachRequest) => void;
 }
 
-// New chat rows fade in on mount and fade out on unmount. Opacity-only by
-// design — animating row positions/heights made the whole list shove around.
-// The list is wrapped in <AnimatePresence mode="popLayout">: the only row that
-// routinely unmounts is the loading bubble, and popLayout pulls it out of the
-// layout flow as it fades so the incoming coach response can fade in over the
-// same spot — a calm crossfade instead of a hard dots→response cut. Existing
-// rows keep stable keys (see `key` below) so they never re-animate.
+// A soft ease-out that decelerates into place (easeOutExpo-ish) — used for
+// entrances and for the `layout` resize tweens below so size changes glide
+// instead of snapping.
+const SMOOTH_EASE = [0.22, 1, 0.36, 1] as const;
+
+// Each row fades in on mount, fades out on unmount, and — via the `layout`
+// prop on the motion.div — smoothly tweens its own size/position changes
+// rather than popping. The classic example: when an interactive card (with
+// buttons, full width) becomes its display-only version (no buttons, narrower)
+// after the user answers, `layout` animates that resize. The list is wrapped
+// in <AnimatePresence mode="popLayout"> so the one row that routinely unmounts
+// — the loading bubble — gets pulled out of the layout flow as it fades, and
+// the incoming coach response fades in over the same spot (a calm crossfade,
+// not a hard dots→response cut). Stable keys (see `key` below) mean existing
+// rows never re-mount, so `layout` only ever animates real size changes.
 const rowMotion = {
 	initial: { opacity: 0 },
 	animate: { opacity: 1 },
-	exit: { opacity: 0, transition: { duration: 0.15, ease: "easeIn" } },
-	transition: { duration: 0.25, ease: "easeOut" },
+	exit: { opacity: 0, transition: { duration: 0.2, ease: "easeIn" } },
+	transition: {
+		duration: 0.4,
+		ease: SMOOTH_EASE,
+		// Give the layout (resize) tween its own slightly springy timing so it
+		// reads as a deliberate glide.
+		layout: { duration: 0.4, ease: SMOOTH_EASE },
+	},
 } as const;
 
 export const ChatMessages: React.FC<ChatMessagesProps> = ({
@@ -57,68 +71,73 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
 	onSendUserMessageToCoach,
 }) => {
 	return (
-		<div className="_ChatMessages scrollbar not-last:flex-grow overflow-y-auto sm:p-6 bg-gold-50  dark:bg-[#333333]">
-			<AnimatePresence mode="popLayout" initial={false}>
-				{messages.map((message: Message, index: number) => (
-					<motion.div
-						key={message.id ?? `${message.timestamp}-${message.role}`}
-						{...rowMotion}
-					>
-						{message.role === "coach" ? (
-							(() => {
-								const isLastCoachMessage = index === messages.length - 1;
-								let componentToRender = null;
+		// reducedMotion="user" honors the OS "reduce motion" setting: Framer
+		// drops the transform-based layout/position tweens and keeps opacity.
+		<MotionConfig reducedMotion="user">
+			<div className="_ChatMessages scrollbar not-last:flex-grow overflow-y-auto sm:p-6 bg-gold-50  dark:bg-[#333333]">
+				<AnimatePresence mode="popLayout" initial={false}>
+					{messages.map((message: Message, index: number) => (
+						<motion.div
+							layout
+							key={message.id ?? `${message.timestamp}-${message.role}`}
+							{...rowMotion}
+						>
+							{message.role === "coach" ? (
+								(() => {
+									const isLastCoachMessage = index === messages.length - 1;
+									let componentToRender = null;
 
-								if (isLastCoachMessage) {
-									// Prefer the in-memory cache when not processing (freshest
-									// server response). Fall through to `message.component_config`
-									// for server-seeded cards (welcome SESSION_VIDEO,
-									// post-END_BREAK intros) — those represent persisted
-									// history and stay visible even during in-flight requests,
-									// so clicking Continue doesn't blink the card out while
-									// we wait for the response.
-									componentToRender =
-										(!isProcessingMessage && componentConfig) ||
-										message.component_config ||
-										null;
-								} else {
-									// For all other coach messages, ONLY check message.component_config
-									componentToRender = message.component_config || null;
-								}
+									if (isLastCoachMessage) {
+										// Prefer the in-memory cache when not processing (freshest
+										// server response). Fall through to `message.component_config`
+										// for server-seeded cards (welcome SESSION_VIDEO,
+										// post-END_BREAK intros) — those represent persisted
+										// history and stay visible even during in-flight requests,
+										// so clicking Continue doesn't blink the card out while
+										// we wait for the response.
+										componentToRender =
+											(!isProcessingMessage && componentConfig) ||
+											message.component_config ||
+											null;
+									} else {
+										// For all other coach messages, ONLY check message.component_config
+										componentToRender = message.component_config || null;
+									}
 
-								return componentToRender ? (
-									<CoachMessageWithComponent
-										componentConfig={componentToRender}
-										onSendUserMessageToCoach={onSendUserMessageToCoach}
-										disabled={isProcessingMessage}
-									>
-										<MarkdownRenderer content={message.content} />
-									</CoachMessageWithComponent>
-								) : (
-									<CoachMessage>
-										<MarkdownRenderer content={message.content} />
-									</CoachMessage>
-								);
-							})()
-						) : message.role === "user" ? (
-							<UserMessage>{message.content}</UserMessage>
-						) : (
-							<div className="mb-4 p-3.5 pr-4 pl-4 rounded-[18px] max-w-[85%] leading-[1.5] shadow-sm break-words mx-auto bg-red-500/70 text-center font-medium">
-								{message.content}
-							</div>
-						)}
-					</motion.div>
-				))}
-				{isProcessingMessage && (
-					<motion.div key="loading-bubbles" {...rowMotion}>
-						<CoachMessage>
-							<LoadingBubbles />
-						</CoachMessage>
-					</motion.div>
-				)}
-			</AnimatePresence>
-			{/* Dummy div to scroll to bottom */}
-			<div ref={messagesEndRef} />
-		</div>
+									return componentToRender ? (
+										<CoachMessageWithComponent
+											componentConfig={componentToRender}
+											onSendUserMessageToCoach={onSendUserMessageToCoach}
+											disabled={isProcessingMessage}
+										>
+											<MarkdownRenderer content={message.content} />
+										</CoachMessageWithComponent>
+									) : (
+										<CoachMessage>
+											<MarkdownRenderer content={message.content} />
+										</CoachMessage>
+									);
+								})()
+							) : message.role === "user" ? (
+								<UserMessage>{message.content}</UserMessage>
+							) : (
+								<div className="mb-4 p-3.5 pr-4 pl-4 rounded-[18px] max-w-[85%] leading-[1.5] shadow-sm break-words mx-auto bg-red-500/70 text-center font-medium">
+									{message.content}
+								</div>
+							)}
+						</motion.div>
+					))}
+					{isProcessingMessage && (
+						<motion.div layout key="loading-bubbles" {...rowMotion}>
+							<CoachMessage>
+								<LoadingBubbles />
+							</CoachMessage>
+						</motion.div>
+					)}
+				</AnimatePresence>
+				{/* Dummy div to scroll to bottom */}
+				<div ref={messagesEndRef} />
+			</div>
+		</MotionConfig>
 	);
 };

--- a/client/src/pages/chat/components/ChatMessages.tsx
+++ b/client/src/pages/chat/components/ChatMessages.tsx
@@ -31,28 +31,20 @@ interface ChatMessagesProps {
 	onSendUserMessageToCoach: (request: CoachRequest) => void;
 }
 
-// A soft ease-out that decelerates into place (easeOutExpo-ish) — used for
-// entrances and for the `layout` resize tweens so size changes glide.
+// A soft ease-out that decelerates into place (easeOutExpo-ish).
 const SMOOTH_EASE = [0.22, 1, 0.36, 1] as const;
 
-// Each row fades in on mount, fades out on unmount, and — via the `layout`
-// prop on the motion.div — smoothly tweens its own size/position changes
-// rather than popping. Two places this matters: (1) an interactive card
-// collapsing to its display-only form after the user answers, and (2) the
-// pending coach bubble growing from the loading dots to the full response as
-// its inner content swaps. Stable keys mean existing rows never re-mount, so
-// `layout` only ever animates real size changes. AnimatePresence here uses the
-// default (in-flow) mode — NOT popLayout — so a rare exit fades in place
-// instead of being absolutely positioned and "falling" over the composer.
+// Each row fades in on mount and fades out on unmount — opacity only, NO
+// `layout` animation. (We tried `layout`: animating a bubble's size by scaling
+// it visibly distorts the text as it grows and, under popLayout, made the
+// loading dots "fall" onto the composer. A plain opacity crossfade is calmer.)
+// AnimatePresence uses the default in-flow mode so any rare exit fades in place.
+// Stable keys mean existing rows never re-mount, so they never re-animate.
 const rowMotion = {
 	initial: { opacity: 0 },
 	animate: { opacity: 1 },
 	exit: { opacity: 0, transition: { duration: 0.2, ease: "easeIn" } },
-	transition: {
-		duration: 0.4,
-		ease: SMOOTH_EASE,
-		layout: { duration: 0.4, ease: SMOOTH_EASE },
-	},
+	transition: { duration: 0.4, ease: SMOOTH_EASE },
 } as const;
 
 export const ChatMessages: React.FC<ChatMessagesProps> = ({
@@ -87,28 +79,14 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
 		<div className="_ChatMessages scrollbar not-last:flex-grow overflow-y-auto sm:p-6 bg-gold-50  dark:bg-[#333333]">
 			<AnimatePresence initial={false}>
 				{messages.map((message: Message, index: number) => {
-					const isPendingCoach =
-						message.role === "coach" && message.pending === true;
-
 					return (
 						<motion.div
-							layout
 							key={message.id ?? `${message.timestamp}-${message.role}`}
-							initial={rowMotion.initial}
-							animate={rowMotion.animate}
-							exit={rowMotion.exit}
-							// Stagger the dots in slightly behind the user's message so the
-							// pair doesn't appear in the same jarring instant.
-							transition={
-								isPendingCoach
-									? { ...rowMotion.transition, delay: 0.15 }
-									: rowMotion.transition
-							}
+							{...rowMotion}
 						>
 							{message.role === "coach" ? (
 								// One persistent bubble: the dots crossfade to the response
-								// (mode="wait" → dots fully fade before content fades in) while
-								// the row's `layout` animates the height growth.
+								// (mode="wait" → dots fully fade before content fades in).
 								<AnimatePresence mode="wait" initial={false}>
 									{message.pending ? (
 										<motion.div

--- a/client/src/pages/chat/components/UserMessage.tsx
+++ b/client/src/pages/chat/components/UserMessage.tsx
@@ -15,7 +15,7 @@ export const UserMessage: React.FC<
 	React.PropsWithChildren<React.HTMLAttributes<HTMLDivElement>>
 > = ({ children, ...props }) => (
 	<div
-		className="_UserMessage mb-4 px-8 py-4 rounded-tl-[20px] rounded-tr-[20px] rounded-bl-[20px] rounded-br-[2px] w-fit max-w-[75%] animate-fadeIn break-words ml-auto text-white text-[18px] font-medium leading-[1.5] shadow-sm"
+		className="_UserMessage mb-4 py-3.5 px-4 rounded-tl-[20px] rounded-tr-[20px] rounded-bl-[20px] rounded-br-[2px] w-fit max-w-[75%] animate-fadeIn break-words ml-auto text-white text-[18px] font-medium leading-[1.5] shadow-sm"
 		style={{
 			fontFamily: "'Montserrat', sans-serif",
 			background:

--- a/client/src/pages/chat/components/__tests__/ChatMessages.test.tsx
+++ b/client/src/pages/chat/components/__tests__/ChatMessages.test.tsx
@@ -107,18 +107,26 @@ describe("ChatMessages", () => {
 		expect(screen.getAllByTestId("coach-message")).toHaveLength(1);
 	});
 
-	it("shows loading bubbles when processing", () => {
-		renderChatMessages(
-			[{ role: "user", content: "Hello", timestamp: "2025-01-01T00:00:00Z" }],
-			{ isProcessingMessage: true },
-		);
+	it("shows loading bubbles for a pending coach message", () => {
+		// Loading is now modeled as a `pending` coach placeholder (the dots and
+		// the eventual response share one bubble), not a separate element driven
+		// by isProcessingMessage.
+		renderChatMessages([
+			{ role: "user", content: "Hello", timestamp: "2025-01-01T00:00:00Z" },
+			{
+				role: "coach",
+				content: "",
+				timestamp: "2025-01-01T00:00:01Z",
+				pending: true,
+			},
+		]);
 		expect(screen.getByTestId("loading-bubbles")).toBeInTheDocument();
 	});
 
-	it("does not show loading bubbles when not processing", () => {
+	it("does not show loading bubbles when there is no pending message", () => {
 		renderChatMessages(
 			[{ role: "user", content: "Hello", timestamp: "2025-01-01T00:00:00Z" }],
-			{ isProcessingMessage: false },
+			{ isProcessingMessage: true },
 		);
 		expect(screen.queryByTestId("loading-bubbles")).not.toBeInTheDocument();
 	});
@@ -210,11 +218,10 @@ describe("ChatMessages", () => {
 			).not.toBeInTheDocument();
 		});
 
-		it("keeps server-seeded component visible during processing (no blink on Continue click)", () => {
+		it("keeps server-seeded component visible while the pending bubble loads (no blink on Continue click)", () => {
 			// The welcome SESSION_VIDEO card is persisted on the message row.
-			// While the ACK click is in flight, the card must stay visible —
-			// blanking it makes the UI flicker as it disappears + reappears
-			// around the refetch. LoadingBubbles still appears beneath.
+			// While the ACK click is in flight, the card must stay visible — the
+			// pending coach bubble (dots) sits beneath it as its own message.
 			renderChatMessages(
 				[
 					{
@@ -223,6 +230,12 @@ describe("ChatMessages", () => {
 						timestamp: "2025-01-01T00:00:00Z",
 						component_config: sessionVideoConfig,
 					},
+					{
+						role: "coach",
+						content: "",
+						timestamp: "2025-01-01T00:00:01Z",
+						pending: true,
+					},
 				],
 				{ isProcessingMessage: true },
 			);
@@ -230,17 +243,24 @@ describe("ChatMessages", () => {
 			expect(screen.getByTestId("loading-bubbles")).toBeInTheDocument();
 		});
 
-		it("suppresses cache-only component while processing (legacy SHOW_XXX behavior)", () => {
-			// No message.component_config; component came from in-memory
-			// cache only (legacy SHOW_COMBINE_IDENTITIES-style flow). While
-			// a POST is in flight, blank it so it's clear the previous
-			// interactive choice is being processed.
+		it("suppresses cache-only component on an older coach message while a newer bubble loads", () => {
+			// No message.component_config; the component came from the in-memory
+			// cache only (legacy SHOW_COMBINE_IDENTITIES-style flow). Once a pending
+			// coach bubble is appended, the older "Pick one" message is no longer
+			// the last coach message, so the cache componentConfig no longer applies
+			// to it and it renders as plain text. Dots come from the pending bubble.
 			renderChatMessages(
 				[
 					{
 						role: "coach",
 						content: "Pick one",
 						timestamp: "2025-01-01T00:00:00Z",
+					},
+					{
+						role: "coach",
+						content: "",
+						timestamp: "2025-01-01T00:00:01Z",
+						pending: true,
 					},
 				],
 				{

--- a/client/src/pages/chat/components/coach-message-with-component/IntroCannedResponseComponent.tsx
+++ b/client/src/pages/chat/components/coach-message-with-component/IntroCannedResponseComponent.tsx
@@ -11,7 +11,7 @@ type ChoiceButton = NonNullable<ComponentConfig["buttons"]>[number];
 //   2. once they're gone, the chosen option slides into the reply position
 //   3. then we dispatch (the real user message takes its place + the coach replies)
 const FADE_MS = 1000; // step 1: slow fade of the un-chosen options
-const SLIDE_MS = 800; // step 2: chosen option slides into place
+const SLIDE_MS = 2000; // step 2: chosen option slides into place
 
 // The chosen option is styled to MATCH a real user message so that when it
 // slides into the reply position it already looks like the message it becomes.

--- a/client/src/pages/chat/components/coach-message-with-component/IntroCannedResponseComponent.tsx
+++ b/client/src/pages/chat/components/coach-message-with-component/IntroCannedResponseComponent.tsx
@@ -10,8 +10,8 @@ type ChoiceButton = NonNullable<ComponentConfig["buttons"]>[number];
 //   1. un-chosen options fade out slowly; the chosen one holds still
 //   2. once they're gone, the chosen option slides into the reply position
 //   3. then we dispatch (the real user message takes its place + the coach replies)
-const FADE_MS = 1000; // step 1: slow fade of the un-chosen options
-const SLIDE_MS = 2000; // step 2: chosen option slides into place
+const FADE_MS = 400; // step 1: fade of the un-chosen options
+const SLIDE_MS = 600; // step 2: chosen option slides into place
 
 // The chosen option is styled to MATCH a real user message so that when it
 // slides into the reply position it already looks like the message it becomes.

--- a/client/src/pages/chat/components/coach-message-with-component/IntroCannedResponseComponent.tsx
+++ b/client/src/pages/chat/components/coach-message-with-component/IntroCannedResponseComponent.tsx
@@ -1,6 +1,7 @@
 import type { CoachRequest } from "@/types/coachRequest";
 import type { ComponentConfig } from "@/types/componentConfig";
 import MarkdownRenderer from "@/utils/MarkdownRenderer";
+import { AnimatePresence, motion } from "framer-motion";
 import React from "react";
 
 export const IntroCannedResponseComponent: React.FC<{
@@ -29,38 +30,50 @@ export const IntroCannedResponseComponent: React.FC<{
 				)}
 			</div>
 
-			{config.buttons && config.buttons.length > 0 && (
-				<div className="mt-3 flex flex-wrap gap-2 justify-end">
-					{config.buttons.map((button, index) => (
-						<button
-							type="button"
-							key={index}
-							onClick={() =>
-								onSendUserMessageToCoach({
-									message: button.label,
-									actions: button.actions,
-								})
-							}
-							disabled={disabled}
-							className="px-3 py-1.5 text-sm font-medium rounded-md transition-colors cursor-pointer"
-							style={{
-								backgroundColor: "var(--nv-royal-purple, #531e96)",
-								color: "white",
-							}}
-							onMouseEnter={(e) => {
-								e.currentTarget.style.backgroundColor =
-									"var(--nv-violet-blue, #6a5ffb)";
-							}}
-							onMouseLeave={(e) => {
-								e.currentTarget.style.backgroundColor =
-									"var(--nv-royal-purple, #531e96)";
-							}}
-						>
-							{button.label}
-						</button>
-					))}
-				</div>
-			)}
+			{/* Fade the buttons out (rather than vanish) when the card flips to
+			    display-only after the user picks an option. The card's own height
+			    then settles via the `layout` animation on the message row. */}
+			<AnimatePresence>
+				{hasButtons && (
+					<motion.div
+						key="buttons"
+						initial={{ opacity: 0 }}
+						animate={{ opacity: 1 }}
+						exit={{ opacity: 0 }}
+						transition={{ duration: 0.2, ease: "easeInOut" }}
+						className="mt-3 flex flex-wrap gap-2 justify-end"
+					>
+						{config.buttons?.map((button, index) => (
+							<button
+								type="button"
+								key={index}
+								onClick={() =>
+									onSendUserMessageToCoach({
+										message: button.label,
+										actions: button.actions,
+									})
+								}
+								disabled={disabled}
+								className="px-3 py-1.5 text-sm font-medium rounded-md transition-colors cursor-pointer"
+								style={{
+									backgroundColor: "var(--nv-royal-purple, #531e96)",
+									color: "white",
+								}}
+								onMouseEnter={(e) => {
+									e.currentTarget.style.backgroundColor =
+										"var(--nv-violet-blue, #6a5ffb)";
+								}}
+								onMouseLeave={(e) => {
+									e.currentTarget.style.backgroundColor =
+										"var(--nv-royal-purple, #531e96)";
+								}}
+							>
+								{button.label}
+							</button>
+						))}
+					</motion.div>
+				)}
+			</AnimatePresence>
 		</div>
 	);
 };

--- a/client/src/pages/chat/components/coach-message-with-component/IntroCannedResponseComponent.tsx
+++ b/client/src/pages/chat/components/coach-message-with-component/IntroCannedResponseComponent.tsx
@@ -1,26 +1,37 @@
 import type { CoachRequest } from "@/types/coachRequest";
 import type { ComponentConfig } from "@/types/componentConfig";
 import MarkdownRenderer from "@/utils/MarkdownRenderer";
-import { AnimatePresence, motion } from "framer-motion";
+import { motion } from "framer-motion";
 import React, { useState } from "react";
 
 type ChoiceButton = NonNullable<ComponentConfig["buttons"]>[number];
 
-// How long the chosen button is allowed to "confirm" (and the others to fade
-// out) before we actually dispatch. Keeps the choice from vanishing in the same
-// instant it's clicked.
-const CHOICE_DISPATCH_DELAY_MS = 260;
+// Ordered choreography after a click (all tunable):
+//   1. un-chosen options fade out slowly; the chosen one holds still
+//   2. once they're gone, the chosen option slides into the reply position
+//   3. then we dispatch (the real user message takes its place + the coach replies)
+const FADE_MS = 1000; // step 1: slow fade of the un-chosen options
+const SLIDE_MS = 800; // step 2: chosen option slides into place
+
+// The chosen option is styled to MATCH a real user message so that when it
+// slides into the reply position it already looks like the message it becomes.
+const USER_BUBBLE_CLASS =
+	"py-3.5 px-4 rounded-tl-[20px] rounded-tr-[20px] rounded-bl-[20px] rounded-br-[2px] w-fit max-w-[75%] break-words text-left text-white text-[18px] font-medium leading-[1.5] shadow-sm";
+const USER_BUBBLE_STYLE: React.CSSProperties = {
+	fontFamily: "'Montserrat', sans-serif",
+	background:
+		"var(--nv-gradient-primary, linear-gradient(45deg, #531e96 0%, #6a5ffb 100%))",
+};
 
 /**
- * The option buttons for a canned response. Rendered as a SEPARATE element
- * beneath the coach text bubble (not inside it) so the coach bubble itself
- * never changes size when the options come and go.
+ * The option buttons for a canned response, rendered as a right-aligned stack
+ * of user-message-styled bubbles BENEATH the coach text bubble (a sibling, not
+ * a child — so the coach bubble never resizes).
  *
- * On click: the un-chosen options fade out, the chosen one briefly confirms,
- * and then — after a short beat — we dispatch. The dispatch flips the card to
- * display-only (these buttons unmount) and the choice reappears as the real
- * user message (which slides in from the right in ChatMessages), so it reads as
- * the option sliding over to become the user's message.
+ * On click the steps run strictly in order: the un-chosen options fade out
+ * slowly while the chosen one stays put; only once they're gone does the chosen
+ * option slide (via `layout`) up into the reply position; then we dispatch, and
+ * the real user message takes over in the same spot.
  */
 const ChoiceButtons: React.FC<{
 	buttons: ChoiceButton[];
@@ -28,64 +39,60 @@ const ChoiceButtons: React.FC<{
 	onChoose: (request: CoachRequest) => void;
 }> = ({ buttons, disabled, onChoose }) => {
 	const [chosenIndex, setChosenIndex] = useState<number | null>(null);
+	// "fading" → un-chosen are fading (still occupying space so the chosen holds
+	// still). "sliding" → un-chosen removed; the chosen slides into place.
+	const [phase, setPhase] = useState<"idle" | "fading" | "sliding">("idle");
 
 	const handleChoose = (index: number, button: ChoiceButton) => {
 		if (chosenIndex !== null || disabled) return;
 		setChosenIndex(index);
+		setPhase("fading");
+		window.setTimeout(() => setPhase("sliding"), FADE_MS);
 		window.setTimeout(() => {
 			onChoose({ message: button.label, actions: button.actions });
-		}, CHOICE_DISPATCH_DELAY_MS);
+		}, FADE_MS + SLIDE_MS);
 	};
 
 	return (
-		<div className="mb-4 flex flex-wrap gap-2 justify-end">
-			<AnimatePresence>
-				{buttons.map((button, index) => {
-					// Once chosen, drop the others so they animate out; keep the chosen
-					// one until the card flips display-only and this whole row unmounts.
-					if (chosenIndex !== null && index !== chosenIndex) return null;
-					const isChosen = chosenIndex === index;
-					return (
-						<motion.button
-							type="button"
-							// biome-ignore lint/suspicious/noArrayIndexKey: buttons are a fixed, ordered list
-							key={index}
-							layout
-							initial={{ opacity: 0, y: 4 }}
-							animate={{ opacity: 1, y: 0, scale: isChosen ? 1.05 : 1 }}
-							exit={{ opacity: 0, scale: 0.85 }}
-							transition={{ duration: 0.2, ease: "easeOut" }}
-							onClick={() => handleChoose(index, button)}
-							disabled={disabled || chosenIndex !== null}
-							className="px-3 py-1.5 text-sm font-medium rounded-md cursor-pointer disabled:cursor-default"
-							style={{
-								backgroundColor: "var(--nv-royal-purple, #531e96)",
-								color: "white",
-							}}
-							onMouseEnter={(e) => {
-								if (chosenIndex === null)
-									e.currentTarget.style.backgroundColor =
-										"var(--nv-violet-blue, #6a5ffb)";
-							}}
-							onMouseLeave={(e) => {
-								e.currentTarget.style.backgroundColor =
-									"var(--nv-royal-purple, #531e96)";
-							}}
-						>
-							{button.label}
-						</motion.button>
-					);
-				})}
-			</AnimatePresence>
+		<div className="mb-4 flex flex-col items-end gap-2">
+			{buttons.map((button, index) => {
+				const isChosen = index === chosenIndex;
+				// Drop the un-chosen options only once they've finished fading, so the
+				// chosen one doesn't shift while they fade — then its position change
+				// (via `layout`) is the slide into place.
+				if (phase === "sliding" && !isChosen) return null;
+				const fadingOut = phase !== "idle" && !isChosen;
+				return (
+					<motion.button
+						type="button"
+						// biome-ignore lint/suspicious/noArrayIndexKey: buttons are a fixed, ordered list
+						key={index}
+						layout
+						initial={{ opacity: 0, y: 4 }}
+						animate={{ opacity: fadingOut ? 0 : 1, y: 0 }}
+						transition={{
+							opacity: { duration: fadingOut ? FADE_MS / 1000 : 0.25 },
+							layout: { duration: SLIDE_MS / 1000, ease: "easeInOut" },
+							default: { duration: 0.25 },
+						}}
+						onClick={() => handleChoose(index, button)}
+						disabled={disabled || chosenIndex !== null}
+						className={`${USER_BUBBLE_CLASS} cursor-pointer transition-[filter] hover:brightness-110 disabled:cursor-default`}
+						style={USER_BUBBLE_STYLE}
+					>
+						{button.label}
+					</motion.button>
+				);
+			})}
 		</div>
 	);
 };
 
 /**
  * A canned-response coach turn: a fixed coach text bubble plus, optionally, a
- * separate row of option buttons. Keeping the buttons OUT of the bubble means
+ * separate stack of option bubbles. Keeping the options OUT of the bubble means
  * the bubble is laid out once and never resized — answering only removes the
- * sibling button row, it doesn't reflow the coach text.
+ * sibling options, it doesn't reflow the coach text.
  */
 export const IntroCannedResponseComponent: React.FC<{
 	coachMessage: React.ReactNode;
@@ -98,7 +105,7 @@ export const IntroCannedResponseComponent: React.FC<{
 
 	return (
 		<div className="_IntroCannedResponseComponent">
-			{/* Fixed-size coach text bubble — never resizes when buttons appear or
+			{/* Fixed-size coach text bubble — never resizes when options appear or
 			    leave (they're a sibling below, not a child). */}
 			<div
 				className="mb-2 p-3.5 pr-4 pl-4 rounded-t-[18px] rounded-br-[18px] rounded-bl-[6px] w-fit max-w-[75%] shadow-sm break-words mr-auto text-[18px] font-medium leading-[1.5] text-black"

--- a/client/src/pages/chat/components/coach-message-with-component/IntroCannedResponseComponent.tsx
+++ b/client/src/pages/chat/components/coach-message-with-component/IntroCannedResponseComponent.tsx
@@ -21,7 +21,7 @@ export const IntroCannedResponseComponent: React.FC<{
 				backgroundColor: "var(--nv-pale-lavender, #eae6fb)",
 			}}
 		>
-			<div className="max-w-[75%]">
+			<div>
 				{React.isValidElement(coachMessage) ? (
 					coachMessage
 				) : (

--- a/client/src/pages/chat/components/coach-message-with-component/IntroCannedResponseComponent.tsx
+++ b/client/src/pages/chat/components/coach-message-with-component/IntroCannedResponseComponent.tsx
@@ -54,7 +54,7 @@ const ChoiceButtons: React.FC<{
 	};
 
 	return (
-		<div className="mb-4 flex flex-col items-end gap-2">
+		<div className="mb-4 flex flex-wrap items-center justify-end gap-2">
 			{buttons.map((button, index) => {
 				const isChosen = index === chosenIndex;
 				// Drop the un-chosen options only once they've finished fading, so the

--- a/client/src/pages/chat/components/coach-message-with-component/IntroCannedResponseComponent.tsx
+++ b/client/src/pages/chat/components/coach-message-with-component/IntroCannedResponseComponent.tsx
@@ -2,27 +2,111 @@ import type { CoachRequest } from "@/types/coachRequest";
 import type { ComponentConfig } from "@/types/componentConfig";
 import MarkdownRenderer from "@/utils/MarkdownRenderer";
 import { AnimatePresence, motion } from "framer-motion";
-import React from "react";
+import React, { useState } from "react";
 
+type ChoiceButton = NonNullable<ComponentConfig["buttons"]>[number];
+
+// How long the chosen button is allowed to "confirm" (and the others to fade
+// out) before we actually dispatch. Keeps the choice from vanishing in the same
+// instant it's clicked.
+const CHOICE_DISPATCH_DELAY_MS = 260;
+
+/**
+ * The option buttons for a canned response. Rendered as a SEPARATE element
+ * beneath the coach text bubble (not inside it) so the coach bubble itself
+ * never changes size when the options come and go.
+ *
+ * On click: the un-chosen options fade out, the chosen one briefly confirms,
+ * and then — after a short beat — we dispatch. The dispatch flips the card to
+ * display-only (these buttons unmount) and the choice reappears as the real
+ * user message (which slides in from the right in ChatMessages), so it reads as
+ * the option sliding over to become the user's message.
+ */
+const ChoiceButtons: React.FC<{
+	buttons: ChoiceButton[];
+	disabled: boolean;
+	onChoose: (request: CoachRequest) => void;
+}> = ({ buttons, disabled, onChoose }) => {
+	const [chosenIndex, setChosenIndex] = useState<number | null>(null);
+
+	const handleChoose = (index: number, button: ChoiceButton) => {
+		if (chosenIndex !== null || disabled) return;
+		setChosenIndex(index);
+		window.setTimeout(() => {
+			onChoose({ message: button.label, actions: button.actions });
+		}, CHOICE_DISPATCH_DELAY_MS);
+	};
+
+	return (
+		<div className="mb-4 flex flex-wrap gap-2 justify-end">
+			<AnimatePresence>
+				{buttons.map((button, index) => {
+					// Once chosen, drop the others so they animate out; keep the chosen
+					// one until the card flips display-only and this whole row unmounts.
+					if (chosenIndex !== null && index !== chosenIndex) return null;
+					const isChosen = chosenIndex === index;
+					return (
+						<motion.button
+							type="button"
+							// biome-ignore lint/suspicious/noArrayIndexKey: buttons are a fixed, ordered list
+							key={index}
+							layout
+							initial={{ opacity: 0, y: 4 }}
+							animate={{ opacity: 1, y: 0, scale: isChosen ? 1.05 : 1 }}
+							exit={{ opacity: 0, scale: 0.85 }}
+							transition={{ duration: 0.2, ease: "easeOut" }}
+							onClick={() => handleChoose(index, button)}
+							disabled={disabled || chosenIndex !== null}
+							className="px-3 py-1.5 text-sm font-medium rounded-md cursor-pointer disabled:cursor-default"
+							style={{
+								backgroundColor: "var(--nv-royal-purple, #531e96)",
+								color: "white",
+							}}
+							onMouseEnter={(e) => {
+								if (chosenIndex === null)
+									e.currentTarget.style.backgroundColor =
+										"var(--nv-violet-blue, #6a5ffb)";
+							}}
+							onMouseLeave={(e) => {
+								e.currentTarget.style.backgroundColor =
+									"var(--nv-royal-purple, #531e96)";
+							}}
+						>
+							{button.label}
+						</motion.button>
+					);
+				})}
+			</AnimatePresence>
+		</div>
+	);
+};
+
+/**
+ * A canned-response coach turn: a fixed coach text bubble plus, optionally, a
+ * separate row of option buttons. Keeping the buttons OUT of the bubble means
+ * the bubble is laid out once and never resized — answering only removes the
+ * sibling button row, it doesn't reflow the coach text.
+ */
 export const IntroCannedResponseComponent: React.FC<{
 	coachMessage: React.ReactNode;
 	config: ComponentConfig;
 	onSendUserMessageToCoach: (request: CoachRequest) => void;
 	disabled: boolean;
 }> = ({ coachMessage, config, onSendUserMessageToCoach, disabled }) => {
-	const hasButtons = config.buttons && config.buttons.length > 0;
+	const buttons = config.buttons;
+	const hasButtons = Boolean(buttons && buttons.length > 0);
 
 	return (
-		<div
-			className={`_IntroCannedResponseComponent mb-4 p-3.5 pr-4 pl-4 rounded-t-[18px] rounded-br-[18px] rounded-bl-[6px] ${
-				hasButtons ? "w-fit max-w-[100%]" : "w-fit max-w-[75%]"
-			} shadow-sm animate-fadeIn break-words mr-auto text-[18px] font-medium leading-[1.5] text-black`}
-			style={{
-				fontFamily: "'Montserrat', sans-serif",
-				backgroundColor: "var(--nv-pale-lavender, #eae6fb)",
-			}}
-		>
-			<div>
+		<div className="_IntroCannedResponseComponent">
+			{/* Fixed-size coach text bubble — never resizes when buttons appear or
+			    leave (they're a sibling below, not a child). */}
+			<div
+				className="mb-2 p-3.5 pr-4 pl-4 rounded-t-[18px] rounded-br-[18px] rounded-bl-[6px] w-fit max-w-[75%] shadow-sm break-words mr-auto text-[18px] font-medium leading-[1.5] text-black"
+				style={{
+					fontFamily: "'Montserrat', sans-serif",
+					backgroundColor: "var(--nv-pale-lavender, #eae6fb)",
+				}}
+			>
 				{React.isValidElement(coachMessage) ? (
 					coachMessage
 				) : (
@@ -30,50 +114,13 @@ export const IntroCannedResponseComponent: React.FC<{
 				)}
 			</div>
 
-			{/* Fade the buttons out (rather than vanish) when the card flips to
-			    display-only after the user picks an option. The card's own height
-			    then settles via the `layout` animation on the message row. */}
-			<AnimatePresence>
-				{hasButtons && (
-					<motion.div
-						key="buttons"
-						initial={{ opacity: 0 }}
-						animate={{ opacity: 1 }}
-						exit={{ opacity: 0 }}
-						transition={{ duration: 0.2, ease: "easeInOut" }}
-						className="mt-3 flex flex-wrap gap-2 justify-end"
-					>
-						{config.buttons?.map((button, index) => (
-							<button
-								type="button"
-								key={index}
-								onClick={() =>
-									onSendUserMessageToCoach({
-										message: button.label,
-										actions: button.actions,
-									})
-								}
-								disabled={disabled}
-								className="px-3 py-1.5 text-sm font-medium rounded-md transition-colors cursor-pointer"
-								style={{
-									backgroundColor: "var(--nv-royal-purple, #531e96)",
-									color: "white",
-								}}
-								onMouseEnter={(e) => {
-									e.currentTarget.style.backgroundColor =
-										"var(--nv-violet-blue, #6a5ffb)";
-								}}
-								onMouseLeave={(e) => {
-									e.currentTarget.style.backgroundColor =
-										"var(--nv-royal-purple, #531e96)";
-								}}
-							>
-								{button.label}
-							</button>
-						))}
-					</motion.div>
-				)}
-			</AnimatePresence>
+			{hasButtons && buttons && (
+				<ChoiceButtons
+					buttons={buttons}
+					disabled={disabled}
+					onChoose={onSendUserMessageToCoach}
+				/>
+			)}
 		</div>
 	);
 };

--- a/client/src/types/message.ts
+++ b/client/src/types/message.ts
@@ -16,4 +16,12 @@ export interface Message {
 	content: string;
 	timestamp: string;
 	component_config?: ComponentConfig;
+	/**
+	 * True while this is a placeholder coach message awaiting the server
+	 * response. The bubble shows the loading dots; when the response lands the
+	 * SAME message is finalized in place (content filled, `pending` cleared) so
+	 * the dots crossfade into the response inside one persistent bubble instead
+	 * of a separate loading bubble unmounting (which made the dots "fall").
+	 */
+	pending?: boolean;
 }

--- a/client/src/types/message.ts
+++ b/client/src/types/message.ts
@@ -24,4 +24,10 @@ export interface Message {
 	 * of a separate loading bubble unmounting (which made the dots "fall").
 	 */
 	pending?: boolean;
+	/**
+	 * Client-only: true when this user message came from clicking a canned
+	 * option (not typed). ChatMessages gives only these the slide-over entrance,
+	 * so ordinary typed messages just fade in. Not persisted by the server.
+	 */
+	fromChoice?: boolean;
 }

--- a/client/src/types/message.ts
+++ b/client/src/types/message.ts
@@ -4,6 +4,14 @@ import type { ComponentConfig } from "./componentConfig";
  * A single message in the conversation history.
  */
 export interface Message {
+	/**
+	 * Stable identity for React keys. Server-persisted messages carry their
+	 * DB UUID; optimistic/synthetic messages created client-side get a
+	 * `client-*` id so a row keeps the same key from optimistic render through
+	 * commit and never remounts (which would re-run its entrance animation and
+	 * make the list flicker). Optional because historical payloads predate it.
+	 */
+	id?: string;
 	role: string;
 	content: string;
 	timestamp: string;

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -15,6 +15,13 @@ export default defineConfig({
     react(),
     tailwindcss(),
   ],
+  server: {
+    // Docker bind-mounts on macOS/Windows don't deliver native filesystem
+    // events into the container, so Vite never sees host edits and HMR appears
+    // dead (you have to rebuild to pick up changes). Polling restores live
+    // reload inside the container. Harmless when running on the host.
+    watch: { usePolling: true },
+  },
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
## Why

The chat window felt jerky for users: bubbles re-animated on every send, the loading dots and the reply were separate elements that hard-swapped (and sometimes "fell" onto the composer), interactive cards resized as they became display-only, and the view never scrolled fully to the bottom. This PR reworks the chat message flow and the canned-response interaction so the whole experience reads as calm, paced, and intentional — ready for real consumers.

All changes are client-side and scoped to the chat surface.

## What changed

**Stable message identity (no more remount flicker)**
- Every message carries a stable `id` (server UUID for persisted messages; a `client-*` id for optimistic ones). Rows are keyed by it, so the user's bubble no longer unmounts/re-animates between the optimistic render and the committed one.
- The optimistic user message is written once in `onMutate` (single source of truth) with an `onError` rollback.
- The component-turn refetch is now `refetchType: "none"` — it marked the list stale but its active refetch was replacing every row mid-turn and flashing the just-rendered card. The reply already carries everything needed to render (verified in `process_message`); server truth reconciles on the next natural mount.

**One persistent dots → reply bubble**
- Loading is modeled as a `pending` coach message rather than a separate element. The same bubble's content crossfades from the dots to the reply (`mode="wait"`), so nothing unmounts and the dots can't "fall" onto the composer.
- `layout` animation was tried and removed — scaling a bubble to animate its size visibly distorts the text. Rows use a plain opacity crossfade.

**Deliberate pacing**
- A minimum "thinking" beat (`MIN_THINKING_MS`) so canned responses (which skip the LLM and return instantly) don't snap in; the dots bubble is also deferred (`DOTS_DELAY_MS`) so it appears after the user's message settles, not in the same instant.

**Canned-response choreography**
- The coach text and the option buttons are now separate siblings, so the coach bubble is laid out once and never resizes when options come/go.
- Options render as a right-aligned horizontal row of bubbles styled like a real user message. On click the steps run strictly in order: un-chosen options fade out → the chosen one slides into the reply position → it dispatches and the real user message takes over the same spot.
- User/coach bubble padding matched so the two look the same size.

**Scroll reliability**
- A `ResizeObserver` on the message list keeps the view pinned to the very bottom across the full ~1s of post-turn height changes, only when the user is already near the bottom (won't interrupt reading history). Fixes the "stops short / hidden behind the input" issue.

**Dev tooling**
- `vite.config.ts`: enable `server.watch.usePolling` so HMR works through Docker bind-mounts on macOS/Windows (changes were previously only visible after a full container rebuild).

## Testing

- `npx tsc --noEmit` clean.
- `npx vitest run` — all chat/hook tests pass (`ChatMessages`, `useChatMessages`, canned/session components). The only failing file, `useAuth.test.ts`, fails identically on `main` and is unrelated to this PR.
- Manually verified in the local Docker stack: send/receive flow, the dots→reply crossfade, canned-choice fade→slide→commit, and full scroll-to-bottom.

## Notes / follow-ups

- The animation timings are constants (`FADE_MS`, `SLIDE_MS`, `MIN_THINKING_MS`, `DOTS_DELAY_MS`) for easy tuning.
- Reduced-motion support was intentionally not forced globally (an earlier attempt disabled the loading dots and layout tweens on machines with OS "reduce motion" on). A targeted reduced-motion pass is a sensible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)