### PR TITLE
Fix: stop interactive coach cards resizing when answered (P3)

### DIFF
--- a/client/src/pages/chat/components/coach-message-with-component/ArchiveIdentityConfirmation.tsx
+++ b/client/src/pages/chat/components/coach-message-with-component/ArchiveIdentityConfirmation.tsx
@@ -11,7 +11,7 @@ import type {
 } from "@/types/componentConfig";
 import MarkdownRenderer from "@/utils/MarkdownRenderer";
 import { getIdentityCategoryIcon } from "@/utils/getIdentityCategoryIcon";
-import { motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import { Trash2 } from "lucide-react";
 import React from "react";
 const log = createLogger("ArchiveIdentityConfirmation", LogLevel.DEBUG);
@@ -132,13 +132,11 @@ export const ArchiveIdentityConfirmation: React.FC<{
 	const identities = (config.identities || []) as ComponentIdentity[];
 	const identity = identities[0] || null;
 
-	const hasButtons = config.buttons && config.buttons.length > 0;
-
 	return (
 		<div
-			className={`_ArchiveIdentityConfirmation mb-4 p-3 rounded-xl ${
-				hasButtons ? "w-fit max-w-[100%]" : "w-fit max-w-[75%]"
-			} leading-[1.5] shadow-sm animate-fadeIn break-words mr-auto bg-gold-200`}
+			// Fixed width (no hasButtons swap) so the card never resizes when it
+			// flips to display-only — answering only fades the buttons out.
+			className="_ArchiveIdentityConfirmation mb-4 p-3 rounded-xl w-fit max-w-[100%] leading-[1.5] shadow-sm break-words mr-auto bg-gold-200"
 		>
 			<div className="mb-3">
 				{React.isValidElement(coachMessage) ? (
@@ -217,31 +215,40 @@ export const ArchiveIdentityConfirmation: React.FC<{
 				</div>
 			</div>
 
-			{config.buttons && config.buttons.length > 0 && (
-				<div className="_ArchiveIdentityConfirmationButtons mt-4 flex flex-wrap gap-2 justify-end">
-					{config.buttons.map((button, index) => (
-						<button
-							type="button"
-							key={index}
-							onClick={() => {
-								log.debug(`Button '${button.label}' was clicked`);
-								onSendUserMessageToCoach({
-									message: button.label,
-									actions: button.actions,
-								});
-							}}
-							disabled={disabled}
-							className={`${
-								button.label.toLowerCase() === "yes"
-									? "bg-gold-500 hover:bg-gold-600 text-black"
-									: "bg-gold-300 hover:bg-gold-400 text-black dark:bg-gold-100 dark:hover:bg-gold-200 dark:text-gold-100"
-							} px-3 py-1.5 text-sm font-medium rounded-md transition-colors cursor-pointer`}
-						>
-							{button.label}
-						</button>
-					))}
-				</div>
-			)}
+			<AnimatePresence>
+				{config.buttons && config.buttons.length > 0 && (
+					<motion.div
+						key="buttons"
+						initial={{ opacity: 0 }}
+						animate={{ opacity: 1 }}
+						exit={{ opacity: 0 }}
+						transition={{ duration: 0.3 }}
+						className="_ArchiveIdentityConfirmationButtons mt-4 flex flex-wrap gap-2 justify-end"
+					>
+						{config.buttons.map((button, index) => (
+							<button
+								type="button"
+								key={index}
+								onClick={() => {
+									log.debug(`Button '${button.label}' was clicked`);
+									onSendUserMessageToCoach({
+										message: button.label,
+										actions: button.actions,
+									});
+								}}
+								disabled={disabled}
+								className={`${
+									button.label.toLowerCase() === "yes"
+										? "bg-gold-500 hover:bg-gold-600 text-black"
+										: "bg-gold-300 hover:bg-gold-400 text-black dark:bg-gold-100 dark:hover:bg-gold-200 dark:text-gold-100"
+								} px-3 py-1.5 text-sm font-medium rounded-md transition-colors cursor-pointer`}
+							>
+								{button.label}
+							</button>
+						))}
+					</motion.div>
+				)}
+			</AnimatePresence>
 		</div>
 	);
 };

--- a/client/src/pages/chat/components/coach-message-with-component/CombineIdentitiesConfirmation.tsx
+++ b/client/src/pages/chat/components/coach-message-with-component/CombineIdentitiesConfirmation.tsx
@@ -10,6 +10,7 @@ import type {
 	ComponentIdentity,
 } from "@/types/componentConfig";
 import MarkdownRenderer from "@/utils/MarkdownRenderer";
+import { AnimatePresence, motion } from "framer-motion";
 import React from "react";
 import { AiOutlineSun } from "react-icons/ai";
 import { BsStars } from "react-icons/bs";
@@ -122,13 +123,11 @@ export const CombineIdentitiesConfirmation: React.FC<{
 	const identityA = identities[0] || null;
 	const identityB = identities[1] || null;
 
-	const hasButtons = config.buttons && config.buttons.length > 0;
-
 	return (
 		<div
-			className={`_CombineIdentitiesConfirmation mb-4 p-4 rounded-xl ${
-				hasButtons ? "w-fit max-w-[100%]" : "w-fit max-w-[75%]"
-			} shadow-sm animate-fadeIn break-words mr-auto text-[18px] font-medium leading-[1.5] text-black`}
+			// Width is fixed (not swapped on hasButtons) so the card never resizes
+			// when it flips to display-only — answering only fades the buttons out.
+			className="_CombineIdentitiesConfirmation mb-4 p-4 rounded-xl w-fit max-w-[100%] shadow-sm break-words mr-auto text-[18px] font-medium leading-[1.5] text-black"
 			style={{
 				fontFamily: "'Montserrat', sans-serif",
 				backgroundColor: "var(--nv-pale-lavender, #eae6fb)",
@@ -238,55 +237,64 @@ export const CombineIdentitiesConfirmation: React.FC<{
 				})()}
 			</div>
 
-			{config.buttons && config.buttons.length > 0 && (
-				<div className="_CombineIdentitiesConfirmationButtons mt-4 flex flex-wrap gap-2 justify-end">
-					{config.buttons.map((button, index) => (
-						<button
-							type="button"
-							key={index}
-							onClick={() => {
-								log.debug(`Button '${button.label}' was clicked`);
-								onSendUserMessageToCoach({
-									message: button.label,
-									actions: button.actions,
-								});
-							}}
-							disabled={disabled}
-							className="px-3 py-1.5 text-sm font-medium rounded-md transition-colors cursor-pointer"
-							style={{
-								backgroundColor:
-									button.label.toLowerCase() === "yes"
-										? "var(--nv-royal-purple, #531e96)"
-										: "var(--nv-pale-lavender, #eae6fb)",
-								color:
-									button.label.toLowerCase() === "yes"
-										? "white"
-										: "var(--nv-indigo, #0b1c4a)",
-							}}
-							onMouseEnter={(e) => {
-								if (button.label.toLowerCase() === "yes") {
-									e.currentTarget.style.backgroundColor =
-										"var(--nv-violet-blue, #6a5ffb)";
-								} else {
-									e.currentTarget.style.backgroundColor =
-										"var(--nv-lilac-white, #f7f5ff)";
-								}
-							}}
-							onMouseLeave={(e) => {
-								if (button.label.toLowerCase() === "yes") {
-									e.currentTarget.style.backgroundColor =
-										"var(--nv-royal-purple, #531e96)";
-								} else {
-									e.currentTarget.style.backgroundColor =
-										"var(--nv-pale-lavender, #eae6fb)";
-								}
-							}}
-						>
-							{button.label}
-						</button>
-					))}
-				</div>
-			)}
+			<AnimatePresence>
+				{config.buttons && config.buttons.length > 0 && (
+					<motion.div
+						key="buttons"
+						initial={{ opacity: 0 }}
+						animate={{ opacity: 1 }}
+						exit={{ opacity: 0 }}
+						transition={{ duration: 0.3 }}
+						className="_CombineIdentitiesConfirmationButtons mt-4 flex flex-wrap gap-2 justify-end"
+					>
+						{config.buttons.map((button, index) => (
+							<button
+								type="button"
+								key={index}
+								onClick={() => {
+									log.debug(`Button '${button.label}' was clicked`);
+									onSendUserMessageToCoach({
+										message: button.label,
+										actions: button.actions,
+									});
+								}}
+								disabled={disabled}
+								className="px-3 py-1.5 text-sm font-medium rounded-md transition-colors cursor-pointer"
+								style={{
+									backgroundColor:
+										button.label.toLowerCase() === "yes"
+											? "var(--nv-royal-purple, #531e96)"
+											: "var(--nv-pale-lavender, #eae6fb)",
+									color:
+										button.label.toLowerCase() === "yes"
+											? "white"
+											: "var(--nv-indigo, #0b1c4a)",
+								}}
+								onMouseEnter={(e) => {
+									if (button.label.toLowerCase() === "yes") {
+										e.currentTarget.style.backgroundColor =
+											"var(--nv-violet-blue, #6a5ffb)";
+									} else {
+										e.currentTarget.style.backgroundColor =
+											"var(--nv-lilac-white, #f7f5ff)";
+									}
+								}}
+								onMouseLeave={(e) => {
+									if (button.label.toLowerCase() === "yes") {
+										e.currentTarget.style.backgroundColor =
+											"var(--nv-royal-purple, #531e96)";
+									} else {
+										e.currentTarget.style.backgroundColor =
+											"var(--nv-pale-lavender, #eae6fb)";
+									}
+								}}
+							>
+								{button.label}
+							</button>
+						))}
+					</motion.div>
+				)}
+			</AnimatePresence>
 		</div>
 	);
 };

--- a/client/src/pages/chat/components/coach-message-with-component/IAmStatementsSummaryComponent.tsx
+++ b/client/src/pages/chat/components/coach-message-with-component/IAmStatementsSummaryComponent.tsx
@@ -114,14 +114,13 @@ export const IAmStatementsSummaryComponent: React.FC<{
 	disabled: boolean;
 }> = ({ coachMessage, config, onSendUserMessageToCoach, disabled }) => {
 	const identities = (config.identities || []) as ComponentIdentity[];
-	const hasButtons = config.buttons && config.buttons.length > 0;
 	const { downloadPdf, isDownloading } = useDownloadIAmPdf();
 
 	return (
 		<div
-			className={`_IAmStatementsSummaryComponent mb-4 p-4 rounded-xl ${
-				hasButtons ? "w-fit max-w-[100%]" : "w-fit max-w-[75%]"
-			} leading-[1.5] shadow-sm animate-fadeIn break-words mr-auto bg-gold-200 dark:bg-transparent dark:border dark:border-gold-600 dark:text-gold-200`}
+			// Fixed width (no hasButtons swap) so the card doesn't resize when the
+			// action buttons go away (the Download PDF button always remains).
+			className="_IAmStatementsSummaryComponent mb-4 p-4 rounded-xl w-fit max-w-[100%] leading-[1.5] shadow-sm break-words mr-auto bg-gold-200 dark:bg-transparent dark:border dark:border-gold-600 dark:text-gold-200"
 		>
 			<div className="mb-4">
 				{React.isValidElement(coachMessage) ? (

--- a/client/src/pages/chat/components/coach-message-with-component/NestIdentitiesConfirmation.tsx
+++ b/client/src/pages/chat/components/coach-message-with-component/NestIdentitiesConfirmation.tsx
@@ -11,6 +11,7 @@ import type {
 } from "@/types/componentConfig";
 import MarkdownRenderer from "@/utils/MarkdownRenderer";
 import { getIdentityCategoryIcon } from "@/utils/getIdentityCategoryIcon";
+import { AnimatePresence, motion } from "framer-motion";
 import React from "react";
 const log = createLogger("NestIdentitiesConfirmation", LogLevel.DEBUG);
 
@@ -136,13 +137,11 @@ export const NestIdentitiesConfirmation: React.FC<{
 	const nestedIdentity = identities[0] || null;
 	const parentIdentity = identities[1] || null;
 
-	const hasButtons = config.buttons && config.buttons.length > 0;
-
 	return (
 		<div
-			className={`_NestIdentitiesConfirmation mb-4 p-3 rounded-xl ${
-				hasButtons ? "w-fit max-w-[100%]" : "w-fit max-w-[75%]"
-			} leading-[1.5] shadow-sm animate-fadeIn break-words mr-auto bg-gold-200`}
+			// Fixed width (no hasButtons swap) so the card never resizes when it
+			// flips to display-only — answering only fades the buttons out.
+			className="_NestIdentitiesConfirmation mb-4 p-3 rounded-xl w-fit max-w-[100%] leading-[1.5] shadow-sm break-words mr-auto bg-gold-200"
 		>
 			<div className="mb-3">
 				{React.isValidElement(coachMessage) ? (
@@ -180,31 +179,40 @@ export const NestIdentitiesConfirmation: React.FC<{
 				/>
 			</div>
 
-			{config.buttons && config.buttons.length > 0 && (
-				<div className="_NestIdentitiesConfirmationButtons mt-4 flex flex-wrap gap-2 justify-end">
-					{config.buttons.map((button, index) => (
-						<button
-							type="button"
-							key={index}
-							onClick={() => {
-								log.debug(`Button '${button.label}' was clicked`);
-								onSendUserMessageToCoach({
-									message: button.label,
-									actions: button.actions,
-								});
-							}}
-							disabled={disabled}
-							className={`${
-								button.label.toLowerCase() === "yes"
-									? "bg-gold-500 hover:bg-gold-600 text-black"
-									: "bg-gold-300 hover:bg-gold-400 text-black dark:bg-gold-100 dark:hover:bg-gold-200 dark:text-gold-100"
-							} px-3 py-1.5 text-sm font-medium rounded-md transition-colors cursor-pointer`}
-						>
-							{button.label}
-						</button>
-					))}
-				</div>
-			)}
+			<AnimatePresence>
+				{config.buttons && config.buttons.length > 0 && (
+					<motion.div
+						key="buttons"
+						initial={{ opacity: 0 }}
+						animate={{ opacity: 1 }}
+						exit={{ opacity: 0 }}
+						transition={{ duration: 0.3 }}
+						className="_NestIdentitiesConfirmationButtons mt-4 flex flex-wrap gap-2 justify-end"
+					>
+						{config.buttons.map((button, index) => (
+							<button
+								type="button"
+								key={index}
+								onClick={() => {
+									log.debug(`Button '${button.label}' was clicked`);
+									onSendUserMessageToCoach({
+										message: button.label,
+										actions: button.actions,
+									});
+								}}
+								disabled={disabled}
+								className={`${
+									button.label.toLowerCase() === "yes"
+										? "bg-gold-500 hover:bg-gold-600 text-black"
+										: "bg-gold-300 hover:bg-gold-400 text-black dark:bg-gold-100 dark:hover:bg-gold-200 dark:text-gold-100"
+								} px-3 py-1.5 text-sm font-medium rounded-md transition-colors cursor-pointer`}
+							>
+								{button.label}
+							</button>
+						))}
+					</motion.div>
+				)}
+			</AnimatePresence>
 		</div>
 	);
 };

--- a/client/src/pages/chat/components/coach-message-with-component/SuggestIAmStatementComponent.tsx
+++ b/client/src/pages/chat/components/coach-message-with-component/SuggestIAmStatementComponent.tsx
@@ -67,9 +67,9 @@ export const SuggestIAmStatementComponent: React.FC<{
 
 	return (
 		<div
-			className={`_SuggestIAmStatementComponent mb-4 p-4 rounded-xl ${
-				hasButtons ? "w-fit max-w-[100%]" : "w-fit max-w-[75%]"
-			} leading-[1.5] shadow-sm animate-fadeIn break-words mr-auto bg-gold-200 dark:bg-transparent dark:border dark:border-gold-600 dark:text-gold-200`}
+			// Fixed width (no hasButtons swap) so the card doesn't snap narrower
+			// when it flips from the editable prompt to the submitted statement.
+			className="_SuggestIAmStatementComponent mb-4 p-4 rounded-xl w-fit max-w-[100%] leading-[1.5] shadow-sm break-words mr-auto bg-gold-200 dark:bg-transparent dark:border dark:border-gold-600 dark:text-gold-200"
 		>
 			<div className="mb-3">
 				{React.isValidElement(coachMessage) ? (


### PR DESCRIPTION
## Why

Follow-up to #152. Several interactive coach cards still had the jarring "the bubble jumps size the moment you answer" behavior that #152 fixed for the canned/intro card. When the user picked an option, these cards snapped their width (`max-w-[100%] → max-w-[75%]`) and their buttons vanished abruptly.

## What

For **Combine / Nest / Archive / Suggest / IAmStatementsSummary**:

- **Lock the card width** to a single value (drop the `hasButtons ? max-w-[100%] : max-w-[75%]` swap) so the card is laid out once and never resizes when it flips to display-only.
- **Fade the confirmation buttons out** (Combine / Nest / Archive) via `AnimatePresence` instead of having them blink away.
- Remove the dead `animate-fadeIn` class (no such keyframe exists) from these wrappers.

This mirrors the structural fix from #152 and the project's chat-animation lessons (separate/stabilize, no Framer `layout`, no global reduced-motion).

### Intentionally out of scope

**SessionBreak** is left untouched — its jank is a different problem (a full-card ↔ pill-badge *state* swap, not a button removal) that needs a crossfade/morph, not the width-lock pattern. Flagged as its own follow-up.

## Testing

- `tsc --noEmit` clean; biome clean (only pre-existing `noArrayIndexKey` / `noLabelWithoutControl` **warnings**, both `"warn"` level, on lines this PR doesn't change).
- `vitest` chat suite passes (79 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)