### PR TITLE
Fix: thinking-dots bounce static in production (use CSS animation)

### DIFF
--- a/client/src/pages/chat/components/LoadingBubbles.tsx
+++ b/client/src/pages/chat/components/LoadingBubbles.tsx
@@ -1,29 +1,38 @@
-import { motion } from "framer-motion";
 import type React from "react";
 
+/**
+ * The coach "thinking" indicator: three dots that bounce in a staggered loop.
+ *
+ * The bounce is a plain CSS keyframe animation, NOT framer-motion. Framer's
+ * JS/WAAPI-driven *infinite* transform animation rendered the dots but did not
+ * actually run them in the production build (they sat static on neovita.ai
+ * while animating fine under `vite dev`). A CSS animation runs identically
+ * across every browser and build mode, which is exactly what a simple looping
+ * indicator wants. Keyframes are inlined via a scoped <style> (same pattern as
+ * StudioUnlockAnimation) so this component stays self-contained.
+ */
 export const LoadingBubbles: React.FC = () => {
 	const numBubbles = 3;
-	const duration = 0.9;
-	const stagger = 0.18;
+	const stagger = 0.18; // seconds between each dot
 
 	return (
 		<div
 			className="flex gap-1.5 py-3 min-w-[60px] items-end"
 			aria-label="Loading..."
 		>
+			<style>{`
+				@keyframes lb-bounce {
+					0%, 100% { transform: translateY(0); }
+					50% { transform: translateY(-8px); }
+				}
+				.lb-dot { animation: lb-bounce 0.9s ease-in-out infinite; }
+			`}</style>
 			{Array.from({ length: numBubbles }).map((_, i) => (
-				<motion.div
+				<span
+					// biome-ignore lint/suspicious/noArrayIndexKey: fixed-length, never reordered
 					key={i}
-					className="w-2 h-2 rounded-full bg-neutral-500 dark:bg-gold-600"
-					initial={{ y: 0 }}
-					animate={{ y: [0, -8, 0] }}
-					transition={{
-						duration,
-						repeat: Number.POSITIVE_INFINITY,
-						repeatType: "loop",
-						ease: "easeInOut",
-						delay: i * stagger,
-					}}
+					className="lb-dot w-2 h-2 rounded-full bg-neutral-500 dark:bg-gold-600"
+					style={{ animationDelay: `${i * stagger}s` }}
 					aria-hidden="true"
 				/>
 			))}


### PR DESCRIPTION
## Problem

The coach "thinking" dots render but **don't animate in the deployed build** (neovita.ai) — they sit as three static dots. They bounce fine under `vite dev` locally.

## Diagnosis

I pulled the live production bundle and confirmed the code is correct and fully deployed: the bounce config (`animate:{y:[0,-8,0]}`, `repeat: Infinity`) is intact, there's no `reducedMotion`/`prefers-reduced-motion` config anywhere, and the deploy is current. The dots also clearly *mount* (they're visible). So it's not a deploy, cache, URL, or reduced-motion issue.

The root cause is framer-motion's JS/WAAPI-driven **infinite transform** animation not running reliably in the production build (and especially in Safari/iOS, if neovita.ai is viewed there vs Chrome on localhost). The app's other animations are one-shot and survive; only this looping one breaks.

## Fix

Drive the bounce with a plain **CSS keyframe animation** instead of framer-motion — injected via a scoped `<style>` (same self-contained pattern already used by `StudioUnlockAnimation`). CSS keyframes run identically across every browser and build mode, which is exactly what a simple looping indicator needs. The visual is unchanged (same 0.9s, −8px, staggered by 0.18s per dot).

## Testing

- `tsc --noEmit` clean, biome clean.
- `npm run build` (production) succeeds and the `lb-bounce` keyframe + `.lb-dot` rule are present in the built output — verified the animation actually ships.
- Existing `ChatMessages` tests pass (LoadingBubbles is mocked there; no behavioral test depended on the framer internals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)