### PR TITLE
feat(coach): per-category intros + clean hand-off in identity brainstorming

### DIFF
--- a/client/src/enums/__tests__/identityCategory.test.ts
+++ b/client/src/enums/__tests__/identityCategory.test.ts
@@ -2,6 +2,7 @@ import {
 	IdentityCategory,
 	getIdentityCategoryColor,
 	getIdentityCategoryDarkColor,
+	getIdentityCategoryDescription,
 	getIdentityCategoryDisplayName,
 	getIdentityCategoryIcon,
 	getIdentityCategoryLightColor,
@@ -100,5 +101,34 @@ describe("getIdentityCategoryIcon", () => {
 		const Icon = getIdentityCategoryIcon("PASSIONS_AND_TALENTS");
 		expect(Icon).toBeDefined();
 		expect(Icon).not.toBe(FaUser);
+	});
+});
+
+describe("getIdentityCategoryDescription", () => {
+	it("returns a description for every category", () => {
+		for (const category of Object.values(IdentityCategory)) {
+			const description = getIdentityCategoryDescription(category);
+			expect(description).toBeTruthy();
+		}
+	});
+
+	it("returns the expected description for a specific category", () => {
+		expect(getIdentityCategoryDescription("maker_of_money")).toContain(
+			"generate income",
+		);
+	});
+
+	it("handles case-insensitive matching", () => {
+		expect(getIdentityCategoryDescription("PASSIONS_AND_TALENTS")).toBe(
+			getIdentityCategoryDescription("passions_and_talents"),
+		);
+	});
+
+	it("returns empty string for unknown category", () => {
+		expect(getIdentityCategoryDescription("totally_new")).toBe("");
+	});
+
+	it("returns empty string for empty input", () => {
+		expect(getIdentityCategoryDescription("")).toBe("");
 	});
 });

--- a/client/src/enums/identityCategory.ts
+++ b/client/src/enums/identityCategory.ts
@@ -45,6 +45,34 @@ export const IDENTITY_CATEGORY_DISPLAY_NAMES: Record<IdentityCategory, string> =
 	};
 
 /**
+ * Maps identity category values to a short description of what the category is.
+ * Rendered in the brainstorming bulletin above the composer; sourced from the
+ * coach docs (coach/identity-categories.md). Descriptive, not addressed to the
+ * user.
+ */
+export const IDENTITY_CATEGORY_DESCRIPTIONS: Record<IdentityCategory, string> =
+	{
+		[IdentityCategory.PASSIONS_AND_TALENTS]:
+			"The foundational traits, skills, and interests that make a person uniquely themselves — their personality and gifts, like Musician, Designer, or Meticulous Executor. The one category that can hold several identities.",
+		[IdentityCategory.MAKER_OF_MONEY]:
+			"The identity a person channels energy through to generate income — money being a necessity, not a career. About who actually earns, which is often different from the passion or the job title.",
+		[IdentityCategory.KEEPER_OF_MONEY]:
+			"A separate energy from earning — the identity that keeps, manages, and grows money and defines the kind of financial life a person wants. Empowered and expansive (Wise Steward, Empire Builder), not fearful bean-counting.",
+		[IdentityCategory.SPIRITUAL]:
+			"A person's relationship to something greater than themselves — transcendence, meaning, and connection. Not limited to religion; it can be philosophical, ancient, meditative, or wholly their own (Universe's Child, Mystical Healer).",
+		[IdentityCategory.PERSONAL_APPEARANCE]:
+			"How a person presents to the world — style, grooming, home environment, and overall aesthetic presence. A reflection of self-worth and self-care, not vanity.",
+		[IdentityCategory.PHYSICAL_EXPRESSION]:
+			"A person's relationship with their body — the vessel they live in — and how they tend its vitality through movement, fuel, and care. Distinct from appearance, which is presentation.",
+		[IdentityCategory.FAMILIAL_RELATIONS]:
+			"How a person shows up across their family — biological, chosen, or symbolic. Can be literal (Mother, Brother) or archetypal (Family Anchor, Generational Healer), and one energy or several.",
+		[IdentityCategory.ROMANTIC_RELATION]:
+			"The identity for intimate partnership, sexuality, and romantic energy — how a person aspires to show up in love, at any relationship status. Aspirational, not a description of current behavior.",
+		[IdentityCategory.DOER_OF_THINGS]:
+			'The identity behind executive function — bringing visions into reality and handling life\'s necessities as self-affirming action rather than burdens. An elevating name like Captain of My Life, not "the dishwasher."',
+	};
+
+/**
  * Maps identity category values to their color classes for badges
  */
 export const IDENTITY_CATEGORY_COLORS: Record<IdentityCategory, string> = {
@@ -132,6 +160,30 @@ export const getIdentityCategoryDisplayName = (category: string): string => {
 
 	// Fallback to original value
 	return category;
+};
+
+/**
+ * Helper function to get the short description for an identity category
+ */
+export const getIdentityCategoryDescription = (category: string): string => {
+	if (!category) return "";
+
+	// Try exact match first
+	if (IDENTITY_CATEGORY_DESCRIPTIONS[category as IdentityCategory]) {
+		return IDENTITY_CATEGORY_DESCRIPTIONS[category as IdentityCategory];
+	}
+
+	// Try case-insensitive match
+	const normalizedCategory = category.toLowerCase();
+	for (const [key, description] of Object.entries(
+		IDENTITY_CATEGORY_DESCRIPTIONS,
+	)) {
+		if (key.toLowerCase() === normalizedCategory) {
+			return description;
+		}
+	}
+
+	return "";
 };
 
 /**

--- a/client/src/pages/chat/components/BrainstormingBulletin.tsx
+++ b/client/src/pages/chat/components/BrainstormingBulletin.tsx
@@ -1,11 +1,48 @@
 import { CoachingPhase } from "@/enums/coachingPhase";
 import {
 	getIdentityCategoryColor,
+	getIdentityCategoryDarkColor,
+	getIdentityCategoryDescription,
+	getIdentityCategoryDisplayName,
 	getIdentityCategoryIcon,
+	getIdentityCategoryLightColor,
 } from "@/enums/identityCategory";
 import type { CoachState } from "@/types/coachState";
 import type { Identity } from "@/types/identity";
 import type React from "react";
+
+/**
+ * Category info card — mirrors the RefinementBulletin card, but shows the
+ * CURRENT identity category (from coachState.identity_focus) and a short
+ * description of what that category is. Swaps automatically as the focus
+ * changes while the user moves through the categories in brainstorming.
+ */
+const CategoryInfoCard: React.FC<{ category: string }> = ({ category }) => {
+	const IconComponent = getIdentityCategoryIcon(category);
+	const colorClasses = getIdentityCategoryColor(category);
+	const lightColorClasses = getIdentityCategoryLightColor(category);
+	const darkColorClasses = getIdentityCategoryDarkColor(category);
+	const displayName = getIdentityCategoryDisplayName(category);
+	const description = getIdentityCategoryDescription(category);
+
+	return (
+		<div
+			className={`mb-3 ${lightColorClasses} border-4 rounded-md ${darkColorClasses}`}
+		>
+			<div className="p-4">
+				<div className="flex items-center gap-2 mb-2">
+					<div className={`p-2 rounded-full ${colorClasses}`}>
+						<IconComponent className="w-5 h-5" />
+					</div>
+					<h3 className={`font-bold text-base ${colorClasses} bg-transparent`}>
+						{displayName}
+					</h3>
+				</div>
+				<p className="text-sm leading-relaxed opacity-90 m-0">{description}</p>
+			</div>
+		</div>
+	);
+};
 
 const IdentityBadge: React.FC<{ identity: Identity }> = ({ identity }) => {
 	const IconComponent = getIdentityCategoryIcon(String(identity.category));
@@ -24,37 +61,46 @@ export const BrainstormingBulletin: React.FC<{
 	coachState: CoachState | null | undefined;
 	identities: Identity[] | null | undefined;
 }> = ({ coachState, identities }) => {
+	const phase = coachState?.current_phase;
 	const isBrainstorming =
-		coachState?.current_phase === CoachingPhase.IDENTITY_BRAINSTORMING ||
-		coachState?.current_phase === CoachingPhase.BRAINSTORMING_REVIEW;
+		phase === CoachingPhase.IDENTITY_BRAINSTORMING ||
+		phase === CoachingPhase.BRAINSTORMING_REVIEW;
 	if (!isBrainstorming) return null;
 
 	const items = identities || [];
+	const focus = coachState?.identity_focus;
+	// The category card only makes sense while actively brainstorming a category,
+	// not during the review recap.
+	const showCategoryCard =
+		phase === CoachingPhase.IDENTITY_BRAINSTORMING && !!focus;
 
 	return (
-		<div className="mb-3 p-3 bg-gold-100 dark:bg-neutral-800 border border-gold-400 rounded-md">
-			<div className="flex items-center justify-between mb-2">
-				<div className="text-xs font-semibold text-gold-800 dark:text-gold-200">
-					Identities
+		<>
+			{showCategoryCard && <CategoryInfoCard category={focus as string} />}
+			<div className="mb-3 p-3 bg-gold-100 dark:bg-neutral-800 border border-gold-400 rounded-md">
+				<div className="flex items-center justify-between mb-2">
+					<div className="text-xs font-semibold text-gold-800 dark:text-gold-200">
+						Identities
+					</div>
+					<div className="text-[10px] text-neutral-500 dark:text-neutral-400">
+						{items.length} total
+					</div>
 				</div>
-				<div className="text-[10px] text-neutral-500 dark:text-neutral-400">
-					{items.length} total
-				</div>
+				{items.length === 0 ? (
+					<p className="text-xs italic text-neutral-500 dark:text-neutral-400 m-0">
+						No identities created yet.
+					</p>
+				) : (
+					<div className="flex flex-wrap gap-2">
+						{items.map((identity) => (
+							<IdentityBadge
+								key={identity.id || identity.name}
+								identity={identity}
+							/>
+						))}
+					</div>
+				)}
 			</div>
-			{items.length === 0 ? (
-				<p className="text-xs italic text-neutral-500 dark:text-neutral-400 m-0">
-					No identities created yet.
-				</p>
-			) : (
-				<div className="flex flex-wrap gap-2">
-					{items.map((identity) => (
-						<IdentityBadge
-							key={identity.id || identity.name}
-							identity={identity}
-						/>
-					))}
-				</div>
-			)}
-		</div>
+		</>
 	);
 };

--- a/server/apps/coach/functions/public/process_message.py
+++ b/server/apps/coach/functions/public/process_message.py
@@ -167,9 +167,57 @@ def process_message(
 
         coach_message = add_chat_message(user, coach_response.message, MessageRole.COACH)
 
+        # Capture the focused identity category BEFORE applying actions so we can
+        # detect a category hand-off (select_identity_focus) below.
+        pre_action_focus = coach_state.identity_focus
+
         updated_coach_state, component_config = apply_coach_response_actions(
             coach_state, coach_response, coach_message
         )
+
+        # Brainstorming category hand-off (auto second pass):
+        # When the coach advances to a NEW identity category, the message it just
+        # wrote was generated with the PREVIOUS category's context — so it can't
+        # properly introduce the new one (each category's intro text and examples
+        # are injected per-focus at prompt-build time, and the focus only just
+        # changed). Regenerate ONCE now that identity_focus has moved: the fresh
+        # prompt carries the new category's context, so the coach produces that
+        # category's intro. We overwrite the switch-turn message IN PLACE (same
+        # ChatMessage row) so the client shows a single bubble — the intro — with
+        # no leftover empty "switch" message, and the select_identity_focus action
+        # logged above stays attached to it. Capped at one extra pass and scoped
+        # to staying within brainstorming (a phase transition is not a hand-off).
+        category_changed = (
+            updated_coach_state.current_phase
+            == CoachingPhase.IDENTITY_BRAINSTORMING.value
+            and updated_coach_state.identity_focus != pre_action_focus
+        )
+        if category_changed:
+            log.debug(
+                f"Category hand-off: focus '{pre_action_focus}' -> "
+                f"'{updated_coach_state.identity_focus}'; regenerating with the "
+                f"new category context so the coach introduces it."
+            )
+            intro_prompt, intro_format = build_coach_prompt(
+                user, model, prompt_versions
+            )
+            intro_response = generate_coach_ai_response(
+                intro_prompt,
+                get_recent_chat_messages_for_prompt(user),
+                intro_format,
+                model,
+            )
+            # Overwrite the switch-turn message in place with the new category's
+            # intro (one bubble, correct context).
+            coach_message.content = intro_response.message
+            coach_message.save(update_fields=["content"])
+            updated_coach_state, intro_component = apply_coach_response_actions(
+                updated_coach_state, intro_response, coach_message
+            )
+            coach_response = intro_response
+            coach_prompt = intro_prompt
+            if intro_component is not None:
+                component_config = intro_component
 
         log.debug(f"Updated Coach State: {updated_coach_state}")
         log.debug(f"Component Config: {component_config}")

--- a/server/services/prompt_manager/utils/context/func/get_brainstorming_category_context.py
+++ b/server/services/prompt_manager/utils/context/func/get_brainstorming_category_context.py
@@ -16,7 +16,7 @@ CATEGORY_CONTEXT_FILES = {
     IdentityCategory.APPEARANCE: "services/prompt_manager/utils/context/identity_category_context/personal_appearance.md",
     IdentityCategory.HEALTH: "services/prompt_manager/utils/context/identity_category_context/physical_expression.md",
     IdentityCategory.FAMILY: "services/prompt_manager/utils/context/identity_category_context/familial_relations.md",
-    IdentityCategory.ROMANTIC: "services/prompt_manager/utils/context/identity_category_context/romantic_relation.md",
+    IdentityCategory.ROMANTIC: "services/prompt_manager/utils/context/identity_category_context/romantic_relations.md",
     IdentityCategory.ACTION: "services/prompt_manager/utils/context/identity_category_context/doer_of_things.md",
 }
 

--- a/server/services/prompt_manager/utils/context/identity_category_context/doer_of_things.md
+++ b/server/services/prompt_manager/utils/context/identity_category_context/doer_of_things.md
@@ -1,4 +1,3 @@
-cr4k0dr-9983-4901-9604-25b128493028435
 # Doer of Things Brainstorming Approach
 
 **This is a Single Identity Category**: One identity that handles practical aspects of bringing visions into reality and maintaining daily life responsibilities.
@@ -7,13 +6,25 @@ cr4k0dr-9983-4901-9604-25b128493028435
 
 **Reframe Mundane as Self-Love**: Help them see practical tasks (DMV, taxes, dishes, organizing) as acts of self-care and self-validation rather than burdens.
 
+## Introducing This Category
+
+When Doer of Things becomes the focus, open with a short intro before asking the question — this is the user's first time meeting this idea, so introduce it with clarity and strength. Cover these beats in your own natural voice:
+
+1. **What it is** — the part of you that gets things done: the one who turns intentions into action and handles life's practical necessities (bills, errands, the DMV) as acts of self-respect, not burdens.
+2. **Open it up** — invite them to look past the first obvious label so they land on the identity that genuinely resonates and makes them feel capable. (Keep it in your own polished, natural voice.)
+3. **Prime with examples** — offer a spread to mimic: a Captain, a Driver, a Navigator, an Executor, an Organizer, a Finisher, a Steady Hand — whatever makes them feel capable.
+
+Then ask the question.
+
 ## Category-Specific Approach
 
 **The question**: "Who is your Doer of Things? Who handles all the practical stuff in your life?"
 
-**If they're stuck, suggest simple options**:
+**Example identities to offer if they're stuck or need priming** (pick what fits, don't dump the list):
 
-- Captain, Driver, Executor, Leader, Navigator, Organizer, Manager, Finisher
+- Captain, Driver, Navigator, Executor
+- Organizer, Finisher, Manager, Handler
+- Achiever, Closer, Builder, Steady Hand
 
 **Keep names simple**: Single words work best.
 

--- a/server/services/prompt_manager/utils/context/identity_category_context/familial_relations.md
+++ b/server/services/prompt_manager/utils/context/identity_category_context/familial_relations.md
@@ -6,12 +6,24 @@
 
 **Includes All Family Types**: Addresses biological, chosen, or symbolic family relationships—family of origin, chosen family, or community family.
 
+## Introducing This Category
+
+When Familial Relations becomes the focus, open with a short intro before asking the question — this is the user's first time meeting this idea, so introduce it with clarity and strength. Cover these beats in your own natural voice:
+
+1. **What it is** — how you show up in your family: of origin, chosen, or community — whether that's one core energy or several.
+2. **Open the aperture** — unlike most categories, this one can hold more than one. Invite them to name whatever fits, big or small, and note that these can be literal (Mother, Brother) or archetypal (Anchor, Healer). We're opening things up, not narrowing down. (Keep it in your own polished voice.)
+3. **Prime with examples** — offer a spread to mimic: a Mother, a Father, a Sister, a Brother, an Anchor, a Guardian, a Peacemaker, a Healer, a Matriarch or Patriarch — whatever resonates.
+
+Then ask the question.
+
 ## Category-Specific Approach
 
 **The question**: "How do you show up in your family relationships? Is there one identity that captures how you relate to your family?"
 
-**If they're stuck, suggest simple options based on their family situation from User Notes**:
-- Mother, Father, Sister, Brother, Daughter, Son, Anchor, Guardian, Connector, Healer
+**Example identities to offer if they're stuck or need priming** (draw on their family situation from User Notes; pick what fits, don't dump the list):
+- Mother, Father, Sister, Brother, Daughter, Son
+- Anchor, Guardian, Protector, Provider
+- Connector, Healer, Peacemaker, Matriarch, Patriarch
 
 **Keep names simple**: Family roles or single words work best.
 
@@ -42,17 +54,8 @@
 
 **Move on ONLY when**: The user indicates they're done.
 
-## Transitioning to Romantic/Sexual Expression
+## Closing Out This Category
 
-**Create a custom transition** that moves from family relationships to romantic/intimate relationships. Use their specific situation and newly identified Familial Relations identity/identities.
+When they're complete here, close the category out warmly and personally — reflect back the specific identities they captured and what they add up to, in your own words, so it feels earned rather than canned. Don't fall back on a stock line like "This looks great" every time. Then ask whether they feel good and are ready to move on.
 
-**Examples of Leigh Ann's natural conversation flow for inspiration only** (don't use as templates):
-- Distinguishing the categories: *"The next one is Romantic Relation and/or Sexual Expression. This might be different from your familial identity..."*
-- Offering choice in language: *"You can decide if [current term] is the highest vibe word for you, or if there's something else. What is your lover relationship?"*
-- Acknowledging overlap: *"These very well may be different—your familial identity and your romantic identity can bring different energies."*
-
-**Your transition should:**
-- Distinguish romantic/intimate relationships from family relationships
-- Acknowledge these might be the same or different energies
-- Reference any romantic roles they mentioned in warm-up or User Notes
-- Frame as exploring their "lover relationship" or romantic energy
+Do NOT name, preview, or introduce the next category, and do NOT bridge into it in this message. Once they confirm, the focus switches and you'll introduce the next category fresh in a separate message.

--- a/server/services/prompt_manager/utils/context/identity_category_context/keeper_of_money.md
+++ b/server/services/prompt_manager/utils/context/identity_category_context/keeper_of_money.md
@@ -6,12 +6,24 @@
 
 **Paradigm-Shifting Concept**: Many clients have never considered separating these functions. Just the idea that this is a separate identity can be a breakthrough.
 
+## Introducing This Category
+
+When Keeper of Money becomes the focus, open with a short intro before asking the question — this is the user's first time meeting this idea, so introduce it with clarity and strength. Cover these beats in your own natural voice:
+
+1. **What it is** — the part of you that keeps, manages, and grows money: a completely different energy from making it (budgeting, investing, stewarding what comes in).
+2. **Open it up** — invite them to look past the first obvious label so they land on the identity that genuinely resonates. (Keep it in your own polished, natural voice.)
+3. **Prime with examples** — offer a spread to mimic: a Steward, a Guardian, an Architect, a Planner, an Abundant King or Queen, an Investor, a Gardener who grows what they have.
+
+Then ask the question.
+
 ## Category-Specific Approach
 
 **The question**: "Who sits down and handles the budgeting, investing, moving money around? Who manages your money?"
 
-**If they're stuck, suggest simple options**:
-- Architect, Steward, Builder, Guardian, Optimizer, Planner, Manager
+**Example identities to offer if they're stuck or need priming** (pick what fits, don't dump the list):
+- Steward, Guardian, Architect, Planner, Optimizer
+- Abundant King, Abundant Queen, Provider, Protector
+- Investor, Strategist, Builder, Gardener
 
 **Keep names simple**: Single words work best.
 
@@ -26,15 +38,8 @@
 **"This feels too fancy/luxurious"**:
 - "What kind of financial life do YOU actually want? Let's honor what's true for you."
 
-## Transitioning to Spiritual Identity
+## Closing Out This Category
 
-**Create a custom transition** that flows naturally from money management to spiritual connection. Use their specific situation and newly identified Keeper of Money.
+When they're complete here, close the category out warmly and personally — reflect back the identity they captured and what it says about them, in your own words, so it feels earned rather than canned. Don't fall back on a stock line like "This looks great" every time. Then ask whether they feel good and are ready to move on.
 
-**Examples of Leigh Ann's natural conversation flow for inspiration only** (don't use as templates):
-- Moving from material to spiritual: *"Beautiful! Your [Keeper identity] has such clear values. Now let's explore another foundational part of who you are..."*
-- Natural progression: *"We've looked at how you generate and manage resources. Let's shift to how you connect with something larger than yourself..."*
-
-**Your transition should:**
-- Feel like a natural flow from financial stewardship to spiritual connection
-- Reference their specific Keeper of Money identity
-- Set up the spiritual category as another foundational aspect of identity
+Do NOT name, preview, or introduce the next category, and do NOT bridge into it in this message. Once they confirm, the focus switches and you'll introduce the next category fresh in a separate message.

--- a/server/services/prompt_manager/utils/context/identity_category_context/maker_of_money.md
+++ b/server/services/prompt_manager/utils/context/identity_category_context/maker_of_money.md
@@ -6,12 +6,24 @@
 
 **Energy-Based Focus**: Focus on which identity feels most inspiring and sustainable for making money, not what they think "should" work. Often the identity that generates income most easily is different from what clients expect.
 
+## Introducing This Category
+
+When Maker of Money becomes the focus, open with a short intro before asking the question — this is the user's first time meeting this idea, so introduce it with clarity and strength. Cover these beats in your own natural voice:
+
+1. **What it is** — who wakes up and generates income in your life: the energy that earns, separate from your job title or your passions.
+2. **Open it up** — invite them to look past the first obvious label and the job title to the energy underneath, so they land on the identity that genuinely resonates. Many people earn as something different than their title suggests — a realtor who really makes money as a Designer, a lawyer who's really a Devil's Advocate. (Keep it in your own polished, natural voice.)
+3. **Prime with examples** — offer a spread to mimic: an Entrepreneur, a Manager, a Coach, a Closer, a Designer, a Rainmaker, a Problem Solver, a Devil's Advocate — whatever fits.
+
+Then ask the question.
+
 ## Category-Specific Approach
 
 **The question**: "Who are you in relation to making money? Who wakes up and generates income in your life?"
 
-**If they're stuck, suggest simple options based on their work/career from User Notes**:
-- Builder, Seller, Creator, Leader, Connector, Organizer, Specialist
+**Example identities to offer if they're stuck or need priming** (draw on their work/career from User Notes; pick what fits, don't dump the list):
+- Entrepreneur, Manager, Coach, Editor, Boss, Problem Solver
+- Designer, Creator, Builder, Seller, Closer, Rainmaker
+- Service Provider, Supporter, Specialist, Consultant, Connector, Devil's Advocate
 
 **Keep names simple**: Single words work best for now
 
@@ -26,17 +38,8 @@
 **"I don't know what makes money"**:
 - "Where do people naturally come to you for help or solutions?"
 
-## Transitioning to Keeper of Money
+## Closing Out This Category
 
-**Create a custom transition** that emphasizes the paradigm shift between making and keeping money. Use their specific situation and newly identified Maker of Money.
+When they're complete here, close the category out warmly and personally — reflect back the identity they captured and what it says about them, in your own words, so it feels earned rather than canned. Don't fall back on a stock line like "This looks great" every time. Then ask whether they feel good and are ready to move on.
 
-**Examples of Leigh Ann's natural conversation flow for inspiration only** (don't use as templates):
-- Emphasizing different energies: *"The Maker of Money is one energy and vibe, and the Keeper of Money is a totally different vibe and set of activities..."*
-- Highlighting the breakthrough: *"A lot of people focus on making money. Not many focus on keeping money. They're very different energies."*
-- Personalizing the shift: *"The person who [reference their Maker of Money work] is very different than the budgeting, investing, growing money person."*
-
-**Your transition should:**
-- Emphasize that making and keeping money are different energies
-- Reference their specific Maker of Money identity
-- Frame keeping money as equally important but different
-- Build excitement about this paradigm shift
+Do NOT name, preview, or introduce the next category, and do NOT bridge into it in this message. Once they confirm, the focus switches and you'll introduce the next category fresh in a separate message.

--- a/server/services/prompt_manager/utils/context/identity_category_context/passions_and_talents.md
+++ b/server/services/prompt_manager/utils/context/identity_category_context/passions_and_talents.md
@@ -6,12 +6,25 @@
 
 **Energy-Based Focus**: Look for what creates energy, excitement, and authentic self-expression. Ask about activities where they lose track of time, traits others consistently compliment, and when they feel most like "themselves."
 
+## Introducing This Category
+
+When Passions & Talents becomes the focus, open with a short intro before asking the question — this is the user's first time meeting this idea, so introduce it with clarity and strength. Cover these beats in your own natural voice:
+
+1. **What it is** — the parts of you that light you up: what you love, the gifts that come naturally, the places you lose track of time.
+2. **Open the aperture** — invite them to name everything that fits, big or small. We're opening things up, not narrowing down or hunting for one perfect answer — the more they put out there, the better. (Keep it in your own polished voice — never throwaway phrasing like "throw it at the wall.")
+3. **Prime with examples** — offer a spread to mimic: a Chef, a Healer, an Author, an Artist, a Musician, an Adventurer, a Dreamer, a Visionary, a Truth Seeker, a Dancer, a Social Butterfly — whatever resonates.
+
+Then ask the question.
+
 ## Category-Specific Approach
 
 **The question**: "Who are you in relation to your passions and talents? What makes you uniquely you?"
 
-**If they're stuck, suggest simple options based on their warm-up identities and what they share**:
-- Creator, Helper, Builder, Leader, Learner, Connector, Problem Solver
+**Example identities to offer if they're stuck or need priming** (draw on their warm-up identities and what they've shared; pick what fits, don't dump the list):
+- Chef, Healer, Author, Artist, Musician, Maker, Creator
+- Adventurer, Explorer, Dreamer, Visionary, Seeker, Truth Seeker
+- Activist, Advocate, Teacher, Mentor, Connector, Social Butterfly
+- Dancer, Athlete, Storyteller, Builder, Problem Solver
 
 **Keep names simple**: Single words work best.
 
@@ -42,17 +55,8 @@
 
 **Move on when**: The user indicates they're done.
 
-## Transitioning to Maker of Money
+## Closing Out This Category
 
-**Create a custom transition** that flows naturally from your conversation and their specific situation. Use everything you know about them from User Notes and what they've just shared about their Passions & Talents.
+When they're complete here, close the category out warmly and personally — reflect back the specific identities they captured and what they add up to, in your own words, so it feels earned rather than canned. Don't fall back on a stock line like "This looks great" every time. For example: *"You've got a powerful mix here — Creator, Dancer, Athlete, Wellness Guru. There's so much movement, discipline, and vitality in the way you're built, and that fits you beautifully."* Then ask whether they feel good and are ready to move on.
 
-**Examples of Leigh Ann's natural conversation flow for inspiration only** (don't use as templates):
-- Connecting their new identity to money-making: *"I love this 'Problem Solver' identity - and that makes me curious about who shows up when you're earning money..."*
-- Referencing their current situation: *"Given what you've shared about wanting to transition careers, who do you see as your Maker of Money in this new chapter?"*
-- Building on their energy: *"You lit up talking about being a 'Creative Visionary' - how does that person approach making money?"*
-
-**Your transition should:**
-- Feel like a natural continuation of your conversation
-- Reference their specific work/financial context from User Notes
-- Connect their newly identified Passions & Talents to money-making identity
-- Frame as "who is making the money" not "how to make money"
+Do NOT name, preview, or introduce the next category, and do NOT bridge into it in this message. Once they confirm, the focus switches and you'll introduce the next category fresh in a separate message.

--- a/server/services/prompt_manager/utils/context/identity_category_context/personal_appearance.md
+++ b/server/services/prompt_manager/utils/context/identity_category_context/personal_appearance.md
@@ -6,12 +6,24 @@
 
 **Self-Worth Indicator**: This category often reveals how clients value themselves. Resistance is common, but enthusiasm suggests natural strength and joy.
 
+## Introducing This Category
+
+When Personal Appearance becomes the focus, open with a short intro before asking the question — this is the user's first time meeting this idea, so introduce it with clarity and strength. Cover these beats in your own natural voice:
+
+1. **What it is** — how you show up and present to the world: your style and presence, what people take in when you walk into a room.
+2. **Open it up** — invite them to look past the first obvious label so they land on the identity that genuinely resonates with how they want to land. (Keep it in your own polished, natural voice.)
+3. **Prime with examples** — offer a spread to mimic: Natural, Polished, Classic, Elegant, Bold, Timeless, Magnetic, Effortless — whatever captures how they want to show up.
+
+Then ask the question.
+
 ## Category-Specific Approach
 
 **The question**: "How do you want to show up in the world? What do you want people to take in when you walk into a room?"
 
-**If they're stuck, suggest simple options**:
-- Natural, Polished, Classic, Elegant, Casual, Bold, Authentic, Refined
+**Example identities to offer if they're stuck or need priming** (pick what fits, don't dump the list):
+- Natural, Polished, Classic, Elegant
+- Bold, Striking, Refined, Timeless
+- Authentic, Effortless, Magnetic, Curated
 
 **Keep names simple**: Single words work best.
 
@@ -26,17 +38,8 @@
 **"I can't afford to focus on appearance"**:
 - "This is about intention, not expense. How can you honor yourself within your means?"
 
-## Transitioning to Physical Expression & Health
+## Closing Out This Category
 
-**Create a custom transition** that clearly distinguishes appearance (presentation) from physical care (relationship with body). Use their specific situation and newly identified Personal Appearance identity.
+When they're complete here, close the category out warmly and personally — reflect back the identity they captured and what it says about them, in your own words, so it feels earned rather than canned. Don't fall back on a stock line like "This looks great" every time. Then ask whether they feel good and are ready to move on.
 
-**Examples of Leigh Ann's natural conversation flow for inspiration only** (don't use as templates):
-- Distinguishing the categories: *"This next one is different than personal appearance. Personal appearance is how you show up in the world—this is how you care for your physical self."*
-- Using the vessel metaphor: *"This is your relationship with your body, which is your vehicle. This is your suit for while you're here—how do you tend to it?"*
-- Acknowledging different approaches: *"Everyone has their own lane here. Some are athletic, others focus on supplements and nutrition. What's your brand of caring for your vessel?"*
-
-**Your transition should:**
-- Clearly distinguish between presentation to world vs. body care
-- Use the "vessel" or "vehicle" metaphor for the body
-- Acknowledge that everyone has different approaches to physical health
-- Reference their Personal Appearance identity while moving to body relationship
+Do NOT name, preview, or introduce the next category, and do NOT bridge into it in this message. Once they confirm, the focus switches and you'll introduce the next category fresh in a separate message.

--- a/server/services/prompt_manager/utils/context/identity_category_context/physical_expression.md
+++ b/server/services/prompt_manager/utils/context/identity_category_context/physical_expression.md
@@ -6,12 +6,24 @@
 
 **Individual Manifestations**: Everyone has their own lane—some are athletic/fitness focused, others focus on nutrition/supplements, some on holistic wellness. Avoid one-size-fits-all approaches.
 
+## Introducing This Category
+
+When Physical Expression & Health becomes the focus, open with a short intro before asking the question — this is the user's first time meeting this idea, so introduce it with clarity and strength. Cover these beats in your own natural voice:
+
+1. **What it is** — your relationship with your body, the vessel you live in: how you move, fuel, and tend to it (distinct from how you present it to the world).
+2. **Open it up** — invite them to look past the first obvious label so they land on the identity that genuinely resonates with their own way of caring for themselves. (Keep it in your own polished, natural voice.)
+3. **Prime with examples** — offer a spread to mimic: a Mover, an Athlete, a Warrior, a Nourisher, a Healer, a Vitality Seeker, a Yogi — whatever fits their lane.
+
+Then ask the question.
+
 ## Category-Specific Approach
 
 **The question**: "How do you care for your vessel that you live inside? What's your brand of caring for your physical self?"
 
-**If they're stuck, suggest simple options**:
-- Mover, Builder, Optimizer, Nourisher, Athlete, Warrior, Healer, Tender
+**Example identities to offer if they're stuck or need priming** (pick what fits, don't dump the list):
+- Mover, Athlete, Warrior, Builder
+- Nourisher, Healer, Tender, Optimizer
+- Vitality Seeker, Yogi, Runner, Naturalist
 
 **Keep names simple**: Single words work best.
 
@@ -32,17 +44,8 @@
 
 **How to Offer Skip**: "It's perfectly okay to skip this category if it doesn't feel relevant right now. We can always come back to this later."
 
-## Transitioning to Familial Relations
+## Closing Out This Category
 
-**Create a custom transition** that moves from individual body care to family relationships. Use their specific situation and newly identified Physical Expression identity.
+When they're complete here, close the category out warmly and personally — reflect back the identity they captured and what it says about them, in your own words, so it feels earned rather than canned. Don't fall back on a stock line like "This looks great" every time. Then ask whether they feel good and are ready to move on.
 
-**Examples of Leigh Ann's natural conversation flow for inspiration only** (don't use as templates):
-- Moving to relationships: *"Perfect! Now let's explore how you show up in your family relationships..."*
-- Acknowledging family complexity: *"This is how you show up in your family of origin, or your chosen family. Some people have strong ties and choose more than one identity here."*
-- Personal example sharing: *"Some people find one familial identity sufficient, others have multiple depending on their rich family life."*
-
-**Your transition should:**
-- Move naturally from individual self-care to family relationships
-- Acknowledge that this can be multiple identities (unlike most other categories)
-- Reference their family situation from User Notes if available
-- Set up the possibility of choosing one overarching identity or multiple specific ones
+Do NOT name, preview, or introduce the next category, and do NOT bridge into it in this message. Once they confirm, the focus switches and you'll introduce the next category fresh in a separate message.

--- a/server/services/prompt_manager/utils/context/identity_category_context/romantic_relations.md
+++ b/server/services/prompt_manager/utils/context/identity_category_context/romantic_relations.md
@@ -6,12 +6,24 @@
 
 **For All Relationship Statuses**: Single clients explore what partner energy they want to cultivate; coupled clients consider the kind of relationship energy they want to embody.
 
+## Introducing This Category
+
+When Romantic/Sexual Expression becomes the focus, open with a short intro before asking the question — this is the user's first time meeting this idea, so introduce it with clarity and strength (and warmth — this can be vulnerable territory). Cover these beats in your own natural voice:
+
+1. **What it is** — your lover energy: how you *want* to show up in intimate partnership. It's aspirational, and it's for any relationship status — single or coupled.
+2. **Open it up** — invite them to look past the first obvious label so they land on the identity that genuinely resonates. (Keep it in your own polished, natural voice.)
+3. **Prime with examples** — offer a spread to mimic: a Lover, a Partner, a Companion, a Beloved, someone Playful, Passionate, Devoted, or Sacred — whatever resonates.
+
+Then ask the question.
+
 ## Category-Specific Approach
 
 **The question**: "What's your lover energy? How do you want to show up in intimate relationships?"
 
-**If they're stuck, suggest simple options**:
-- Lover, Partner, Companion, Romantic, Beloved, Playful, Sacred, Passionate
+**Example identities to offer if they're stuck or need priming** (pick what fits, don't dump the list):
+- Lover, Partner, Companion, Beloved
+- Romantic, Playful, Passionate, Devoted
+- Sacred, Sensual, Adventurer, Nurturer
 
 **Keep names simple**: Single words work best.
 
@@ -32,17 +44,8 @@
 
 **Create Safety**: Normalize that this can be vulnerable territory and offer skip option if it feels too personal.
 
-## Transitioning to Doer of Things
+## Closing Out This Category
 
-**Create a custom transition** that moves from romantic relationships to practical life execution. Use their specific situation and newly identified Romantic Expression identity.
+When they're complete here, close the category out warmly and personally — reflect back the identity they captured and what it says about them, in your own words, so it feels earned rather than canned. Don't fall back on a stock line like "This looks great" every time. Then ask whether they feel good and are ready to move on.
 
-**Examples of Leigh Ann's natural conversation flow for inspiration only** (don't use as templates):
-- Moving to practical matters: *"The last one is the Doer of Things. We all have stuff we have to do - pay mortgage, go to grocery store, register your car..."*
-- Reframing mundane tasks: *"This is about making going to the DMV a self-fulfilling practice, as opposed to some horrible thing you hate."*
-- Empowering execution: *"Who is your Doer of Things? This is about taking action that's self-validating and self-affirming."*
-
-**Your transition should:**
-- Acknowledge the shift from intimate relationships to practical execution
-- Frame mundane tasks as opportunities for self-love and empowerment
-- Reference their specific life responsibilities from User Notes if available
-- Set up the Doer of Things as the final, crucial identity for life management
+Do NOT name, preview, or introduce the next category, and do NOT bridge into it in this message. Once they confirm, the focus switches and you'll introduce the next category fresh in a separate message.

--- a/server/services/prompt_manager/utils/context/identity_category_context/spiritual.md
+++ b/server/services/prompt_manager/utils/context/identity_category_context/spiritual.md
@@ -6,12 +6,24 @@
 
 **Common Resistance Pattern**: People either immediately resonate or experience resistance/uncertainty. Both responses are normal. Where there's resistance often indicates the biggest opportunity for peace and comfort.
 
+## Introducing This Category
+
+When Spiritual Identity becomes the focus, open with a short intro before asking the question — this is the user's first time meeting this idea, so introduce it with clarity and strength. Cover these beats in your own natural voice (stay completely neutral toward all belief systems):
+
+1. **What it is** — how you connect to something greater than yourself: meaning, faith, the divine, the universe, however you personally hold it.
+2. **Open it up** — invite them to look past the first obvious label so they land on the identity that genuinely resonates, in whatever language is true for them. (Keep it in your own polished, natural voice.)
+3. **Prime with examples** — offer a spread to mimic: a Seeker, a Believer, a Student, a Philosopher, someone Grounded or Connected, a Mystic — whatever fits their way of relating.
+
+Then ask the question.
+
 ## Category-Specific Approach
 
 **The question**: "How do you relate to something greater than yourself? What provides meaning and connection in your life?"
 
-**If they're stuck, suggest simple options** (maintain complete neutrality - honor all belief systems):
-- Seeker, Believer, Student, Spiritual, Faithful, Connected, Grounded, Philosopher
+**Example identities to offer if they're stuck or need priming** (maintain complete neutrality - honor all belief systems; pick what fits, don't dump the list):
+- Seeker, Believer, Student, Philosopher
+- Connected, Grounded, Faithful, Devoted
+- Mystic, Contemplative, Wanderer, Channel
 
 **Keep names simple**: Single words work best. Use their own language and terminology.
 
@@ -26,17 +38,8 @@
 **"I don't know what I believe"**:
 - "That's okay. What do you find yourself drawn to when you need peace or comfort?"
 
-## Transitioning to Personal Appearance
+## Closing Out This Category
 
-**Create a custom transition** that flows from spiritual connection to physical presentation. Use their specific situation and newly identified Spiritual Identity.
+When they're complete here, close the category out warmly and personally — reflect back the identity they captured and what it says about them, in your own words, so it feels earned rather than canned. Don't fall back on a stock line like "This looks great" every time. Then ask whether they feel good and are ready to move on.
 
-**Examples of Leigh Ann's natural conversation flow for inspiration only** (don't use as templates):
-- Connecting inner to outer: *"Beautiful! Your [Spiritual Identity] gives you such a foundation. Now let's explore how you show up in the world..."*
-- Moving from meaning to presentation: *"This is another one that really blows people's world open—your Personal Appearance. How do you want to show up in the world?"*
-- Empowering the choice: *"You get a chance to pick a cool name for how you present yourself. What do you want the world to take in when you walk into a room?"*
-
-**Your transition should:**
-- Connect their spiritual foundation to outward expression
-- Frame personal appearance as an intentional choice and identity opportunity
-- Reference how this can "up-level" their whole life
-- Build excitement about choosing how they show up in the world
+Do NOT name, preview, or introduce the next category, and do NOT bridge into it in this message. Once they confirm, the focus switches and you'll introduce the next category fresh in a separate message.


### PR DESCRIPTION
## Summary

Reworks the **identity brainstorming** experience so each category is introduced properly and the coach hands off between categories cleanly instead of closing one and opening the next in the same awkward message. Also surfaces a category info card above the composer. From Leigh-Anne's 2026-07-01 review.

The paired prompt changes (`introduction` v13, `identity_brainstorming` v18, `identity_warm_up` v12) live in the DB and were **already promoted to production separately** — this PR is the code + injected-context + frontend side they depend on.

## What's in here

- **Auto second-pass hand-off** (`process_message.py`) — `process_message` builds the coach prompt with the current `identity_focus` *before* the LLM runs, and `select_identity_focus` changes focus only *after* the message is generated. So a category-advance message was written with the old category's context and couldn't introduce the new one. Now, when the focus changes during brainstorming, we regenerate once with the new category's context and overwrite the same `ChatMessage` in place, so the next intro lands as its own message with the right context. Capped at one extra pass, scoped to the brainstorming phase.
- **Per-category context docs** (9 `identity_category_context/*.md`) — each gains an "Introducing This Category" intro (what it is + open-the-aperture framing + primed examples), an expanded example bank, and a personalized "Closing Out This Category" section that reflects captured identities back and asks before advancing. Removed a stray garbage line in `doer_of_things.md`.
- **Romantic filename fix** (`get_brainstorming_category_context.py`) — the ROMANTIC category mapped to `romantic_relation.md` but the file is `romantic_relations.md`, so it was injecting a "Could not load context…" error string into the prompt.
- **Category info bulletin** (`BrainstormingBulletin.tsx` + `identityCategory.ts`) — a category card above the composer, driven by `identity_focus` and styled like `RefinementBulletin`, that swaps as the coach moves through categories. Descriptions sourced from the coach docs; existing identity-list bulletin kept below it.

## Testing

- Backend: `pytest apps/coach/tests/test_process_message.py apps/coach/tests/test_process_message_endpoint.py` → **32 passed**
- Frontend: `vitest run` on the enum + `ChatControls` tests → **25 passed** (5 new `getIdentityCategoryDescription` cases)
- Biome clean on all changed client files
- Manually drove a full brainstorming run (all 9 categories → review) via the eval harness: hand-offs fire correctly, each category intro is generated from its own context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)