### PR TITLE
fix(api): register JWT token routes so /token/refresh stops 404ing

### DIFF
--- a/server/apps/api_urls.py
+++ b/server/apps/api_urls.py
@@ -80,9 +80,11 @@ admin_router.register(
 admin_router.register(r"invites", AdminInviteViewSet, basename="admin-invites")
 
 # JWT token URLs
+# No trailing slash to match the DRF routers (trailing_slash=False) and the client,
+# which calls /token and /token/refresh without a trailing slash.
 jwt_patterns = [
-    path("token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
-    path("token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
+    path("token", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("token/refresh", TokenRefreshView.as_view(), name="token_refresh"),
 ]
 
 auth_paths = [
@@ -100,6 +102,7 @@ docs_paths = [
 urlpatterns = (
     default_router.urls
     + [path("admin/", include(admin_router.urls))]
+    + jwt_patterns
     + auth_paths
     + docs_paths
 )


### PR DESCRIPTION
## Problem

`POST /api/v1/token/refresh` returns **404 Not Found** in production. The client's `authFetch` refresh-on-401 flow (`client/src/utils/authFetch.ts`) calls this endpoint when an access token expires, and has had nothing to hit.

## Root cause

In `server/apps/api_urls.py`, `jwt_patterns` (the `token` and `token/refresh` routes) were **defined but never concatenated into `urlpatterns`**. `git log -L` on that block confirms this has been the case since the very first commit — the JWT routes have never been mounted. It only surfaced now because the refresh path finally gets exercised on token expiry.

A secondary trailing-slash mismatch also existed: the JWT paths used trailing slashes (`token/refresh/`) while the DRF routers use `trailing_slash=False` and the client calls `/token/refresh` with no slash. `APPEND_SLASH` does not redirect POSTs, so the route would 404 even once mounted.

## Fix

- Add `jwt_patterns` to `urlpatterns`.
- Drop the trailing slashes from the JWT paths to match the router convention and the client.

## Verification

In the local backend container:
- Both `/api/v1/token` and `/api/v1/token/refresh` now resolve (`TokenObtainPairView` / `TokenRefreshView`).
- `POST /api/v1/token/refresh` with a bad token returns `401 token_not_valid` (correct), instead of `404`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)